### PR TITLE
A Minor PR: nta -> tbp and sometimes Numenta -> Thousand Brains Project

### DIFF
--- a/docs/how-to-use-monty/getting-started.md
+++ b/docs/how-to-use-monty/getting-started.md
@@ -20,7 +20,7 @@ Next, you need to **clone the repository onto your device**. To do that, open th
 ![](../figures/how-to-use-monty/clone.png)
 
 > [!NOTE]
-> If you want the same setup as we use at Numenta by default, clone the repository at `${HOME}/tbp/`. If you don't have an `tbp` folder in your home directory yet you can run `cd ~; mkdir tbp; cd tbp` to create it. It's not required to clone the code in this folder but it is the path we assume in our tutorials.
+> If you want the same setup as we use at the Thousand Brains Project by default, clone the repository at `${HOME}/tbp/`. If you don't have a `tbp` folder in your home directory yet you can run `cd ~; mkdir tbp; cd tbp` to create it. It's not required to clone the code in this folder but it is the path we assume in our tutorials.
 
 ## 1.2 Make Sure Your Local Copy is Up-To-Date
 

--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -1,6 +1,6 @@
 ---
 title: Glossary
-description: This section aims to provide concise definitions of terms commonly used at Numenta and in the Monty project.
+description: This section aims to provide concise definitions of terms commonly used at the Thousand Brains Project and in Monty.
 ---
 # Dendrites
 


### PR DESCRIPTION
`nta` has already been switched to `tbp` pretty much everywhere in the docs. I fixed one definite article thing resulting from the switch ("a" vs "an"). I also switched Numenta to Thousand Brain Project in a couple of places. The remaining Numenta references are left untouched as they either belong as-is or should be updated later once we have new email addresses and such.

Note: It looks like Will might be actively doing these changes since I saw an `nta` on ReadMe had already been replaced by `tbp` in the codebase. I'm happy to withdraw this PR if it's redundant or unnecessary.