### PR TITLE
Tools: Delete readme version

### DIFF
--- a/tools/github_readme_sync/README.md
+++ b/tools/github_readme_sync/README.md
@@ -36,7 +36,7 @@ export IMAGE_PATH=thousandbrainsproject/tbp.monty/refs/heads/main/docs/figures
 ```
 > python -m tools.github_readme_sync.cli -h
 
-usage: cli.py [-h] {export,check,upload,check-external} ...
+usage: cli.py [-h] {export,check,upload,check-external,delete} ...
 
 CLI tool to manage exporting, checking, and uploading docs.
 
@@ -46,6 +46,7 @@ positional arguments:
     check               Check the hierarchy.md file and ensure all docs exist
     upload              Upload the docs in the folder to ReadMe under the specified version
     check-external      Check external links in all markdown files from the specified directory
+    delete              Delete a specific version from ReadMe
 
 optional arguments:
   -h, --help            show this help message and exit

--- a/tools/github_readme_sync/cli.py
+++ b/tools/github_readme_sync/cli.py
@@ -78,6 +78,12 @@ def main():
         help="List of directories to exclude from link checking",
     )
 
+    # Delete version command
+    delete_parser = subparsers.add_parser(
+        "delete", help="Delete a specific version from ReadMe"
+    )
+    delete_parser.add_argument("version", help="The version to delete")
+
     args = parser.parse_args()
 
     initialize()
@@ -98,6 +104,11 @@ def main():
     elif args.command == "check-external":
         check_readme_api_key()
         check_external(args.folder, args.ignore, ReadMe(args.version))
+
+    elif args.command == "delete":
+        check_readme_api_key()
+        rdme = ReadMe(args.version)
+        rdme.delete_version()
 
 
 def check_readme_api_key():

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -272,6 +272,10 @@ class ReadMe:
 
         return regex_images.sub(replace_image, markdown_text)
 
+    def delete_version(self):
+        delete(f"{PREFIX}/version/v{self.version}")
+        logging.info(f"{GREEN}Successfully deleted version {self.version}{RESET}")
+
     def convert_cloudinary_videos(self, markdown_text: str) -> str:
         def replace_video(match):
             title, full_url, cloud_id, version, filename = match.groups()

--- a/tools/github_readme_sync/tests/req_test.py
+++ b/tools/github_readme_sync/tests/req_test.py
@@ -11,6 +11,7 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 
+from tools.github_readme_sync.readme import ReadMe
 from tools.github_readme_sync.req import delete, get, post, put
 
 
@@ -155,6 +156,23 @@ class TestReq(unittest.TestCase):
         result = delete(url)
 
         self.assertFalse(result)
+        mock_delete.assert_called_once_with(
+            url, headers={"Authorization": "Basic test_api_key"}
+        )
+
+    @patch("requests.delete")
+    def test_delete_version(self, mock_delete):
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_delete.return_value = mock_response
+
+        url = "https://dash.readme.com/api/v1/version/v1.0.0"
+
+        rdme = ReadMe("1.0.0")
+        with self.assertLogs() as log:
+            rdme.delete_version()
+
+        self.assertIn("Successfully deleted version 1.0.0", log.output[0])
         mock_delete.assert_called_once_with(
             url, headers={"Authorization": "Basic test_api_key"}
         )


### PR DESCRIPTION
This PR adds functionality to the github_readme_sync tool to delete a readme version.  This will be used in github actions that delete temporary readme preview versions when a branch is merged to main.