### PR TITLE
chore: remove extraneous direct dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,8 +21,6 @@ dependencies:
 
   - aihabitat::habitat-sim=0.2.2
   - pytorch::pytorch=1.11.0
-  - pyg::pytorch-sparse
-  - pyg::pytorch-scatter
   - conda-forge::quaternion=2023.0.3 # later versions missing np.long
   - pytorch::torchvision
   - aihabitat::withbullet

--- a/environment_arm64.yml
+++ b/environment_arm64.yml
@@ -27,8 +27,6 @@ dependencies:
   - aihabitat::habitat-sim=0.2.2
   - mkl<2022 # prevents Intel errors when osx-64 environment is running on osx-arm64 platform
   - pytorch::pytorch=1.11.0
-  - pyg::pytorch-sparse
-  - pyg::pytorch-scatter
   - conda-forge::quaternion=2023.0.3 # later versions missing np.long
   - pytorch::torchvision
   - aihabitat::withbullet


### PR DESCRIPTION
`pyg::pytorch-scatter` and `pyg::pytorch-sparse` are not directly used in the code: no `import/from torch_scatter` and no `import/from torch_sparse`.

Additionally, removal from dependencies list should have no impact as they are already included in `pyg::pyg`:
```
(tbp.monty) tbp.monty % conda repoquery whoneeds pytorch-scatter
Collecting package metadata: done
 Name           Version Build                   Depends   Channel Subdir
─────────────────────────────────────────────────────────────────────────
 pyg            2.1.0   py38_torch_1.11.0_cpu   localhost        
 pytorch-sparse 0.6.15  py38_torch_1.11.0_cpu   localhost        

(tbp.monty) tbp.monty % conda repoquery whoneeds pytorch-sparse 
Collecting package metadata: done
 Name Version Build                   Depends   Channel Subdir
───────────────────────────────────────────────────────────────
 pyg  2.1.0   py38_torch_1.11.0_cpu   localhost        
```