### PR TITLE
ci: rightsize runners for specific jobs

### DIFF
--- a/.github/workflows/monty.yml
+++ b/.github/workflows/monty.yml
@@ -234,7 +234,7 @@ jobs:
           shasum -a 256 ~/tbp/tbp.monty/environment_arm64.yml | awk '{print $1}' > ~/tbp/environment_arm64.sha
           shasum -a 256 ~/tbp/tbp.monty/environment.yml | awk '{print $1}' > ~/tbp/environment.sha
           shasum -a 256 ~/tbp/tbp.monty/pyproject.toml | awk '{print $1}' > ~/tbp/pyproject.toml.sha
-          echo "monty-v2-${RUNNER_OS}-$(cat ~/tbp/environment_arm64.sha)-$(cat ~/tbp/environment.sha)-$(cat ~/tbp/pyproject.toml.sha)" > ~/tbp/conda_env_cache_key.txt
+          echo "monty-${RUNNER_OS}-$(cat ~/tbp/environment_arm64.sha)-$(cat ~/tbp/environment.sha)-$(cat ~/tbp/pyproject.toml.sha)" > ~/tbp/conda_env_cache_key.txt
           echo "conda_env_cache_key_sha=$(cat ~/tbp/conda_env_cache_key.txt | shasum -a 256 | awk '{print $1}')" >> $GITHUB_OUTPUT
       - name: Set up Python 3.8
         if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}


### PR DESCRIPTION
After rightsizing the runners, observed no significant changes in workflow runtimes. The test workflow runtime is uneffected because `pytest` was run with `-n 8`, so going from 16 to 8 cores had no apparent impact.

This reduces the cost of each Monty full-length workflow to less than a 1/3rd of current cost. From \~28min x $0.064 = **\~$1.792** to \~13min x $0.008 + 15min x $0.032 = $0.104 + $0.48 = **\~$0.584**

Why are we using paid 2-core instances instead of free-tier 2-core instances? free-tier 2-core instances do not have large enough disk to download and restore the cache after installing Monty \~5.7GB.