### PR TITLE
ci: grant cla-assistant ability to write comments on issues and PRs

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  issues: write
+
 jobs:
 
   verify_cla:


### PR DESCRIPTION
The GITHUB_TOKEN is read-only by default in the public repository. This update grants the `cla-assistant` configured in the `cla.yml` permission to create a comment on the Pull Request it is checking. This way, the `cla-assistant` can notify the Contributor to sign the CLA and provide the link.