### PR TITLE
Fix first experiment run docs

### DIFF
--- a/docs/how-to-use-monty/getting-started.md
+++ b/docs/how-to-use-monty/getting-started.md
@@ -92,7 +92,7 @@ In your usual interaction with this code base, you will most likely run experime
 
 ## 4.1 Download the YCB Dataset
 
-A lot of our current experiments are based on the [YCB dataset](https://www.ycbbenchmarks.com/) which is a dataset of 77 3D objects that we render in habitat. To download the dataset, run `python -m habitat_sim.utils.environments_download --uids ycb --data-path ~/tbp/data/habitat`.
+A lot of our current experiments are based on the [YCB dataset](https://www.ycbbenchmarks.com/) which is a dataset of 77 3D objects that we render in habitat. To download the dataset, run `python -m habitat_sim.utils.datasets_download --uids ycb --data-path ~/tbp/data/habitat`.
 
 ## 4.2 Download Pretrained Models
 

--- a/environment_arm64.yml
+++ b/environment_arm64.yml
@@ -4,6 +4,9 @@
 # $ conda env create --file environment_arm64.yml --subdir=osx-64
 # $ conda activate tbp.monty
 # $ conda config --env --set subdir osx-64
+# 
+# If `conda activate` fails, run:
+# $ source ${miniconda_dir}/base/bin/activate base
 #
 # ## Anaconda (omit --subdir=osx-64)
 # $ conda env create --file environment_arm64.yml


### PR DESCRIPTION
## Problem 1

trying to activate the (mini)conda environment fails with the commands described in the [environment_arm64.yml]([environment_arm64.yml):

```shell
% conda init
no change     /opt/homebrew/Caskroom/miniconda/base/condabin/conda
...
No action taken.

% conda activate tbp.monty
CondaError: Run 'conda init' before 'conda activate'
```

the internet suggests a quick-fix, commented in the proposed change

## Problem 2

Downloading the habitat as described in the readme fails due to a wrong python module:

```shell
% python -m habitat_sim.utils.environments_download --uids ycb --data-path ~/tbp/data/habitat
/opt/homebrew/Caskroom/miniconda/base/envs/tbp.monty/bin/python: No module named habitat_sim.utils.environments_download
```

The download works when switching to the `datasets_download` module

## CLA

CLA should have been signed successully