### PR TITLE
A typo in tutorials.md

### DIFF
--- a/docs/how-to-use-monty/tutorials.md
+++ b/docs/how-to-use-monty/tutorials.md
@@ -6,4 +6,4 @@ These tutorials will help you get familiar with Monty. Topics and experiments in
 - [Pretraining a Model](tutorials/pretraining-a-model.md): Shows how to configure an experiment for supervised pretraining.
 - [Running Inference with a Pretrained Model](tutorials/running-inference-with-a-pretrained-model.md): Demonstrates how to load a pretrained model and use it to perform object and pose recognition.
 - [Unsupervised Continual Learning](tutorials/unsupervised-continual-learning.md): Demonstrates how to use Monty for unsupervised continual learning to learn new objects from scratch.
-- [Multiple Learning Modules](tutorials/multiple-learning-modules.md): Show how to perform pretraining and inference using multiple sensor modules and multiple learning modules.
+- [Multiple Learning Modules](tutorials/multiple-learning-modules.md): Shows how to perform pretraining and inference using multiple sensor modules and multiple learning modules.


### PR DESCRIPTION
Fixes a clumsy typo in `tutorials.md`.

