### PR TITLE
Docs: rename title to match slug after slug change

### DIFF
--- a/docs/overview/application-criteria.md
+++ b/docs/overview/application-criteria.md
@@ -1,5 +1,5 @@
 ---
-title: Application Criteria & Current Capabilities
+title: Application Criteria
 description: What can you use Monty for?
 ---
 # Requirements


### PR DESCRIPTION
Fixes the issue found in #51 