### PR TITLE
ci: always try to download api docs artifact

### DIFF
--- a/.github/workflows/monty_api_docs.yml
+++ b/.github/workflows/monty_api_docs.yml
@@ -34,28 +34,31 @@ jobs:
           fetch-depth: 0
           lfs: true
           path: tbp.monty
-      # We want to deploy the docs using the same criteria for deciding if Monty code changed.
-      - name: Should Run Monty API Docs
-        id: should_run_monty_api_docs
-        uses: ./tbp.monty/.github/actions/should_run_monty
-        with:
-          working_directory: tbp.monty
       # Downloading the artifact from the previous run so that actions/deploy-pages can find it.
+      # If the artifact is not found, then there is nothing to deploy and the last step
+      # will succeed, indicating job success.
       - name: Download artifact
-        if: ${{ steps.should_run_monty_api_docs.outputs.should_run_monty == 'true'}}
+        id: download
         uses: actions/download-artifact@v4
         with:
           name: github-pages-${{ github.sha }}
           run-id: ${{ github.event.workflow_run.id }}
       - name: Upload artifact
-        if: ${{ steps.should_run_monty_api_docs.outputs.should_run_monty == 'true'}}
+        id: upload
         uses: actions/upload-artifact@v4
         with:
           name: github-pages-${{ github.sha }}
           path: github-pages-${{ github.sha }}
       - name: Deploy Monty API docs
-        id: deployment
-        if: ${{ steps.should_run_monty_api_docs.outputs.should_run_monty == 'true'}}
+        id: deploy
         uses: actions/deploy-pages@v4
         with:
           artifact_name: github-pages-${{ github.sha }}
+      - name: Ignore download failure
+        if: ${{ failure() }}
+        run: |
+          if [ '${{ steps.download.conclusion }}' == 'failure' ]
+          then
+            exit 0
+          fi
+          exit 1


### PR DESCRIPTION
Another attempt at Monty API Docs workflow.

In the last attempt, I learned that Monty API Docs workflow could not use `git diff --name-only HEAD^1 > changed_files.txt` to detect changed files because the latest commit in `main` might not be the one that generated the docs.

<img width="611" alt="Screenshot 2024-11-26 at 09 20 42" src="https://github.com/user-attachments/assets/ed27153a-6db1-44b9-83d1-c7339fb911fb">

So, instead of relying on commit diff criteria, this workflow attempts to download the artifact generated by any workflow that should run. If the artifact is missing, the workflow will exit without error. It is valid to use the presence of the artifact as "should run" criteria since we check that the previous workflow conclusion was `success`.

As with previous pull requests for this workflow, it needs to be merged to `main` before it will run.
