### PR TITLE
ci: use commit sha instead of HEAD to check changes on push

### DIFF
--- a/.github/actions/should_run_monty/action.yml
+++ b/.github/actions/should_run_monty/action.yml
@@ -28,7 +28,7 @@ runs:
       working-directory: ${{ inputs.working_directory }}
       shell: bash
       run: |
-        git diff --name-only HEAD^1 > changed_files.txt
+        git diff --name-only ${{ github.sha }}^1 > changed_files.txt
         ./.github/actions/should_run_monty/check_changed_files.sh
     - name: Should run
       id: should_run

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -100,7 +100,7 @@ jobs:
         id: filter_by_path_push
         working-directory: tbp.monty
         run: |
-          git diff --name-only HEAD^1 > changed_files.txt
+          git diff --name-only ${{ github.sha }}^1 > changed_files.txt
           while IFS= read -r changed_file
           do
             echo $changed_file

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -45,7 +45,7 @@ jobs:
         id: filter_by_path_push
         working-directory: tbp.monty
         run: |
-          git diff --name-only HEAD^1 > changed_files.txt
+          git diff --name-only ${{ github.sha }}^1 > changed_files.txt
           while IFS= read -r changed_file
           do
             echo $changed_file


### PR DESCRIPTION
This pull request improves the robustness of "should run" checks. As noted in #71, if there are two closely timed `push` events, the `git diff HEAD^1` will always diff against the latest commit instead of the one for which the check runs. Now, the check compares the desired commit against the previous one.