### PR TITLE
ci: should_run_monty action explicit inputs

### DIFF
--- a/.github/actions/should_run_monty/action.yml
+++ b/.github/actions/should_run_monty/action.yml
@@ -2,6 +2,13 @@ name: "Should Run Monty"
 description: "Determines if the Monty workflow should run based on the changed files."
 
 inputs:
+  event_name:
+    description: "The event name."
+    required: true
+  git_base_ref:
+    description: "The git base ref to compare against."
+  git_sha:
+    description: "The git sha to compare against."
   working_directory:
     description: "The directory to run the command in."
     required: true
@@ -15,20 +22,20 @@ runs:
   using: "composite"
   steps:
     - name: Filter by path for a pull request
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ inputs.event_name == 'pull_request' }}
       id: filter_by_path_pr
       working-directory: ${{ inputs.working_directory }}
       shell: bash
       run: |
-        git diff --name-only origin/${{ github.base_ref }} > changed_files.txt
+        git diff --name-only origin/${{ inputs.git_base_ref }} > changed_files.txt
         ./.github/actions/should_run_monty/check_changed_files.sh
     - name: Filter by path for a push
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ inputs.event_name == 'push' }}
       id: filter_by_path_push
       working-directory: ${{ inputs.working_directory }}
       shell: bash
       run: |
-        git diff --name-only ${{ github.sha }}^1 > changed_files.txt
+        git diff --name-only ${{ inputs.git_sha }}^1 > changed_files.txt
         ./.github/actions/should_run_monty/check_changed_files.sh
     - name: Should run
       id: should_run

--- a/.github/actions/should_run_monty/action.yml
+++ b/.github/actions/should_run_monty/action.yml
@@ -2,13 +2,13 @@ name: "Should Run Monty"
 description: "Determines if the Monty workflow should run based on the changed files."
 
 inputs:
-  event_name:
-    description: "The event name."
-    required: true
   git_base_ref:
     description: "The git base ref to compare against."
   git_sha:
     description: "The git sha to compare against."
+  github_event_name:
+    description: "The event name."
+    required: true
   working_directory:
     description: "The directory to run the command in."
     required: true
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Filter by path for a pull request
-      if: ${{ inputs.event_name == 'pull_request' }}
+      if: ${{ inputs.github_event_name == 'pull_request' }}
       id: filter_by_path_pr
       working-directory: ${{ inputs.working_directory }}
       shell: bash
@@ -30,7 +30,7 @@ runs:
         git diff --name-only origin/${{ inputs.git_base_ref }} > changed_files.txt
         ./.github/actions/should_run_monty/check_changed_files.sh
     - name: Filter by path for a push
-      if: ${{ inputs.event_name == 'push' }}
+      if: ${{ inputs.github_event_name == 'push' }}
       id: filter_by_path_push
       working-directory: ${{ inputs.working_directory }}
       shell: bash

--- a/.github/workflows/monty.yml
+++ b/.github/workflows/monty.yml
@@ -295,9 +295,9 @@ jobs:
         id: should_run_monty
         uses: ./tbp.monty/.github/actions/should_run_monty
         with:
-          event_name: ${{ github.event_name }}
           git_base_ref: ${{ github.base_ref }}
           git_sha: ${{ github.sha }}
+          github_event_name: ${{ github.event_name }}
           working_directory: tbp.monty
 
   test_monty:

--- a/.github/workflows/monty.yml
+++ b/.github/workflows/monty.yml
@@ -295,6 +295,9 @@ jobs:
         id: should_run_monty
         uses: ./tbp.monty/.github/actions/should_run_monty
         with:
+          event_name: ${{ github.event_name }}
+          git_base_ref: ${{ github.base_ref }}
+          git_sha: ${{ github.sha }}
           working_directory: tbp.monty
 
   test_monty:

--- a/.github/workflows/monty_api_docs.yml
+++ b/.github/workflows/monty_api_docs.yml
@@ -39,9 +39,9 @@ jobs:
         id: should_run_monty_api_docs
         uses: ./tbp.monty/.github/actions/should_run_monty
         with:
-          event_name: ${{ github.event.workflow_run.event }}
           git_base_ref: ${{ github.event.workflow_run.head_branch }}
           git_sha: ${{ github.event.workflow_run.head_sha }}
+          github_event_name: ${{ github.event.workflow_run.event }}
           working_directory: tbp.monty
       # Downloading the artifact from the previous run so that actions/deploy-pages can find it.
       - name: Download artifact

--- a/.github/workflows/monty_api_docs.yml
+++ b/.github/workflows/monty_api_docs.yml
@@ -39,6 +39,9 @@ jobs:
         id: should_run_monty_api_docs
         uses: ./tbp.monty/.github/actions/should_run_monty
         with:
+          event_name: ${{ github.event.workflow_run.event }}
+          git_base_ref: ${{ github.event.workflow_run.head_branch }}
+          git_sha: ${{ github.event.workflow_run.head_sha }}
           working_directory: tbp.monty
       # Downloading the artifact from the previous run so that actions/deploy-pages can find it.
       - name: Download artifact


### PR DESCRIPTION
When resuing the `should_run_monty` action, the context it is running in can change. For example, when triggered by a `workflow_run` event, there is no `github.sha` in context. This pull request makes all inputs explicit so that the action will work independently of context.