### PR TITLE
ci: generate pages artifact in Monty API Docs workflow

### DIFF
--- a/.github/workflows/monty.yml
+++ b/.github/workflows/monty.yml
@@ -56,27 +56,6 @@ jobs:
         with:
           name: sphinx-html-${{ github.sha }}
           path: tbp.monty/tools/generate_api_docs/build/html
-      - name: Debug - Delete generated API docs
-        if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
-        run: |
-          rm -rf tbp.monty/tools/generate_api_docs/build/html
-          ls -l tbp.monty/tools/generate_api_docs/build
-      - name: Debug - Download API docs artifact
-        if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
-        uses: actions/download-artifact@v4
-        with:
-          name: sphinx-html-${{ github.sha }}
-          path: tbp.monty/tools/generate_api_docs/build/html
-      - name: Debug - List API docs artifact
-        if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
-        run: |
-          ls -l tbp.monty/tools/generate_api_docs/build/html
-      - name: Store API docs GitHub Pages artifact
-        if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
-        uses: actions/upload-pages-artifact@v3
-        with:
-          name: github-pages-${{ github.sha }}
-          path: tbp.monty/tools/generate_api_docs/build/html
 
   build_wheel_monty:
     name: build-wheel-monty

--- a/.github/workflows/monty.yml
+++ b/.github/workflows/monty.yml
@@ -20,10 +20,10 @@ jobs:
       group: tbp.monty
       labels: tbp-linux-x64-ubuntu2204-2core
     needs:
-      - check_dependencies_monty # Don't run if dependency check fails
-      - check_license_monty # Don't run if license check fails
-      - check_style_monty # Don't run if style check fails
-      - check_types_monty # Don't run if type check fails
+      # - check_dependencies_monty # Don't run if dependency check fails
+      # - check_license_monty # Don't run if license check fails
+      # - check_style_monty # Don't run if style check fails
+      # - check_types_monty # Don't run if type check fails
       - install_monty
       - should_run_monty
     steps:
@@ -51,6 +51,22 @@ jobs:
           cd tools/generate_api_docs
           make apidoc html
       - name: Store API docs artifact
+        if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-pages-${{ github.sha }}
+          path: tbp.monty/tools/generate_api_docs/build/html
+      - name: Debug - Download API docs artifact
+        if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: github-pages-${{ github.sha }}
+      - name: Debug - List API docs artifact
+        if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
+        run: |
+          ls -l tbp.monty
+          ls -l tbp.monty/tools/generate_api_docs/build/html
+      - name: Store API docs GitHub Pages artifact
         if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/monty.yml
+++ b/.github/workflows/monty.yml
@@ -20,10 +20,10 @@ jobs:
       group: tbp.monty
       labels: tbp-linux-x64-ubuntu2204-2core
     needs:
-      # - check_dependencies_monty # Don't run if dependency check fails
-      # - check_license_monty # Don't run if license check fails
-      # - check_style_monty # Don't run if style check fails
-      # - check_types_monty # Don't run if type check fails
+      - check_dependencies_monty # Don't run if dependency check fails
+      - check_license_monty # Don't run if license check fails
+      - check_style_monty # Don't run if style check fails
+      - check_types_monty # Don't run if type check fails
       - install_monty
       - should_run_monty
     steps:

--- a/.github/workflows/monty.yml
+++ b/.github/workflows/monty.yml
@@ -54,7 +54,7 @@ jobs:
         if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
         uses: actions/upload-artifact@v4
         with:
-          name: github-pages-${{ github.sha }}
+          name: sphinx-html-${{ github.sha }}
           path: tbp.monty/tools/generate_api_docs/build/html
       - name: Debug - Delete generated API docs
         if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
@@ -65,11 +65,11 @@ jobs:
         if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
         uses: actions/download-artifact@v4
         with:
-          name: github-pages-${{ github.sha }}
+          name: sphinx-html-${{ github.sha }}
+          path: tbp.monty/tools/generate_api_docs/build/html
       - name: Debug - List API docs artifact
         if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
         run: |
-          ls -l tbp.monty
           ls -l tbp.monty/tools/generate_api_docs/build/html
       - name: Store API docs GitHub Pages artifact
         if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}

--- a/.github/workflows/monty.yml
+++ b/.github/workflows/monty.yml
@@ -56,6 +56,11 @@ jobs:
         with:
           name: github-pages-${{ github.sha }}
           path: tbp.monty/tools/generate_api_docs/build/html
+      - name: Debug - Delete generated API docs
+        if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
+        run: |
+          rm -rf tbp.monty/tools/generate_api_docs/build/html
+          ls -l tbp.monty/tools/generate_api_docs/build
       - name: Debug - Download API docs artifact
         if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
         uses: actions/download-artifact@v4

--- a/.github/workflows/monty_api_docs.yml
+++ b/.github/workflows/monty_api_docs.yml
@@ -43,19 +43,20 @@ jobs:
           git_sha: ${{ github.event.workflow_run.head_sha }}
           github_event_name: ${{ github.event.workflow_run.event }}
           working_directory: tbp.monty
-      # Downloading the artifact from the previous run so that actions/deploy-pages can find it.
+      # Downloading the Sphinx HTML artifact from the previous run.
       - name: Download artifact
         if: ${{ steps.should_run_monty_api_docs.outputs.should_run_monty == 'true'}}
         uses: actions/download-artifact@v4
         with:
-          name: github-pages-${{ github.sha }}
+          name: sphinx-html-${{ github.sha }}
           run-id: ${{ github.event.workflow_run.id }}
-      - name: Upload artifact
+          path: tbp.monty/sphinx_html
+      - name: Upload GitHub Pages artifact
         if: ${{ steps.should_run_monty_api_docs.outputs.should_run_monty == 'true'}}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           name: github-pages-${{ github.sha }}
-          path: github-pages-${{ github.sha }}
+          path: tbp.monty/sphinx_html
       - name: Deploy Monty API docs
         id: deployment
         if: ${{ steps.should_run_monty_api_docs.outputs.should_run_monty == 'true'}}


### PR DESCRIPTION
After #73, I learned that the `actions/download-artifact@v4` cannot find an artifact uploaded with `actions/upload-pages-artifact@v3` (or at least I haven't found a way to configure it correctly).

This pull request uploads a "normal" Monty API Docs artifact via `actions/upload-artifact@v4`, so that `actions/download-artifact@v4` can find it. This "normal" artifact is then downloaded and the GitHub Pages artifact is created and uploaded in the Monty API Docs workflow and then deployed.