### PR TITLE
ci: provide required github-token param

### DIFF
--- a/.github/workflows/monty_api_docs.yml
+++ b/.github/workflows/monty_api_docs.yml
@@ -51,6 +51,7 @@ jobs:
           name: sphinx-html-${{ github.sha }}
           run-id: ${{ github.event.workflow_run.id }}
           path: tbp.monty/sphinx_html
+          github-token: ${{ github.token }}
       - name: Upload GitHub Pages artifact
         if: ${{ steps.should_run_monty_api_docs.outputs.should_run_monty == 'true'}}
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
`github-token` is a required parameter for `actions/download-artifact@v4` to download an artifact from a different workflow run.
-- https://github.com/actions/download-artifact?tab=readme-ov-file#inputs