### PR TITLE
fix: export habitat actuator symbols that are used as types

### DIFF
--- a/src/tbp/monty/simulators/habitat/actuator.py
+++ b/src/tbp/monty/simulators/habitat/actuator.py
@@ -35,6 +35,8 @@ from tbp.monty.frameworks.actions.actuator import Actuator
 
 __all__ = [
     "HabitatActuator",
+    "HabitatActuatorRequirements",
+    "HabitatParameterizer",
 ]
 
 


### PR DESCRIPTION
I noticed that not all [HabitatActuator](https://github.com/thousandbrainsproject/tbp.monty/blob/d5631219e86f1fbaa69a8b96dcacd118b023c493/src/tbp/monty/simulators/habitat/actuator.py#L49) symbols appear in the API documentation. This is because they were not exported as part of `__all__`. This pull request exports the symbols that are used as types.