### PR TITLE
refactor: remove habitat_sim dependency in motor_policies.py

### DIFF
--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1886,10 +1886,9 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
             # locations to the headings (also in the reference frame of the agent) that
             # we might take
             # TODO could vectorize this
-            rotated_locs = [
-                qt.rotate_vectors(inverse_quaternion_rotation, point)
-                for point in adjusted_prev_locs
-            ]
+            rotated_locs = qt.rotate_vectors(
+                inverse_quaternion_rotation, adjusted_prev_locs
+            )
 
             # Until we have not found a direction that we can guarentee is
             # in a new heading, continue to attempt new directions

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -15,8 +15,8 @@ import math
 import os
 from typing import Any, Callable, Dict, List, Tuple, Type, Union, cast
 
-import habitat_sim.utils as hab_utils
 import numpy as np
+import quaternion as qt
 import scipy.ndimage
 from scipy.spatial.transform import Rotation as rot  # noqa: N813
 
@@ -1150,7 +1150,7 @@ class SurfacePolicy(InformedPolicy):
             self.tangential_angle * (1 - self.alpha) + new_target_direction * self.alpha
         )
 
-        direction = hab_utils.quat_rotate_vector(
+        direction = qt.rotate_vectors(
             self.state[self.agent_id]["rotation"],
             [
                 np.cos(self.tangential_angle - np.pi / 2),
@@ -1220,19 +1220,12 @@ class SurfacePolicy(InformedPolicy):
         identity pose, which will be aquired by transforming the original pose by the
         inverse
 
-        NB Magnum appears to be a library used by Habitat; i.e. it is still grounded
-        in quaternions
-
         Returns:
             Inverse quaternion rotation.
         """
-        inverse_magnum_rotation = hab_utils.common.quat_to_magnum(
-            self.state["agent_id_0"]["rotation"]
-        ).inverted()
-        inverse_quaternion_rotation = hab_utils.common.quat_from_magnum(
-            inverse_magnum_rotation
-        )
-        return inverse_quaternion_rotation
+        [w, x, y, z] = qt.as_float_array(self.state[self.agent_id]["rotation"])
+        [x, y, z, w] = rot.from_quat([x, y, z, w]).inv().as_quat()
+        return qt.quaternion(w, x, y, z)
 
     def orienting_angle_from_normal(self, orienting: str) -> float:
         """Compute turn angle to face the object.
@@ -1250,7 +1243,7 @@ class SurfacePolicy(InformedPolicy):
 
         inverse_quaternion_rotation = self.get_inverse_agent_rot()
 
-        rotated_point_normal = hab_utils.quat_rotate_vector(
+        rotated_point_normal = qt.rotate_vectors(
             inverse_quaternion_rotation, original_point_normal
         )
         x, y, z = rotated_point_normal
@@ -1603,9 +1596,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
         # Rotate the tangential vector to be in the coordinate frame of the sensory
         # agent (rather than the global reference frame of the environment)
         inverse_quaternion_rotation = self.get_inverse_agent_rot()
-        rotated_form = hab_utils.quat_rotate_vector(
-            inverse_quaternion_rotation, selected_pc_dir
-        )
+        rotated_form = qt.rotate_vectors(inverse_quaternion_rotation, selected_pc_dir)
 
         # Before updating the representation and removing z-axis direction, check
         # for movements defined in the z-axis
@@ -1654,7 +1645,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
             self.reset_pc_buffers()
             self.following_heading_counter = 0
 
-            return hab_utils.quat_rotate_vector(
+            return qt.rotate_vectors(
                 self.state["agent_id_0"]["rotation"],
                 self.tangential_vec,
             )
@@ -1675,7 +1666,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
         self.following_pc_counter += 1
         self.continuous_pc_steps += 1
 
-        return hab_utils.quat_rotate_vector(
+        return qt.rotate_vectors(
             self.state["agent_id_0"]["rotation"],
             self.tangential_vec,
         )
@@ -1739,7 +1730,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
 
         self.following_heading_counter += 1
 
-        return hab_utils.quat_rotate_vector(
+        return qt.rotate_vectors(
             self.state["agent_id_0"]["rotation"],
             self.tangential_vec,
         )
@@ -1896,7 +1887,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
             # we might take
             # TODO could vectorize this
             rotated_locs = [
-                hab_utils.quat_rotate_vector(inverse_quaternion_rotation, point)
+                qt.rotate_vectors(inverse_quaternion_rotation, point)
                 for point in adjusted_prev_locs
             ]
 

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1223,7 +1223,9 @@ class SurfacePolicy(InformedPolicy):
         Returns:
             Inverse quaternion rotation.
         """
+        # Note that quaternion format is [w, x, y, z]
         [w, x, y, z] = qt.as_float_array(self.state[self.agent_id]["rotation"])
+        # Note that scipy.spatial.transform.Rotation (v1.10.0) format is [x, y, z, w]
         [x, y, z, w] = rot.from_quat([x, y, z, w]).inv().as_quat()
         return qt.quaternion(w, x, y, z)
 

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -896,49 +896,6 @@ class PolicyTest(unittest.TestCase):
 
         self.exp.dataset.close()
 
-    def test_hab_utils_quat_rotate_vector(self):
-        """Verify hab_utils.quat_rotate_vector replacement results."""
-        quat_wxyz = qt.quaternion(1, 2, 3, 4)
-        vec_xyz = np.array([5, 6, 7])
-        hu_vec_rotated_xyz = hab_utils.quat_rotate_vector(quat_wxyz, vec_xyz)
-        print(hu_vec_rotated_xyz)  # [2.6 6.  8.2]
-
-        qt_vec_rotated_xyz = qt.rotate_vectors(quat_wxyz, vec_xyz)
-        print(qt_vec_rotated_xyz)  # [2.6 6.  8.2]
-
-        rot_vec_rotated_xyz = Rotation.from_quat(qt.as_float_array(quat_wxyz)).apply(
-            vec_xyz
-        )
-        print(rot_vec_rotated_xyz)  # [1.8 7.6 7. ]
-
-        [w, x, y, z] = qt.as_float_array(quat_wxyz)
-        rot_vec_rotated_xyz = Rotation.from_quat([x, y, z, w]).apply(vec_xyz)
-        print(rot_vec_rotated_xyz)  # [2.6 6.  8.2]
-
-        assert np.allclose(
-            hu_vec_rotated_xyz, rot_vec_rotated_xyz, rtol=1.0e-10, atol=1.0e-10
-        ), "hu_vec_rotated_xyz and rot_vec_rotated_xyz do not match"
-
-    def test_hab_utils_inverse(self):
-        """Verify get_inverse_agent_rot replacement results."""
-        vec_xyz = np.array([5, 6, 7])
-        quat_wxyz = qt.quaternion(1, 2, 3, 4)
-        inverse_magnum_rotation = hab_utils.common.quat_to_magnum(quat_wxyz).inverted()
-        inverse_quaternion_rotation = hab_utils.common.quat_from_magnum(
-            inverse_magnum_rotation
-        )
-        [w, x, y, z] = qt.as_float_array(inverse_quaternion_rotation)
-        magnum_vec_rotated_xyz = Rotation.from_quat([x, y, z, w]).apply(vec_xyz)
-        print(magnum_vec_rotated_xyz)  # [3.00000014 5.1999997 8.60000013]
-
-        [w, x, y, z] = qt.as_float_array(quat_wxyz)
-        rot_vec_rotated_xyz = Rotation.from_quat([x, y, z, w]).inv().apply(vec_xyz)
-        print(rot_vec_rotated_xyz)  # [3.  5.2 8.6]
-
-        assert np.allclose(
-            magnum_vec_rotated_xyz, rot_vec_rotated_xyz, rtol=1.0e-5, atol=1.0e-8
-        ), "magnum_vec_rotated_xyz and rot_vec_rotated_xyz do not match"
-
     def test_surface_policy_orientation(self):
         """Test ability of surface agent to orient to a point-normal.
 

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -896,6 +896,49 @@ class PolicyTest(unittest.TestCase):
 
         self.exp.dataset.close()
 
+    def test_hab_utils_quat_rotate_vector(self):
+        """Verify hab_utils.quat_rotate_vector replacement results."""
+        quat_wxyz = qt.quaternion(1, 2, 3, 4)
+        vec_xyz = np.array([5, 6, 7])
+        hu_vec_rotated_xyz = hab_utils.quat_rotate_vector(quat_wxyz, vec_xyz)
+        print(hu_vec_rotated_xyz)  # [2.6 6.  8.2]
+
+        qt_vec_rotated_xyz = qt.rotate_vectors(quat_wxyz, vec_xyz)
+        print(qt_vec_rotated_xyz)  # [2.6 6.  8.2]
+
+        rot_vec_rotated_xyz = Rotation.from_quat(qt.as_float_array(quat_wxyz)).apply(
+            vec_xyz
+        )
+        print(rot_vec_rotated_xyz)  # [1.8 7.6 7. ]
+
+        [w, x, y, z] = qt.as_float_array(quat_wxyz)
+        rot_vec_rotated_xyz = Rotation.from_quat([x, y, z, w]).apply(vec_xyz)
+        print(rot_vec_rotated_xyz)  # [2.6 6.  8.2]
+
+        assert np.allclose(
+            hu_vec_rotated_xyz, rot_vec_rotated_xyz, rtol=1.0e-10, atol=1.0e-10
+        ), "hu_vec_rotated_xyz and rot_vec_rotated_xyz do not match"
+
+    def test_hab_utils_inverse(self):
+        """Verify get_inverse_agent_rot replacement results."""
+        vec_xyz = np.array([5, 6, 7])
+        quat_wxyz = qt.quaternion(1, 2, 3, 4)
+        inverse_magnum_rotation = hab_utils.common.quat_to_magnum(quat_wxyz).inverted()
+        inverse_quaternion_rotation = hab_utils.common.quat_from_magnum(
+            inverse_magnum_rotation
+        )
+        [w, x, y, z] = qt.as_float_array(inverse_quaternion_rotation)
+        magnum_vec_rotated_xyz = Rotation.from_quat([x, y, z, w]).apply(vec_xyz)
+        print(magnum_vec_rotated_xyz)  # [3.00000014 5.1999997 8.60000013]
+
+        [w, x, y, z] = qt.as_float_array(quat_wxyz)
+        rot_vec_rotated_xyz = Rotation.from_quat([x, y, z, w]).inv().apply(vec_xyz)
+        print(rot_vec_rotated_xyz)  # [3.  5.2 8.6]
+
+        assert np.allclose(
+            magnum_vec_rotated_xyz, rot_vec_rotated_xyz, rtol=1.0e-5, atol=1.0e-8
+        ), "magnum_vec_rotated_xyz and rot_vec_rotated_xyz do not match"
+
     def test_surface_policy_orientation(self):
         """Test ability of surface agent to orient to a point-normal.
 


### PR DESCRIPTION
This pull request makes progress on decoupling Monty from HabitatSim (identified in #52). Specifically, the `habitat_sim` dependency within `motor_policies.py` is removed.

These temporary tests (excluded from the pull request) guided the changes in addition to the standard test suite. Notably, `Rotation` expects an `x, y, z, w` quaternion format.

```python
    def test_hab_utils_quat_rotate_vector(self):
        """Verify hab_utils.quat_rotate_vector replacement results."""
        quat_wxyz = qt.quaternion(1, 2, 3, 4)
        vec_xyz = np.array([5, 6, 7])
        hu_vec_rotated_xyz = hab_utils.quat_rotate_vector(quat_wxyz, vec_xyz)
        print(hu_vec_rotated_xyz)  # [2.6 6.  8.2]

        qt_vec_rotated_xyz = qt.rotate_vectors(quat_wxyz, vec_xyz)
        print(qt_vec_rotated_xyz)  # [2.6 6.  8.2]

        rot_vec_rotated_xyz = Rotation.from_quat(qt.as_float_array(quat_wxyz)).apply(
            vec_xyz
        )
        print(rot_vec_rotated_xyz)  # [1.8 7.6 7. ]

        [w, x, y, z] = qt.as_float_array(quat_wxyz)
        rot_vec_rotated_xyz = Rotation.from_quat([x, y, z, w]).apply(vec_xyz)
        print(rot_vec_rotated_xyz)  # [2.6 6.  8.2]

        assert np.allclose(
            hu_vec_rotated_xyz, rot_vec_rotated_xyz, rtol=1.0e-10, atol=1.0e-10
        ), "hu_vec_rotated_xyz and rot_vec_rotated_xyz do not match"

    def test_hab_utils_inverse(self):
        """Verify get_inverse_agent_rot replacement results."""
        vec_xyz = np.array([5, 6, 7])
        quat_wxyz = qt.quaternion(1, 2, 3, 4)
        inverse_magnum_rotation = hab_utils.common.quat_to_magnum(quat_wxyz).inverted()
        inverse_quaternion_rotation = hab_utils.common.quat_from_magnum(
            inverse_magnum_rotation
        )
        [w, x, y, z] = qt.as_float_array(inverse_quaternion_rotation)
        magnum_vec_rotated_xyz = Rotation.from_quat([x, y, z, w]).apply(vec_xyz)
        print(magnum_vec_rotated_xyz)  # [3.00000014 5.1999997 8.60000013]

        [w, x, y, z] = qt.as_float_array(quat_wxyz)
        rot_vec_rotated_xyz = Rotation.from_quat([x, y, z, w]).inv().apply(vec_xyz)
        print(rot_vec_rotated_xyz)  # [3.  5.2 8.6]

        assert np.allclose(
            magnum_vec_rotated_xyz, rot_vec_rotated_xyz, rtol=1.0e-5, atol=1.0e-8
        ), "magnum_vec_rotated_xyz and rot_vec_rotated_xyz do not match"
```