### PR TITLE
ci: use git sha from workflow_run trigger and not latest commit

### DIFF
--- a/.github/workflows/monty_api_docs.yml
+++ b/.github/workflows/monty_api_docs.yml
@@ -48,7 +48,7 @@ jobs:
         if: ${{ steps.should_run_monty_api_docs.outputs.should_run_monty == 'true'}}
         uses: actions/download-artifact@v4
         with:
-          name: sphinx-html-${{ github.sha }}
+          name: sphinx-html-${{ github.event.workflow_run.head_sha }}
           run-id: ${{ github.event.workflow_run.id }}
           path: tbp.monty/sphinx_html
           github-token: ${{ github.token }}
@@ -56,11 +56,11 @@ jobs:
         if: ${{ steps.should_run_monty_api_docs.outputs.should_run_monty == 'true'}}
         uses: actions/upload-pages-artifact@v3
         with:
-          name: github-pages-${{ github.sha }}
+          name: github-pages-${{ github.event.workflow_run.head_sha }}
           path: tbp.monty/sphinx_html
       - name: Deploy Monty API docs
         id: deployment
         if: ${{ steps.should_run_monty_api_docs.outputs.should_run_monty == 'true'}}
         uses: actions/deploy-pages@v4
         with:
-          artifact_name: github-pages-${{ github.sha }}
+          artifact_name: github-pages-${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
This pull request updates the Monty API Docs workflow to use the correct git SHA when looking for an artifact.

In the screenshot below, we can see that Should Run Monty API Docs is being triggered with the correct git SHA; however, the SHA in the artifact name is the latest on the main branch and not the desired one for the workflow.

<img width="1616" alt="Screenshot 2024-11-27 at 19 19 45" src="https://github.com/user-attachments/assets/0fbe2be2-7d4e-49cc-9c92-8f38531fff8b">

-- https://github.com/thousandbrainsproject/tbp.monty/actions/runs/12060456960/job/33630906625

<img width="1701" alt="Screenshot 2024-11-27 at 19 23 00" src="https://github.com/user-attachments/assets/de93bb2c-1afb-4ad2-a653-4c0f573f224e">

-- https://github.com/thousandbrainsproject/tbp.monty/actions/runs/12060216594

<img width="1671" alt="Screenshot 2024-11-27 at 19 24 26" src="https://github.com/user-attachments/assets/0832ce4b-0427-4880-bb3e-58b16f2e61f3">

-- https://github.com/thousandbrainsproject/tbp.monty/actions/runs/12060409282