### PR TITLE
ci: grant pull-requests write to cla workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
 


### PR DESCRIPTION
I am trying to understand why the CLA workflow fails to write comments on a pull request. This is an attempt to see if it requires `pull-request: write` permission despite using the Issues write endpoint.