### PR TITLE
updated environment.yaml to include lark

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - cmake>=3.14.0
   - pyg::pyg
   - wget
+  - lark=1.2.2
 
   - aihabitat::habitat-sim=0.2.2
   - pytorch::pytorch=1.11.0


### PR DESCRIPTION
I got an error about lark after running pytest, so I went ahead and included lark 1.2.2 as a dependency in environment.yaml. 

ModuleNotFoundError: No module named 'lark'

*Note: I'm just starting to play with the TBP codebase. Please make sure this doesn't break anything. 