### PR TITLE
Updated to fix "No module named 'lark'"

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,6 @@ dependencies:
   - cmake>=3.14.0
   - pyg::pyg
   - wget
-  - lark=1.2.2
 
   - aihabitat::habitat-sim=0.2.2
   - pytorch::pytorch=1.11.0

--- a/environment.yml
+++ b/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - cmake>=3.14.0
   - pyg::pyg
   - wget
+  - lark=1.2.2
 
   - aihabitat::habitat-sim=0.2.2
   - pytorch::pytorch=1.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     'torch-geometric',
     'tqdm',
     'wandb',
+    'lark',
 ]
 description = 'Numenta Monty'
 dynamic = ['version']


### PR DESCRIPTION
Encountered the error below when running pytest after the initial setup. Added "lark" to the pyproject.toml to resolve. 

ModuleNotFoundError: No module named 'lark'
