### PR TITLE
Fix division by zero when running the tutorial experiment

### DIFF
--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1251,9 +1251,9 @@ class SurfacePolicy(InformedPolicy):
         x, y, z = rotated_point_normal
 
         if "horizontal" == orienting:
-            return -np.degrees(np.arctan(x / z))
+            return -np.degrees(np.arctan(x / z)) if z != 0 else -np.sign(x)*90.0
         if "vertical" == orienting:
-            return -np.degrees(np.arctan(y / z))
+            return -np.degrees(np.arctan(y / z)) if z != 0 else -np.sign(y)*90.0
 
 
 ###


### PR DESCRIPTION
## Problem

when running

```shell
% python benchmarks/run.py -e randrot_noise_10distinctobj_surf_agent
# or
% python benchmarks/run_parallel.py -e randrot_noise_10distinctobj_surf_agent
```

the following run-time errors can be observed:

```shell
.../tbp/monty/frameworks/models/motor_policies.py:1259: RuntimeWarning: divide by zero encountered in scalar divide
  return -np.degrees(np.arctan(x / z))
.../numpy/core/fromnumeric.py:3464: RuntimeWarning: Mean of empty slice.
  return _methods._mean(a, axis=axis, dtype=dtype,
.../numpy/core/_methods.py:192: RuntimeWarning: invalid value encountered in scalar divide
  ret = ret.dtype.type(ret / rcount)
```

as these might affect numeric results, an analysis is necessary. This has implications for published benchmarks that were affected.

[Initial discussion](https://thousandbrains.discourse.group/t/three-runtimewarning-s-when-running-the-tutorial-experiment/296?u=dled)

## Analysis

```python
>>> import numpy as np
>>> x=-1
>>> z=0
>>> -np.degrees(np.arctan(x / z))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ZeroDivisionError: division by zero
```

interestingly in the shell context this is a run-time error. Is this somehow (mis-)configured to be ignored?

## Fix

Fix `orienting_angle_from_normal` to not be affected by division by zero

## Result

```shell
> python benchmarks/run.py -e randrot_noise_10distinctobj_surf_agent
...
 overall/percent_correct 100
```