### PR TITLE
rfc: mermaid diagram trailing spaces required for preview to render

### DIFF
--- a/rfcs/0004_action_object/habitatenv_step_seq_diagram_desired.md
+++ b/rfcs/0004_action_object/habitatenv_step_seq_diagram_desired.md
@@ -38,13 +38,13 @@ sequenceDiagram
             loop each action parameter
                 HP ->>+ action_params : [param]=[action.param]
             end
-        HP -->>- HAct :
+        HP -->>- HAct : 
         HAct ->>+ sim_agent : act(action_name)
-        sim_agent -->>- HAct :
+        sim_agent -->>- HAct : 
     deactivate HAct
 
-    HAct -->>- A :
-    A -->>- HS :
+    HAct -->>- A : 
+    A -->>- HS : 
     HS ->> HS : get_observations
     activate HS
         HS ->>+ S : get_sensor_observations(agent_ids=agent_indices)


### PR DESCRIPTION
The [current Mermaid diagram preview in RFC 4](https://github.com/thousandbrainsproject/tbp.monty/blob/21954a3f97a9abe990734354b9a71b03f516c26a/rfcs/0004_action_object/habitatenv_step_seq_diagram_desired.md) does not render due to missing trailing whitespace.

This pull request adds trailing whitespace so that [the preview renders in GitHub](https://github.com/tristanls/tbp.monty/blob/f4fff071ab86ec1a07926c6e0f920eb69dc5800d/rfcs/0004_action_object/habitatenv_step_seq_diagram_desired.md). 