### PR TITLE
ci: pin cla-assistant@v1.0.0

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ github.repository_owner == 'thousandbrainsproject' }}
     steps:
       - name: "Verify CLA"
-        uses: thousandbrainsproject/cla-assistant@main
+        uses: thousandbrainsproject/cla-assistant@v1.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TBP_BOT_TOKEN_SECRET: ${{ secrets.TBP_BOT_TOKEN_SECRET }}


### PR DESCRIPTION
I am pinning cla-assistant to [v1.0.0](https://github.com/thousandbrainsproject/cla-assistant/releases/tag/v1.0.0) to change cla-assistant code in https://github.com/thousandbrainsproject/cla-assistant/pull/4 without breaking existing workflows.