### PR TITLE
Tools: Docs Preview was Previewing the Main Branch

### DIFF
--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -27,6 +27,7 @@ jobs:
           fetch-depth: 0
           lfs: true
           path: tbp.monty
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Create initial PR comment
         uses: ./tbp.monty/.github/actions/pin_comment


### PR DESCRIPTION
Which is not what we want.  This happens as a default security feature when you're using `pull_request_target`.