### PR TITLE
Add .rsyncignore.local to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ Session.vim
 
 # JetBrains/PyCharm
 .idea/
+
+# rsync
+.rsyncignore.local


### PR DESCRIPTION
Note: This PR is primarily aimed at the TBP team.

### What
This PR adds `rsyncignore.local` to `.gitignore`.

### Why
Excluding certain files and folder from `rsync`'s purview shaves off precious seconds when creating EC2 instances. When we run experiments on AWS, an EC2 instance is created for each experiment, which is then updated with local copies of `tbp.monty` and `monty_lab` via `rsync`. Much of `rsync`'s time is spent uploading files that might not be necessary for your particular purposes, such as syncing images in documentation prior to running an experiment. It would be preferable prevent user-specific `rsync` settings from being tracked.

### How
A couple of lines were added to `.gitignore`.

This PR is to accompanied a corresponding change in internal tooling to recognize `rsyncignore.local` files in `tbp.monty`.
