### PR TITLE
refactor!: rename num_cpus to num_parallel for run_parallel

### DIFF
--- a/src/tbp/monty/frameworks/config_utils/cmd_parser.py
+++ b/src/tbp/monty/frameworks/config_utils/cmd_parser.py
@@ -121,7 +121,11 @@ def create_cmd_parser_parallel(all_configs):
         choices=list(all_configs.keys()),
     )
     parser.add_argument(
-        "-n", "--num_cpus", default=16, help="How many cpus to use", type=int
+        "-n",
+        "--num_parallel",
+        default=16,
+        help="How many episodes to run in parallel",
+        type=int,
     )
     parser.add_argument(
         "-q",

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -40,15 +40,16 @@ from tbp.monty.frameworks.utils.dataclass_utils import config_to_dict
 """
 Just like run.py, but run episodes in parallel. Running in parallel is as simple as
 
-`python run_parallel.py -e my_exp -n ${NUM_CPUS}`
+`python run_parallel.py -e my_exp -n ${NUM_PARALLEL}`
 
 Assumptions and notes:
 --- There are some differences between training and testing in parallel. At train time,
     we parallelize across objects, but episodes with the same object are run in serial.
-    In this case it is best to set num_cpus to num_objects in your dataset if possible.
-    At test time, we separate all (object, pose) combos into separate jobs and run them
-    in parallel. In this case, the total_n_jobs is n_objects * n_poses, and the
-    more cpus the better (assuming you won't have more than total_n_jobs oavialable).
+    In this case it is best to set num_parallel to num_objects in your dataset if
+    possible. At test time, we separate all (object, pose) combos into separate jobs and
+    run them in parallel. In this case, the total_n_jobs is n_objects * n_poses, and
+    the more parallelism the better (assuming you won't have more than total_n_jobs
+    available).
 --- Only certain experiment classes are supported for training. Right now the focus is
     on SupervisedPreTraning. Some classes like ObjectRecognition are inherently
     not parallelizable because each episode depends on results from the previous.
@@ -380,7 +381,10 @@ def run_episodes_parallel(
             else:
                 print(f"No csv table found at {csv_path} to log to wandb")
 
-    print(f"Total time for {len(configs)} using {num_parallel} cpus: {total_time}")
+    print(
+        f"Total time for {len(configs)} running {num_parallel} episodes in parallel: "
+        f"{total_time}"
+    )
     if configs[0]["logging_config"]["log_parallel_wandb"]:
         run.finish()
 
@@ -389,7 +393,7 @@ def run_episodes_parallel(
     # Keep a record of how long everything takes
     with open(os.path.join(base_dir, "parallel_log.txt"), "w") as f:
         f.write(f"experiment: {experiment_name}\n")
-        f.write(f"num_cpus: {num_parallel}\n")
+        f.write(f"num_parallel: {num_parallel}\n")
         f.write(f"total_time: {total_time}")
 
 

--- a/tests/unit/run_parallel_test.py
+++ b/tests/unit/run_parallel_test.py
@@ -183,7 +183,7 @@ class RunParallelTest(unittest.TestCase):
         run_parallel(
             exp=self.supervised_pre_training,
             experiment="unittest_supervised_pre_training",
-            num_cpus=1,
+            num_parallel=1,
             quiet_habitat_logs=True,
             print_cfg=False,
             is_unittest=True,
@@ -251,7 +251,7 @@ class RunParallelTest(unittest.TestCase):
         run_parallel(
             exp=self.eval_config,
             experiment="unittest_eval_eq",
-            num_cpus=1,
+            num_parallel=1,
             quiet_habitat_logs=True,
             print_cfg=False,
             is_unittest=True,
@@ -302,7 +302,7 @@ class RunParallelTest(unittest.TestCase):
         run_parallel(
             exp=self.eval_config_lt,
             experiment="unittest_eval_lt",
-            num_cpus=1,
+            num_parallel=1,
             quiet_habitat_logs=True,
             print_cfg=False,
             is_unittest=True,
@@ -342,7 +342,7 @@ class RunParallelTest(unittest.TestCase):
         run_parallel(
             exp=self.eval_config_gt,
             experiment="unittest_eval_gt",
-            num_cpus=1,
+            num_parallel=1,
             quiet_habitat_logs=True,
             print_cfg=False,
             is_unittest=True,


### PR DESCRIPTION
I noticed that when we run an experiment with `run_parallel` it outputs:
```
-------- Running evaluation experiment randrot_10distinctobj_surf_agent with 16 cpus --------
```
16 is the number of episodes that will run in parallel. However, this does not guarantee 1 CPU per episode as an episode may launch multi-CPU computations.

This pull request updates the output to read `with 16 episodes in parallel` and renames the `--num_cpus` option and `num_cpus` parameter to `--num_parallel` and `num_parallel` respectively.

As this is a breaking change, I request a broader review from recent experiment runners.

@hlee9212, this impacts floppy copies of run_parallel.