### PR TITLE
refactor: remove habitat dependency from embodied_data

### DIFF
--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -23,7 +23,6 @@ from tbp.monty.frameworks.actions.actions import (
     SetAgentPose,
     SetSensorRotation,
 )
-from tbp.monty.frameworks.environment_utils.habitat_utils import get_bounding_corners
 from tbp.monty.frameworks.models.motor_policies import (
     SurfacePolicy,
     SurfacePolicyCurvatureInformed,
@@ -314,7 +313,7 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
             idx: Index of the new object and ints parameters in object_params
         """
         assert idx <= self.n_objects, "idx must be <= self.n_objects"
-        self.dataset.env._env.remove_all_objects()
+        self.dataset.env.remove_all_objects()
 
         # Specify config for the primary target object and then add it
         init_params = self.object_params.copy()
@@ -324,7 +323,7 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
         init_params["semantic_id"] = self.semantic_label_to_id[self.object_names[idx]]
 
         # TODO clean this up with its own specific call i.e. Law of Demeter
-        primary_target_obj = self.dataset.env._env.add_object(
+        primary_target_obj = self.dataset.env.add_object(
             name=self.object_names[idx], **init_params
         )
 
@@ -356,9 +355,6 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
                 except for the object ID
             primary_target_name (str): name of the primary target object
         """
-        # Get the bounding box info for the primary target obj
-        min_corner, max_corner = get_bounding_corners(primary_target_obj)
-
         # Sample distractor objects from those that are not the primary target; this
         # is so that, for now, we can evaluate how well the model stays on the primary
         # target object until it is classified, with no ambiguity about what final
@@ -373,11 +369,11 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
             new_obj_label = self.rng.choice(sampling_list)
             new_init_params["semantic_id"] = self.semantic_label_to_id[new_obj_label]
             # TODO clean up the **unpacking used
-            self.dataset.env._env.add_object(
+            self.dataset.env.add_object(
                 name=new_obj_label,
                 **new_init_params,
                 object_to_avoid=True,
-                primary_target_bb=[min_corner, max_corner],
+                primary_target_object=primary_target_obj,
             )
 
     def reset_agent(self):

--- a/src/tbp/monty/frameworks/environments/embodied_environment.py
+++ b/src/tbp/monty/frameworks/environments/embodied_environment.py
@@ -10,12 +10,14 @@
 
 import abc
 import collections.abc
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 from tbp.monty.frameworks.actions.actions import Action
 
 __all__ = ["EmbodiedEnvironment", "ActionSpace"]
 
+VectorXYZ = Tuple[float, float, float]
+QuaternionWXYZ = Tuple[float, float, float, float]
 
 class ActionSpace(collections.abc.Container):
     """Represents the environment action space."""
@@ -34,6 +36,44 @@ class EmbodiedEnvironment(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def add_object(
+        self,
+        name: str,
+        position: VectorXYZ = (0.0, 0.0, 0.0),
+        rotation: QuaternionWXYZ = (1.0, 0.0, 0.0, 0.0),
+        scale: VectorXYZ = (1.0, 1.0, 1.0),
+        semantic_id: Optional[str] = None,
+        enable_physics: Optional[bool] = False,
+        object_to_avoid=False,
+        primary_target_object=None,
+    ):
+        """Add an object to the environment.
+
+        Args:
+            name: The name of the object to add.
+            position: The initial absolute position of the object.
+            rotation: The initial rotation WXYZ quaternion of the object. Defaults to
+                (1,0,0,0).
+            scale: The scale of the object to add. Defaults to (1,1,1).
+            semantic_id: Optional override for the object semantic ID.
+            enable_physics: Whether to enable physics on the object. Defaults to False.
+            object_to_avoid: If True, run collision checks to ensure the object will not
+                collide with any other objects in the scene. If collision is detected,
+                the object will be moved. Defaults to False.
+            primary_target_object: If not None, the added object will be positioned to
+                obscure the initial view of the primary target object. Used when adding
+                multiple objects. Defaults to None.
+
+        Returns:
+            The newly added object.
+
+        TODO: This add_object interface is elevated from HabitatSim.add_object and is
+              quite specific to HabitatSim implementation. We should consider
+              refactoring this to be more generic.
+        """
+        pass
+
+    @abc.abstractmethod
     def step(self, action: Action) -> Dict[Any, Dict]:
         """Apply the given action to the environment.
 
@@ -45,6 +85,16 @@ class EmbodiedEnvironment(abc.ABC):
     @abc.abstractmethod
     def get_state(self):
         """Return the state of the environment (and agent)."""
+        pass
+
+    @abc.abstractmethod
+    def remove_all_objects(self):
+        """Remove all objects from the environment.
+
+        TODO: This remove_all_objects interface is elevated from
+              HabitatSim.remove_all_objects and is quite specific to HabitatSim
+              implementation. We should consider refactoring this to be more generic.
+        """
         pass
 
     @abc.abstractmethod

--- a/src/tbp/monty/frameworks/environments/embodied_environment.py
+++ b/src/tbp/monty/frameworks/environments/embodied_environment.py
@@ -60,8 +60,9 @@ class EmbodiedEnvironment(abc.ABC):
             object_to_avoid: If True, run collision checks to ensure the object will not
                 collide with any other objects in the scene. If collision is detected,
                 the object will be moved. Defaults to False.
-            primary_target_object: If not None, the added object will be positioned to
-                obscure the initial view of the primary target object. Used when adding
+            primary_target_object: If not None, the added object will be positioned so
+                that it does not obscure the initial view of the primary target object
+                (which avoiding collision alone cannot guarantee). Used when adding
                 multiple objects. Defaults to None.
 
         Returns:

--- a/src/tbp/monty/frameworks/environments/real_robots.py
+++ b/src/tbp/monty/frameworks/environments/real_robots.py
@@ -50,9 +50,23 @@ class RealRobotsEnvironment(EmbodiedEnvironment):
     def action_space(self):
         return GymActionSpace(self._env.action_space)
 
+    def add_object(self, *args, **kwargs):
+        # TODO The NotImplementedError highlights an issue with the EmbodiedEnvironment
+        #      interface and how the class hierarchy is defined and used.
+        raise NotImplementedError(
+            "RealRobotsEnvironment does not support adding objects"
+        )
+
     def step(self, action):
         observation, reward, done, info = self._env.step(action)
         return dict(**observation, reward=reward, done=done, info=info)
+
+    def remove_all_objects(self):
+        # TODO The NotImplementedError highlights an issue with the EmbodiedEnvironment
+        #      interface and how the class hierarchy is defined and used.
+        raise NotImplementedError(
+            "RealRobotsEnvironment does not support removing all objects"
+        )
 
     def reset(self):
         observation = self._env.reset()

--- a/src/tbp/monty/frameworks/environments/two_d_data.py
+++ b/src/tbp/monty/frameworks/environments/two_d_data.py
@@ -83,6 +83,11 @@ class OmniglotEnvironment(EmbodiedEnvironment):
     def action_space(self):
         return None
 
+    def add_object(self, *args, **kwargs):
+        # TODO The NotImplementedError highlights an issue with the EmbodiedEnvironment
+        #      interface and how the class hierarchy is defined and used.
+        raise NotImplementedError("OmniglotEnvironment does not support adding objects")
+
     def step(self, _action, amount):
         """Retrieve the next observation.
 
@@ -156,6 +161,13 @@ class OmniglotEnvironment(EmbodiedEnvironment):
         self.character_id = character_id
         self.character_version = version_id
         self.current_image, self.locations = self.load_new_character_data()
+
+    def remove_all_objects(self):
+        # TODO The NotImplementedError highlights an issue with the EmbodiedEnvironment
+        #      interface and how the class hierarchy is defined and used.
+        raise NotImplementedError(
+            "OmniglotEnvironment does not support removing all objects"
+        )
 
     def reset(self):
         self.step_num = 0
@@ -298,6 +310,13 @@ class SaccadeOnImageEnvironment(EmbodiedEnvironment):
             ]
         )
 
+    def add_object(self, *args, **kwargs):
+        # TODO The NotImplementedError highlights an issue with the EmbodiedEnvironment
+        #      interface and how the class hierarchy is defined and used.
+        raise NotImplementedError(
+            "SaccadeOnImageEnvironment does not support adding objects"
+        )
+
     def step(self, action: Action):
         """Retrieve the next observation.
 
@@ -390,6 +409,13 @@ class SaccadeOnImageEnvironment(EmbodiedEnvironment):
             self.current_scene_point_cloud,
             self.current_sf_scene_point_cloud,
         ) = self.get_3d_scene_point_cloud()
+
+    def remove_all_objects(self):
+        # TODO The NotImplementedError highlights an issue with the EmbodiedEnvironment
+        #      interface and how the class hierarchy is defined and used.
+        raise NotImplementedError(
+            "SaccadeOnImageEnvironment does not support removing all objects"
+        )
 
     def reset(self):
         """Reset environment and extract image patch.

--- a/src/tbp/monty/simulators/habitat/simulator.py
+++ b/src/tbp/monty/simulators/habitat/simulator.py
@@ -218,9 +218,9 @@ class HabitatSim(HabitatActuator):
                 colliding with any other objects in the scene, and otherwise move it
             primary_target_bb: If not None, the bounding box of the primary target
                 object; passed when we're adding multiple objects, such that we ensure
-                that the added object obscures the initial view of the primary target
-                object (which avoiding collision alone cannot guarantee); defined by a
-                list of the min and max corners
+                that the added object does not obscure the initial view of the primary
+                target object (which avoiding collision alone cannot guarantee); defined
+                by a list of the min and max corners
 
         Returns:
             RigidObject: The newly added object

--- a/tests/unit/embodied_data_test.py
+++ b/tests/unit/embodied_data_test.py
@@ -70,6 +70,9 @@ class FakeEnvironmentRel(EmbodiedEnvironment):
     def action_space(self):
         return FakeActionSpace(EXPECTED_ACTIONS_DIST)
 
+    def add_object(self, *args, **kwargs):
+        return None
+
     def step(self, action):
         self._current_state += 1
         obs = {
@@ -81,6 +84,9 @@ class FakeEnvironmentRel(EmbodiedEnvironment):
 
     def get_state(self):
         return None
+
+    def remove_all_objects(self):
+        pass
 
     def reset(self):
         self._current_state = 0
@@ -103,6 +109,9 @@ class FakeEnvironmentAbs(EmbodiedEnvironment):
     def action_space(self):
         return FakeActionSpace(EXPECTED_ACTIONS_ABS)
 
+    def add_object(self, *args, **kwargs):
+        return None
+
     def step(self, action):
         self._current_state += 1
         obs = {
@@ -114,6 +123,9 @@ class FakeEnvironmentAbs(EmbodiedEnvironment):
 
     def get_state(self):
         return None
+
+    def remove_all_objects(self):
+        pass
 
     def reset(self):
         self._current_state = 0


### PR DESCRIPTION
This pull request removes Habitat dependency from `frameworks/environments/embodied_data.py` as part of the work to decouple Monty runtime from HabitatSim.

<img width="830" alt="Screenshot 2025-01-23 at 17 12 24" src="https://github.com/user-attachments/assets/bbf9df85-b18a-48bc-a280-e9bf8a1cdd81" />

Previous planning called for writing a replacement `get_bounding_corners` function. However, after some investigation, it became clear that the use of `get_bounding_corners` within `embodied_data.py` is done only with the expectation that the Habitat environment is being used. As such, removing the dependency directly is a better refactor.

This refactoring moves the use of Habitat-specific `get_bounding_corners` into Habitat-specific `frameworks/environment/habitat.py`. To accomplish this, the `EmbodiedEnvironment` interface is expanded with `add_object` and `remove_all_objects` methods promoted directly from the `HabitatSim` implementation. Essentially, `embodied_data.py` can now call `EmbodiedEnvironment.add_object(...)`, which calls `HabitatEnvironment.add_object(...)`, which calls `HabitatSim.add_object(...)`. The call to `get_bounding_corners` is now inside `HabitatEnvironment.add_object(...)`. Previously, `embodied_data.py` called `HabitatSim.add_object(...)` directly via `dataset.env._env.add_object(...)`. This achieves our goal: if the runtime is not configured with a `HabitatEnvironment`, then `embodied_data.py` can still execute without importing a Habitat-specific dependency.

Due to the added interface in `EmbodiedEnvironment`, other environments now must implement the `add_object(...)` and `remove_all_objects` methods. This pull request adds these implementations by raising `NotImplementedError`. TODOs are added to highlight that extending existing environments with unimplemented methods highlights a mistake in how our environment hierarchy is defined and used. The work to evaluate and refactor the environment hierarchy is deferred. Environments will be revisited in the future in the scope of other planned work.