### PR TITLE
Add Ramy as maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@
 - [@codeallthethingz](https://github.com/codeallthethingz)
 - [@scottcanoe](https://github.com/scottcanoe)
 - [@hlee9212](https://github.com/hlee9212)
+- [@ramyamounir](https://github.com/ramyamounir)


### PR DESCRIPTION
As per discussion by the current maintainers, we have agreed to add @ramyamounir as a Maintainer to the TBP's governance https://thousandbrainsproject.readme.io/docs/governance#adding-maintainers

This decision was made in light of the large, well-written contribution he made to the codebase in summer 2024 while it was still closed-source (adding the EvidenceSDR to Monty), as well as the more recent contributions he has made.