### PR TITLE
Fix: Don't run docs preview when the PR is closed, or merged

### DIFF
--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -6,6 +6,7 @@ concurrency:
 
 on:
   pull_request_target:
+    types: [opened, synchronize, reopened]
     branches:
       - main
     paths:


### PR DESCRIPTION
Docs preview was running on all PR events, which meant it runs when the PR is merged or closed and this is not desired.