### PR TITLE
Fix: Dangling docs preview

### DIFF
--- a/.github/workflows/cleanup_docs_preview.yml
+++ b/.github/workflows/cleanup_docs_preview.yml
@@ -1,14 +1,13 @@
 name: Cleanup Docs Preview
 
 on:
+  push:
+    branches:
+      - main
   pull_request_target:
     types: [closed]
     branches:
       - main
-    paths:
-      - 'docs/**'
-      - 'tools/github_readme_sync/**'
-      - '.github/workflows/cleanup_docs_preview.yml'
 
 jobs:
   cleanup_docs_preview:


### PR DESCRIPTION
TLDR; docs preview cleanup is now run on any closed PR and on any push to main, regardless of what changed, to ensure no dangling previews are left around.

When does this happen?

If you create a PR and there is a doc change, a docs preview is created. If you undo the change to the documentation and push that to the PR branch then close or merge the PR, the cleanup action is not activated as none of its paths have changed leading to a docs preview never been deleted.