### PR TITLE
Docs: Snippets

### DIFF
--- a/docs/future-work/cmp-hierarchy-improvements.md
+++ b/docs/future-work/cmp-hierarchy-improvements.md
@@ -11,7 +11,7 @@ These are the things we would like to implement:
 - [Test learning at different speeds depending on level in hierarchy](cmp-hierarchy-improvements/test-learning-at-different-speeds-depending-on-level-in-hierarchy.md) #learning #generalization
 - [Send similarity encoding object ID to next level & test](cmp-hierarchy-improvements/send-similarity-encoding-object-id-to-next-level-test.md) #compositional
 
-Please see the [instructions here](project-roadmap.md#how-you-can-contribute) if you would like to tackle one of these tasks.
+!snippet[../snippets/contributing-tasks.md]
 
 > 📘 Heterarchy vs. Hierarchy
 > 

--- a/docs/future-work/environment-improvements.md
+++ b/docs/future-work/environment-improvements.md
@@ -11,4 +11,4 @@ These are the things we would like to implement:
 - [Create dataset and metrics to evaluate categories and generalization](environment-improvements/create-dataset-and-metrics-to-evaluate-categories-and-generalization.md) #generalization
 - [Create dataset and metrics to test new feature-morphology pairs](environment-improvements/create-dataset-and-metrics-to-test-new-feature-morphology-pairs.md) #featsandmorph
 
-Please see the [instructions here](project-roadmap.md#how-you-can-contribute) if you would like to tackle one of these tasks.
+!snippet[../snippets/contributing-tasks.md]

--- a/docs/future-work/framework-improvements.md
+++ b/docs/future-work/framework-improvements.md
@@ -12,4 +12,4 @@ These are the things we would like to implement:
 - [Make configs easier to use](framework-improvements/make-configs-easier-to-use.md) #infrastructure
 - [Find faster alternative to KDTree search](framework-improvements/find-faster-alternative-to-kdtree-search.md) #speed
 
-Please see the [instructions here](project-roadmap.md#how-you-can-contribute) if you would like to tackle one of these tasks.
+!snippet[../snippets/contributing-tasks.md]

--- a/docs/future-work/learning-module-improvements.md
+++ b/docs/future-work/learning-module-improvements.md
@@ -21,4 +21,4 @@ These are the things we would like to implement:
 - [Improve handling of symmetry](learning-module-improvements/improve-handling-of-symmetry.md) #pose
 - [Use Better Priors for Hypothesis Initialization](learning-module-improvements/use-better-priors-for-hypothesis-initialization.md) #numsteps #pose #scale
 
-Please see the [instructions here](project-roadmap.md#how-you-can-contribute) if you would like to tackle one of these tasks.
+!snippet[../snippets/contributing-tasks.md]

--- a/docs/future-work/motor-system-improvements.md
+++ b/docs/future-work/motor-system-improvements.md
@@ -17,4 +17,4 @@ These are the things we would like to implement:
 - [Model-based policy to recognize an object before moving onto a new object](motor-system-improvements/model-based-policy-to-recognize-an-object-before-moving-on-to-a-new-object.md) #multiobj #compositional
 - [Policy to quickly move to a new object](motor-system-improvements/policy-to-quickly-move-to-a-new-object.md) #speed #multiobj #compositional
 
-Please see the [instructions here](project-roadmap.md#how-you-can-contribute) if you would like to tackle one of these tasks.
+!snippet[../snippets/contributing-tasks.md]

--- a/docs/future-work/oss-communication-improvements.md
+++ b/docs/future-work/oss-communication-improvements.md
@@ -7,4 +7,4 @@ These are the things we would like to do:
 - [Organize & start podcast series](oss-communication-improvements/organize-start-podcast-series.md) #oss
 - [Make more condensed videos about the project & Monty](oss-communication-improvements/make-more-condensed-videos-about-the-project-monty) #oss
 
-Please see the [instructions here](project-roadmap.md#how-you-can-contribute) if you would like to tackle one of these tasks.
+!snippet[../snippets/contributing-tasks.md]

--- a/docs/future-work/sensor-module-improvements.md
+++ b/docs/future-work/sensor-module-improvements.md
@@ -8,4 +8,4 @@ These are the things we would like to implement:
 - [Extract better features](sensor-module-improvements/extract-better-features.md) (predefined, classic CV, ANNs, contrastive learning,...) #noise #accuracy #numsteps
 - [Detect local and global flow](sensor-module-improvements/detect-local-and-global-flow.md) #realworld #dynamic
 
-Please see the [instructions here](project-roadmap.md#how-you-can-contribute) if you would like to tackle one of these tasks.
+!snippet[../snippets/contributing-tasks.md]

--- a/docs/future-work/voting-improvements.md
+++ b/docs/future-work/voting-improvements.md
@@ -9,4 +9,4 @@ These are the things we would like to implement:
 - [Generalize voting to associative connections](voting-improvements/generalize-voting-to-associative-connections.md) (arbitrary object ID and reference frame pairs) #infrastructure
 - [Can we change the CMP to use displacements instead of locations?](voting-improvements/can-we-change-the-cmp-to-use-displacements-instead-of-locations.md)
 
-Please see the [instructions here](project-roadmap.md#how-you-can-contribute) if you would like to tackle one of these tasks.
+!snippet[../snippets/contributing-tasks.md]

--- a/docs/snippets/contributing-tasks.md
+++ b/docs/snippets/contributing-tasks.md
@@ -1,0 +1,1 @@
+Please see the [instructions here](project-roadmap.md#how-you-can-contribute) if you would like to tackle one of these tasks.

--- a/tools/github_readme_sync/tests/readme_test.py
+++ b/tools/github_readme_sync/tests/readme_test.py
@@ -629,6 +629,34 @@ This is a test document.""",
             self.assertIn("<td>Value 2</td>", result)
             self.assertIn("</table></div>", result)
 
+    def test_insert_markdown_snippet(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            docs_dir = os.path.join(tmp_dir, "docs")
+            other_dir = os.path.join(tmp_dir, "other")
+            os.makedirs(docs_dir)
+            os.makedirs(other_dir)
+
+            source_md = os.path.join(other_dir, "source.md")
+            with open(source_md, "w") as f:
+                f.write(
+                    "# Test Header\nThis is test content\n* List item 1\n* List item 2"
+                )
+            doc_path = os.path.join(docs_dir, "doc.md")
+
+            result = self.readme.insert_markdown_snippet(
+                "!snippet[../../other/source.md]", doc_path
+            )
+
+            expected_content = (
+                "# Test Header\nThis is test content\n* List item 1\n* List item 2"
+            )
+            self.assertEqual(result, expected_content)
+
+            result = self.readme.insert_markdown_snippet(
+                "!snippet[../other/nonexistent.md]", doc_path
+            )
+            self.assertIn("File not found", result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR adds snippet functionality to the docs using the following format:

`!snippet[../snippets/repeating-text.md]`

`repeating-text.md` will be inserted before any other processing happens.

Example here: https://thousandbrainsproject.readme.io/v0.0-snippet-test/docs/osscommunication-improvements