### PR TITLE
Chore: Build the docs when benchmarks/results/** change

### DIFF
--- a/.github/workflows/docs_preview.yml
+++ b/.github/workflows/docs_preview.yml
@@ -13,6 +13,7 @@ on:
       - 'docs/**'
       - 'tools/github_readme_sync/**'
       - '.github/workflows/docs_preview.yml'
+      - 'benchmarks/results/**'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
This PR fixes a problem where the docs are not getting rebuilt by the the preview system when the benchmarks/results change as they were not included in the build path trigger.