### PR TITLE
Dont require unused dataloaders

### DIFF
--- a/benchmarks/configs/monty_world_experiments.py
+++ b/benchmarks/configs/monty_world_experiments.py
@@ -76,8 +76,6 @@ world_image_on_scanned_model = dict(
     dataset_args=WorldImageDatasetArgs(
         env_init_args=EnvInitArgsMontyWorldStandardScenes()
     ),
-    train_dataloader_class=ED.SaccadeOnImageDataLoader,
-    train_dataloader_args=WorldImageDataloaderArgs(),
     eval_dataloader_class=ED.SaccadeOnImageDataLoader,
     # TODO: write something akin to PredefinedObjectInitializer to automatically
     # determine these values

--- a/benchmarks/configs/monty_world_habitat_experiments.py
+++ b/benchmarks/configs/monty_world_habitat_experiments.py
@@ -28,7 +28,6 @@ from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     EnvironmentDataloaderPerObjectArgs,
     EvalExperimentArgs,
     RandomRotationObjectInitializer,
-    get_env_dataloader_per_object_by_idx,
     get_object_names_by_idx,
 )
 from tbp.monty.frameworks.environments import embodied_data as ED
@@ -78,8 +77,6 @@ randrot_noise_sim_on_scan_monty_world = dict(
     ),
     dataset_class=ED.EnvironmentDataset,
     dataset_args=PatchViewFinderMontyWorldMountHabitatDatasetArgs(),
-    train_dataloader_class=ED.InformedEnvironmentDataLoader,
-    train_dataloader_args=get_env_dataloader_per_object_by_idx(start=0, stop=12),
     eval_dataloader_class=ED.InformedEnvironmentDataLoader,
     eval_dataloader_args=EnvironmentDataloaderPerObjectArgs(
         object_names=get_object_names_by_idx(0, 12, object_list=NUMENTA_OBJECTS),

--- a/benchmarks/configs/pretraining_experiments.py
+++ b/benchmarks/configs/pretraining_experiments.py
@@ -131,8 +131,6 @@ supervised_pre_training_base = dict(
         object_names=get_object_names_by_idx(0, 10, object_list=DISTINCT_OBJECTS),
         object_init_sampler=PredefinedObjectInitializer(rotations=train_rotations_all),
     ),
-    eval_dataloader_class=ED.InformedEnvironmentDataLoader,  # just placeholder
-    eval_dataloader_args=get_env_dataloader_per_object_by_idx(start=0, stop=1),
 )
 
 

--- a/benchmarks/configs/pretraining_experiments.py
+++ b/benchmarks/configs/pretraining_experiments.py
@@ -30,7 +30,6 @@ from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     EnvironmentDataloaderPerObjectArgs,
     ExperimentArgs,
     PredefinedObjectInitializer,
-    get_env_dataloader_per_object_by_idx,
     get_object_names_by_idx,
 )
 from tbp.monty.frameworks.config_utils.policy_setup_utils import (

--- a/benchmarks/configs/ycb_experiments.py
+++ b/benchmarks/configs/ycb_experiments.py
@@ -262,8 +262,6 @@ base_config_10distinctobj_dist_agent = dict(
     ),
     dataset_class=ED.EnvironmentDataset,
     dataset_args=PatchViewFinderMountHabitatDatasetArgs(),
-    train_dataloader_class=ED.InformedEnvironmentDataLoader,
-    train_dataloader_args=get_env_dataloader_per_object_by_idx(start=0, stop=10),
     eval_dataloader_class=ED.InformedEnvironmentDataLoader,
     eval_dataloader_args=EnvironmentDataloaderPerObjectArgs(
         object_names=get_object_names_by_idx(0, 10, object_list=DISTINCT_OBJECTS),

--- a/benchmarks/configs/ycb_experiments.py
+++ b/benchmarks/configs/ycb_experiments.py
@@ -507,6 +507,7 @@ surf_agent_unsupervised_10distinctobj.update(
         learning_module_configs=default_lfs_lm,
     ),
     dataset_args=SurfaceViewFinderMountHabitatDatasetArgs(),
+    train_dataloader_class=ED.InformedEnvironmentDataLoader,
     train_dataloader_args=EnvironmentDataloaderPerObjectArgs(
         object_names=get_object_names_by_idx(0, 10, object_list=DISTINCT_OBJECTS),
         object_init_sampler=RandomRotationObjectInitializer(),

--- a/benchmarks/configs/ycb_experiments.py
+++ b/benchmarks/configs/ycb_experiments.py
@@ -45,7 +45,6 @@ from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     ExperimentArgs,
     PredefinedObjectInitializer,
     RandomRotationObjectInitializer,
-    get_env_dataloader_per_object_by_idx,
     get_object_names_by_idx,
 )
 from tbp.monty.frameworks.environments import embodied_data as ED

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -174,23 +174,31 @@ class MontyExperiment:
         return model
 
     def load_dataset_and_dataloaders(self, config):
-        # TODO: don't need to bother loading train and eval if only doing one
 
         # Initialize everything needed for dataloader
         dataset_class = config["dataset_class"]
         dataset_args = config["dataset_args"]
         self.dataset = self.load_dataset(dataset_class, dataset_args)
 
-        dataloader_class = config["train_dataloader_class"]
-        dataloader_args = config["train_dataloader_args"]
-        self.train_dataloader = self.create_data_loader(
-            dataloader_class, dataloader_args
-        )
-        dataloader_class = config["eval_dataloader_class"]
-        dataloader_args = config["eval_dataloader_args"]
-        self.eval_dataloader = self.create_data_loader(
-            dataloader_class, dataloader_args
-        )
+        # Initialize train dataloaders if needed
+        if config["experiment_args"]["do_train"]:
+            dataloader_class = config["train_dataloader_class"]
+            dataloader_args = config["train_dataloader_args"]
+            self.train_dataloader = self.create_data_loader(
+                dataloader_class, dataloader_args
+            )
+        else:
+            self.train_dataloader = None
+
+        # Initialize eval dataloaders if needed
+        if config["experiment_args"]["do_eval"]:
+            dataloader_class = config["eval_dataloader_class"]
+            dataloader_args = config["eval_dataloader_args"]
+            self.eval_dataloader = self.create_data_loader(
+                dataloader_class, dataloader_args
+            )
+        else:
+            self.eval_dataloader = None
 
     def load_dataset(self, dataset_class, dataset_args):
         """Instantiate a dataset.


### PR DESCRIPTION
This PR removes the need to specify unused data loader classes and args in experiment configs.

### Motivation
Monty experiment configs currently require specifying both training and eval data loaders, regardless of whether both are needed. This means we end up with loads of lines like
```python
some_pretraining_config = dict(
    .
    .
    .
    eval_dataloader_class=ED.InformedEnvironmentDataLoader,  # just placeholder
    eval_dataloader_args=get_env_dataloader_per_object_by_idx(start=0, stop=1),
)
```
or 
```python
some_eval_config = dict(
    .
    .
    .
    # required but unused
    train_dataloader_class=ED.InformedEnvironmentDataLoader,
    train_dataloader_args=get_env_dataloader_per_object_by_idx(start=0, stop=10),
)
```
This adds clutter and may also be misleading, especially to newcomers. This is a small PR that improves quality of life and allows us to write cleaner, less confusing experiment configs.

### Changes
- `MontyExperiment.load_dataset_and_dataloaders` was modified such that an eval or train dataloaders will only be initialized if the experiment config requires it.
- This change was tested by removing unused data loaders from benchmark configs. As such, eval dataloader configs have been removed from benchmark pretraining experiments, and train dataloader configs have been removed benchmark from eval experiments. I reran all pretraining experiments, a couple of experiments from each of the long- and short- YCB experiment list, all unsupervised experiments, and a few monty-meets-world experiments. As expected, all configs run as normal.
