### PR TITLE
Evidence Update Threshold

### DIFF
--- a/benchmarks/configs/ycb_experiments.py
+++ b/benchmarks/configs/ycb_experiments.py
@@ -351,7 +351,11 @@ randrot_noise_10distinctobj_surf_agent.update(
         monty_args=MontyArgs(min_eval_steps=min_eval_steps),
     ),
     dataset_args=SurfaceViewFinderMountHabitatDatasetArgs(),
+    logging_config=CSVLoggingConfig(python_log_level="DEBUG"),
 )
+randrot_noise_10distinctobj_surf_agent["monty_config"].learning_module_configs[
+    "learning_module_0"
+]["learning_module_args"]["use_multithreading"] = False
 
 randrot_10distinctobj_surf_agent = copy.deepcopy(base_config_10distinctobj_surf_agent)
 randrot_10distinctobj_surf_agent.update(


### PR DESCRIPTION
A WIP PR that investigates the possible bug related to Evidence Update Threshold in `EvidenceGraphLM` class. 

**Intended Behavior**

* When using `x_percent_threshold`, we expect to reduce the hypothesis space to objects whose evidence score is above `max_obj_evidence - x_percent_threshold * max_obj_evidence` (e.g. if max evidence is 100 and x_percent_threshold=20%, then all objects whose evidence >= 80 should be kept). However, we may have kept objects with evidence above x_percent_threshold * max_obj_evidence instead. 

