### PR TITLE
Fix Evidence threshold bug

### DIFF
--- a/benchmarks/configs/defaults.py
+++ b/benchmarks/configs/defaults.py
@@ -80,8 +80,8 @@ default_evidence_lm_config = dict(
         max_nneighbors=10,
         # Use this to update all hypotheses at every step as previously
         # evidence_update_threshold="all",
-        # Use this to update all hypotheses > x_percent_threshold (faster)
-        evidence_update_threshold="x_percent_threshold",
+        # Use this to update all hypotheses with evidence > 80% of max evidence (faster)
+        evidence_update_threshold="80%",
         # use_multithreading=False,
         # NOTE: Currently not used when loading pretrained graphs.
         max_graph_size=0.3,  # 30cm

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -1777,7 +1777,7 @@ class EvidenceGraphLM(GraphLM):
         elif self.evidence_update_threshold == "x_percent_threshold":
             max_global_evidence = self.current_mlh["evidence"]
             x_percent_of_max = max_global_evidence / 100 * self.x_percent_threshold
-            return x_percent_of_max
+            return max_global_evidence - x_percent_of_max
         elif self.evidence_update_threshold == "all":
             return np.min(self.evidence[graph_id])
         else:

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -176,7 +176,7 @@ class EvidenceGraphLM(GraphLM):
         initial_possible_poses: initial possible poses that should be tested for.
             In ["uniform", "informed", list]. default = "informed".
         evidence_update_threshold: How to decide which hypotheses should be updated.
-            In [int, float, 'mean', 'median', 'all', 'x_percent_threshold'].
+            In [int, float, '[int]%', 'mean', 'median', 'all', 'x_percent_threshold'].
         vote_evidence_threshold: Only send votes that have a scaled evidence above
             this threshold. Vote evidences are in the range of [-1, 1] so the threshold
             should not be outside this range.
@@ -1774,6 +1774,17 @@ class EvidenceGraphLM(GraphLM):
             return np.mean(self.evidence[graph_id])
         elif self.evidence_update_threshold == "median":
             return np.median(self.evidence[graph_id])
+        elif isinstance(
+            self.evidence_update_threshold, str
+        ) and self.evidence_update_threshold.endswith("%"):
+            percentage_str = self.evidence_update_threshold.strip("%")
+            percentage = float(percentage_str)
+            assert (
+                percentage >= 0 and percentage <= 100
+            ), "Percentage must be between 0 and 100"
+            max_global_evidence = self.current_mlh["evidence"]
+            x_percent_of_max = max_global_evidence * (percentage / 100)
+            return max_global_evidence - x_percent_of_max
         elif self.evidence_update_threshold == "x_percent_threshold":
             max_global_evidence = self.current_mlh["evidence"]
             x_percent_of_max = max_global_evidence / 100 * self.x_percent_threshold
@@ -1783,7 +1794,7 @@ class EvidenceGraphLM(GraphLM):
         else:
             raise Exception(
                 "evidence_update_threshold not in "
-                "[int, float, 'mean', 'median', 'all', 'x_percent_threshold']"
+                "[int, float, '[int]%', 'mean', 'median', 'all', 'x_percent_threshold']"
             )
 
     def _get_node_distance_weights(self, distances):


### PR DESCRIPTION
There was a bug in the `_get_evidence_update_threshold` function in the EvidenceLM where instead of setting the threshold for upding a hypothesis to `x_percent_threshold` it was set to `1 - x_percent_threshold`.


Results are as expected:
- After the change is applied, accuracy and run time go down (green vs. grey) because we test way fewer hypotheses at every step.
- If we set the evidence update threshold manually back to 80% instead of 20%, we get exactly the same results as before the fix (turquoise vs. grey). This is just a sanity check.

![Screenshot 2025-02-21 at 5 06 34 PM](https://github.com/user-attachments/assets/277d4e40-6d96-4b7c-907e-5257b25169cb)

Given that the accuracy decreases so much after the fix, it seems like it would be good to create a separate variable for the evidence update threshold (if it is a percentage) instead of using the x_percent_threshold variable defined for the terminal condition. This PR includes a proposed way to add an option to specify `evidence_update_threshold` as a percentage.

I ran some hyperparameter tests for different values:
![Screenshot 2025-02-21 at 5 08 39 PM](https://github.com/user-attachments/assets/c593968f-bb2c-429b-b390-ae14fc9f5bd0)

Remaining tasks before this can become a full PR:

- [ ] Test this parameter on 77 object experiment
- [ ] Test whether there is a different optimal `x_percent_threshold` value, given that these two parameters as disentangled now
- [ ] Rerun all benchmarks & update results with the new values (if we set new values. Currently results should be exactly the same).

