### PR TITLE
docs: additional context for evidence_update_threshold

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -176,13 +176,13 @@ class EvidenceGraphLM(GraphLM):
         initial_possible_poses: initial possible poses that should be tested for.
             In ["uniform", "informed", list]. default = "informed".
         evidence_update_threshold: How to decide which hypotheses should be updated.
-            When this parameter is either '[int]%' or 'x_percent_threshold`, then
-            this parameter is applied to the Most Likely Hypothesis (MLH) to
-            determine a minimum evidence threshold in order for other hypotheses to be
-            updated. Any hypotheses falling below the resulting evidence threshold do
-            not get updated. The other options set a fixed threshold that does not
-            take MLH into account.In [int, float, '[int]%', 'mean', 'median', 'all',
-            'x_percent_threshold'].
+            When this parameter is either '[int]%' or 'x_percent_threshold', then
+            this parameter is applied to the evidence for the Most Likely Hypothesis
+            (MLH) to determine a minimum evidence threshold in order for other
+            hypotheses to be updated. Any hypotheses falling below the resulting
+            evidence threshold do not get updated. The other options set a fixed
+            threshold that does not take MLH evidence into account. In [int, float,
+            '[int]%', 'mean', 'median', 'all', 'x_percent_threshold'].
         vote_evidence_threshold: Only send votes that have a scaled evidence above
             this threshold. Vote evidences are in the range of [-1, 1] so the threshold
             should not be outside this range.

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -176,7 +176,11 @@ class EvidenceGraphLM(GraphLM):
         initial_possible_poses: initial possible poses that should be tested for.
             In ["uniform", "informed", list]. default = "informed".
         evidence_update_threshold: How to decide which hypotheses should be updated.
-            In [int, float, '[int]%', 'mean', 'median', 'all', 'x_percent_threshold'].
+            Given a Most Likely Hypothesis (MLH), this parameter is applied to MLH to
+            determine a minimum evidence threshold in order for other hypotheses to be
+            updated. Any hypotheses falling below the resulting evidence threshold do
+            not get updated. In [int, float, '[int]%', 'mean', 'median', 'all',
+            'x_percent_threshold'].
         vote_evidence_threshold: Only send votes that have a scaled evidence above
             this threshold. Vote evidences are in the range of [-1, 1] so the threshold
             should not be outside this range.

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -176,10 +176,12 @@ class EvidenceGraphLM(GraphLM):
         initial_possible_poses: initial possible poses that should be tested for.
             In ["uniform", "informed", list]. default = "informed".
         evidence_update_threshold: How to decide which hypotheses should be updated.
-            Given a Most Likely Hypothesis (MLH), this parameter is applied to MLH to
+            When this parameter is either '[int]%' or 'x_percent_threshold`, then
+            this parameter is applied to the Most Likely Hypothesis (MLH) to
             determine a minimum evidence threshold in order for other hypotheses to be
             updated. Any hypotheses falling below the resulting evidence threshold do
-            not get updated. In [int, float, '[int]%', 'mean', 'median', 'all',
+            not get updated. The other options set a fixed threshold that does not
+            take MLH into account.In [int, float, '[int]%', 'mean', 'median', 'all',
             'x_percent_threshold'].
         vote_evidence_threshold: Only send votes that have a scaled evidence above
             this threshold. Vote evidences are in the range of [-1, 1] so the threshold


### PR DESCRIPTION
@vkakerbeck gave this explanation for `evidence_update_threshold` in a video. This explanation is what clicked for me and apparently @scottcanoe. This pull request adds it for context for others who try to understand the purpose of this parameter.