### PR TITLE
build: reset version to 0.0.0 to satisfy conda constraint

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.0.1-dev0"
+__version__ = "0.0.0"


### PR DESCRIPTION
When testing building Monty for `conda` distribution, observed that `conda` does not allow `-` in the version name.

```
(tbp.monty) me@only_slightly_bent tbp.monty % conda build .
(...)

CondaBuildUserError: Bad character(s) (-) in package/version: 0.0.1-dev0.
```

This pull request resets the version to `0.0.0` to satisfy this `conda` constraint. According to [RFC 7 Monty Versioning](https://github.com/thousandbrainsproject/tbp.monty/blob/main/rfcs/0007_monty_versioning.md), we also do not anticipate using build versions at this time.