### PR TITLE
build: set correct working-directory for version_updated action

### DIFF
--- a/.github/actions/version_updated/action.yml
+++ b/.github/actions/version_updated/action.yml
@@ -19,6 +19,7 @@ runs:
   steps:
     - name: Version updated
       id: version_updated
+      working-directory: ${{ inputs.working_directory }}
       shell: bash
       run: |
         git diff --name-only ${{ inputs.git_sha }}^1 > changed_files.txt


### PR DESCRIPTION
I forgot to use `working-directory` in the `version_updated` action, [resulting in job failures](https://github.com/thousandbrainsproject/tbp.monty/actions/runs/13572685337/job/37941404176#step:3:142).