### PR TITLE
build: need fetch-depth=2 for git diff commit^1 comparison

### DIFF
--- a/.github/workflows/monty_publish.yml
+++ b/.github/workflows/monty_publish.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout tbp.monty
         uses: actions/checkout@v4
         with:
+          fetch-depth: 2
           path: tbp.monty
       - name: Version updated
         id: version_updated
@@ -60,6 +61,7 @@ jobs:
       - name: Checkout tbp.monty
         uses: actions/checkout@v4
         with:
+          fetch-depth: 2
           path: tbp.monty
       - name: Version updated
         id: version_updated


### PR DESCRIPTION
The `version_updated` action executes the comparison:
```
git diff --name-only 9f59ad0105d877a40f7d058da3f88cc43c4c7ce0^1 > changed_files.txt
```
The `^1` at the end of the commit hash means to `diff` with the previous commit. However, the default checkout action uses `fetch-depth: 1`, which will not include the previous commit.
```
Run actions/checkout@v4
  with:
    path: tbp.monty
    repository: thousandbrainsproject/tbp.monty
    token: ***
    ssh-strict: true
    ssh-user: git
    persist-credentials: true
    clean: true
    sparse-checkout-cone-mode: true
    fetch-depth: 1
    fetch-tags: false
    show-progress: true
    lfs: false
    submodules: false
    set-safe-directory: true
...
Checking out the ref
/usr/bin/git log -1 --format=%H
9f59ad0105d877a40f7d058da3f88cc43c4c7ce0
```
Results in the error:
```
git diff --name-only 9f59ad0105d877a40f7d058da3f88cc43c4c7ce0^1 > changed_files.txt
fatal: ambiguous argument '9f59ad0105d877a40f7d058da3f88cc43c4c7ce0^1': unknown revision or path not in the working tree.
```

This pull request checks out enough commits for comparison with the previous commit to work.