### PR TITLE
Basic context manager for MontyExperiment

### DIFF
--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -174,7 +174,6 @@ class MontyExperiment:
         return model
 
     def load_dataset_and_dataloaders(self, config):
-
         # Initialize everything needed for dataloader
         dataset_class = config["dataset_class"]
         dataset_args = config["dataset_args"]
@@ -606,3 +605,25 @@ class MontyExperiment:
             logging.debug(f"Removing and closing python log handler: {handler}")
             python_logger.removeHandler(handler)
             handler.close()
+
+    def __enter__(self):
+        """Context manager entry method.
+
+        Returns:
+            MontyExperiment self to allow assignment in a with statement
+        """
+        # TODO - move some of the initialization code from `setup_experiment` into this
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit method.
+
+        Ensure that we always close the environment if necessary.
+
+        Returns:
+            bool to indicate whether to supress any exceptions that were raised
+        """
+        # TODO - we call self.close inside `train` and `evaluate`.
+        #   Those should probably be removed
+        self.close()
+        return False  # don't silence exceptions inside the with block

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -61,24 +61,22 @@ Assumptions and notes:
 def single_train(config):
     os.makedirs(config["logging_config"]["output_dir"], exist_ok=True)
     exp = config["experiment_class"]()
-    exp.setup_experiment(config)
-    print("---------training---------")
-    exp.train()
-    exp.close()
+    with exp:
+        exp.setup_experiment(config)
+        print("---------training---------")
+        exp.train()
 
 
 def single_evaluate(config):
     os.makedirs(config["logging_config"]["output_dir"], exist_ok=True)
     exp = config["experiment_class"]()
-    exp.setup_experiment(config)
-    print("---------evaluating---------")
-    exp.evaluate()
-    if config["logging_config"]["log_parallel_wandb"]:
-        eval_stats = get_episode_stats(exp, "eval")
-        exp.close()
-        return eval_stats
-    else:
-        exp.close()
+    with exp:
+        exp.setup_experiment(config)
+        print("---------evaluating---------")
+        exp.evaluate()
+        if config["logging_config"]["log_parallel_wandb"]:
+            eval_stats = get_episode_stats(exp, "eval")
+            return eval_stats
 
 
 def get_episode_stats(exp, mode):

--- a/tests/unit/graph_building_test.py
+++ b/tests/unit/graph_building_test.py
@@ -225,22 +225,22 @@ class GraphLearningTest(unittest.TestCase):
     def build_and_save_supervised_graph(self):
         pprint("...parsing experiment...")
         self.exp = MontySupervisedObjectPretrainingExperiment()
-        self.exp.setup_experiment(self.supervised_pre_training_in_habitat)
-        self.exp.model.set_experiment_mode("train")
+        with self.exp:
+            self.exp.setup_experiment(self.supervised_pre_training_in_habitat)
+            self.exp.model.set_experiment_mode("train")
 
-        pprint("...training...")
-        self.exp.train()
-        self.exp.dataset.close()
+            pprint("...training...")
+            self.exp.train()
 
     def build_and_save_supervised_graph_feat(self):
         pprint("...parsing experiment...")
         self.exp = MontySupervisedObjectPretrainingExperiment()
-        self.exp.setup_experiment(self.spth_feat)
-        self.exp.model.set_experiment_mode("train")
+        with self.exp:
+            self.exp.setup_experiment(self.spth_feat)
+            self.exp.model.set_experiment_mode("train")
 
-        pprint("...training...")
-        self.exp.train()
-        self.exp.dataset.close()
+            pprint("...training...")
+            self.exp.train()
 
     def test_get_correct_k_n(self):
         # enough data points sampled, just add 1 to remove self connection
@@ -281,99 +281,106 @@ class GraphLearningTest(unittest.TestCase):
                 3,
                 "Edge attributes don't store 3d displacements",
             )
-        self.exp.dataset.close()
 
     def test_can_load_disp_graph(self):
         self.build_and_save_supervised_graph()
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.load_habitat_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("checking loaded graphs")
-        for graph_id in self.exp.model.learning_modules[0].get_all_known_object_ids():
-            graph = self.exp.model.learning_modules[0].get_graph(
-                graph_id, input_channel="first"
-            )
-            self.check_graph_formatting(
-                graph,
-                features_to_check=self.exp.model.sensor_modules[0].features,
-            )
-        pprint("...evaluating on loaded models...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("checking loaded graphs")
+            for graph_id in self.exp.model.learning_modules[
+                0
+            ].get_all_known_object_ids():
+                graph = self.exp.model.learning_modules[0].get_graph(
+                    graph_id, input_channel="first"
+                )
+                self.check_graph_formatting(
+                    graph,
+                    features_to_check=self.exp.model.sensor_modules[0].features,
+                )
+            pprint("...evaluating on loaded models...")
+            self.exp.evaluate()
 
     def test_can_load_disp_graph_for_ppf_matching(self):
         self.build_and_save_supervised_graph()
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.load_habitat_for_ppf)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("checking loaded graphs")
-        for graph_id in self.exp.model.learning_modules[0].get_all_known_object_ids():
-            graph = self.exp.model.learning_modules[0].get_graph(
-                graph_id, input_channel="first"
-            )
-            self.check_graph_formatting(
-                graph,
-                features_to_check=self.exp.model.sensor_modules[0].features,
-            )
-            self.assertEqual(
-                graph.edge_attr.shape[1],
-                4,
-                "Edge attributes don't store 4d PPF (should be added when loading)",
-            )
-        pprint("...evaluating on loaded models...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("checking loaded graphs")
+            for graph_id in self.exp.model.learning_modules[
+                0
+            ].get_all_known_object_ids():
+                graph = self.exp.model.learning_modules[0].get_graph(
+                    graph_id, input_channel="first"
+                )
+                self.check_graph_formatting(
+                    graph,
+                    features_to_check=self.exp.model.sensor_modules[0].features,
+                )
+                self.assertEqual(
+                    graph.edge_attr.shape[1],
+                    4,
+                    "Edge attributes don't store 4d PPF (should be added when loading)",
+                )
+            pprint("...evaluating on loaded models...")
+            self.exp.evaluate()
 
     def test_can_load_disp_graph_for_feature_matching(self):
         self.build_and_save_supervised_graph()
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.load_habitat_for_feat)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("checking loaded graphs")
-        for graph_id in self.exp.model.learning_modules[0].get_all_known_object_ids():
-            graph = self.exp.model.learning_modules[0].get_graph(
-                graph_id, input_channel="first"
-            )
-            self.check_graph_formatting(
-                graph,
-                features_to_check=self.exp.model.sensor_modules[0].features,
-            )
-            self.assertEqual(
-                graph.edge_attr.shape[1],
-                3,
-                "Edge attributes don't store 3d displacements",
-            )
-        pprint("...evaluating on loaded models...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("checking loaded graphs")
+            for graph_id in self.exp.model.learning_modules[
+                0
+            ].get_all_known_object_ids():
+                graph = self.exp.model.learning_modules[0].get_graph(
+                    graph_id, input_channel="first"
+                )
+                self.check_graph_formatting(
+                    graph,
+                    features_to_check=self.exp.model.sensor_modules[0].features,
+                )
+                self.assertEqual(
+                    graph.edge_attr.shape[1],
+                    3,
+                    "Edge attributes don't store 3d displacements",
+                )
+            pprint("...evaluating on loaded models...")
+            self.exp.evaluate()
 
     def test_can_extend_and_save_feat_graph(self):
         self.build_and_save_supervised_graph_feat()
         config = copy.deepcopy(self.load_habitat_for_feat)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("checking loaded graphs")
-        for graph_id in self.exp.model.learning_modules[0].get_all_known_object_ids():
-            graph = self.exp.model.learning_modules[0].get_graph(
-                graph_id, input_channel="first"
-            )
-            self.check_graph_formatting(
-                graph,
-                features_to_check=self.exp.model.sensor_modules[0].features,
-            )
-            # TODO: not sure if we want this check. Right now it doesn't but I
-            # also don't see a reason why it couldn't in the future.
-            self.assertIs(
-                graph.edge_attr,
-                None,
-                "feature at location graph should not contain edges.",
-            )
-        pprint("...evaluating on loaded models...")
-        self.exp.train()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("checking loaded graphs")
+            for graph_id in self.exp.model.learning_modules[
+                0
+            ].get_all_known_object_ids():
+                graph = self.exp.model.learning_modules[0].get_graph(
+                    graph_id, input_channel="first"
+                )
+                self.check_graph_formatting(
+                    graph,
+                    features_to_check=self.exp.model.sensor_modules[0].features,
+                )
+                # TODO: not sure if we want this check. Right now it doesn't but I
+                # also don't see a reason why it couldn't in the future.
+                self.assertIs(
+                    graph.edge_attr,
+                    None,
+                    "feature at location graph should not contain edges.",
+                )
+            pprint("...evaluating on loaded models...")
+            self.exp.train()
 
 
 if __name__ == "__main__":

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -548,127 +548,127 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(base_config)
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(base_config)
 
     def test_can_run_train_episode(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(base_config)
-        self.exp.model.set_experiment_mode("train")
-        pprint("...training...")
-        self.exp.pre_epoch()
-        self.exp.run_episode()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(base_config)
+            self.exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            self.exp.pre_epoch()
+            self.exp.run_episode()
 
     def test_right_data_in_buffer(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(base_config)
-        self.exp.model.set_experiment_mode("train")
-        pprint("...training...")
-        self.exp.pre_epoch()
-        self.exp.pre_episode()
-        for step, observation in enumerate(self.exp.dataloader):
-            self.exp.model.step(observation)
-            self.assertEqual(
-                step + 1,
-                len(self.exp.model.learning_modules[0].buffer),
-                "buffer does not contain the right amount of elements.",
-            )
-            self.assertEqual(
-                step + 1,
-                len(
-                    self.exp.model.learning_modules[
-                        0
-                    ].buffer.get_all_locations_on_object(input_channel="first")
-                ),
-                "buffer does not contain the right amount of locations.",
-            )
-            if step == 0:
-                self.assertListEqual(
-                    list(
-                        self.exp.model.learning_modules[0].buffer.get_nth_displacement(
-                            0, input_channel="first"
-                        )
-                    ),
-                    list([0, 0, 0]),
-                    "displacement at step 0 should be 0.",
+        with self.exp:
+            self.exp.setup_experiment(base_config)
+            self.exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            self.exp.pre_epoch()
+            self.exp.pre_episode()
+            for step, observation in enumerate(self.exp.dataloader):
+                self.exp.model.step(observation)
+                self.assertEqual(
+                    step + 1,
+                    len(self.exp.model.learning_modules[0].buffer),
+                    "buffer does not contain the right amount of elements.",
                 )
-            self.assertEqual(
-                step + 1,
-                len(
-                    self.exp.model.learning_modules[0].buffer.displacements["patch"][
-                        "displacement"
-                    ]
-                ),
-                "buffer does not contain the right amount of displacements.",
-            )
-            self.assertSetEqual(
-                set(self.exp.model.sensor_modules[0].features),
-                set(self.exp.model.learning_modules[0].buffer[-1]["patch"].keys()),
-                "buffer doesn't contain all features required for matching.",
-            )
-            if step == 3:
-                break
-        self.exp.dataset.close()
+                self.assertEqual(
+                    step + 1,
+                    len(
+                        self.exp.model.learning_modules[
+                            0
+                        ].buffer.get_all_locations_on_object(input_channel="first")
+                    ),
+                    "buffer does not contain the right amount of locations.",
+                )
+                if step == 0:
+                    self.assertListEqual(
+                        list(
+                            self.exp.model.learning_modules[
+                                0
+                            ].buffer.get_nth_displacement(0, input_channel="first")
+                        ),
+                        list([0, 0, 0]),
+                        "displacement at step 0 should be 0.",
+                    )
+                self.assertEqual(
+                    step + 1,
+                    len(
+                        self.exp.model.learning_modules[0].buffer.displacements[
+                            "patch"
+                        ]["displacement"]
+                    ),
+                    "buffer does not contain the right amount of displacements.",
+                )
+                self.assertSetEqual(
+                    set(self.exp.model.sensor_modules[0].features),
+                    set(self.exp.model.learning_modules[0].buffer[-1]["patch"].keys()),
+                    "buffer doesn't contain all features required for matching.",
+                )
+                if step == 3:
+                    break
 
     def test_can_run_eval_episode(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(base_config)
-        self.exp.model.set_experiment_mode("eval")
-        pprint("...training...")
-        self.exp.pre_epoch()
-        self.exp.run_episode()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(base_config)
+            self.exp.model.set_experiment_mode("eval")
+            pprint("...training...")
+            self.exp.pre_epoch()
+            self.exp.run_episode()
 
     def test_can_run_eval_episode_with_surface_agent(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.surface_agent_eval_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        self.exp.model.set_experiment_mode("eval")
-        pprint("...training...")
-        self.exp.pre_epoch()
-        self.exp.run_episode()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            self.exp.model.set_experiment_mode("eval")
+            pprint("...training...")
+            self.exp.pre_epoch()
+            self.exp.run_episode()
 
     def test_can_run_ppf_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.ppf_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...evaluating...")
+            self.exp.evaluate()
 
     def test_can_run_disp_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.disp_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...evaluating...")
+            self.exp.evaluate()
 
     def test_can_run_feature_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...evaluating...")
+            self.exp.evaluate()
 
     def test_fixed_actions_disp(self):
         """Runs three test episodes on capsule3DSolid and cubeSolid.
@@ -690,17 +690,20 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_disp)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        # self.exp.model.set_experiment_mode("eval")
-        pprint("...training...")
-        self.exp.train()
-        pprint("...loading and checking train statistics...")
-        train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
-        self.check_train_results(train_stats)
+        with self.exp:
+            self.exp.setup_experiment(config)
+            # self.exp.model.set_experiment_mode("eval")
+            pprint("...training...")
+            self.exp.train()
+            pprint("...loading and checking train statistics...")
+            train_stats = pd.read_csv(
+                os.path.join(self.exp.output_dir, "train_stats.csv")
+            )
+            self.check_train_results(train_stats)
 
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+            pprint("...evaluating...")
+            self.exp.evaluate()
+
         pprint("...loading and checking eval statistics...")
         eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
 
@@ -711,18 +714,21 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_ppf)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        # self.exp.model.set_experiment_mode("eval")
-        pprint("...training...")
-        self.exp.train()
-        pprint("...loading and checking train statistics...")
-        train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
+        with self.exp:
+            self.exp.setup_experiment(config)
+            # self.exp.model.set_experiment_mode("eval")
+            pprint("...training...")
+            self.exp.train()
+            pprint("...loading and checking train statistics...")
+            train_stats = pd.read_csv(
+                os.path.join(self.exp.output_dir, "train_stats.csv")
+            )
 
-        self.check_train_results(train_stats)
+            self.check_train_results(train_stats)
 
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+            pprint("...evaluating...")
+            self.exp.evaluate()
+
         pprint("...loading and checking eval statistics...")
         eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
 
@@ -733,18 +739,21 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...loading and checking train statistics...")
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...loading and checking train statistics...")
 
-        train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(self.exp.output_dir, "train_stats.csv")
+            )
 
-        self.check_train_results(train_stats)
+            self.check_train_results(train_stats)
 
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+            pprint("...evaluating...")
+            self.exp.evaluate()
+
         pprint("...loading and checking eval statistics...")
         eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
 
@@ -754,11 +763,11 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
+        with self.exp:
+            self.exp.setup_experiment(config)
 
-        pprint("...training...")
-        self.exp.train()
-        self.exp.close()
+            pprint("...training...")
+            self.exp.train()
 
         # Create a separate experiment for evaluation to mimic the us case of re-running
         # eval episodes from a pretrained model
@@ -768,12 +777,12 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             "2",  # latest checkpoint
         )
         self.eval_exp_1 = MontyObjectRecognitionExperiment()
-        self.eval_exp_1.setup_experiment(eval_cfg_1)
-        # TODO: update so it only runs one episode
+        with self.eval_exp_1:
+            self.eval_exp_1.setup_experiment(eval_cfg_1)
+            # TODO: update so it only runs one episode
 
-        pprint("...evaluating (first time) ...")
-        self.eval_exp_1.evaluate()
-        self.eval_exp_1.close()
+            pprint("...evaluating (first time) ...")
+            self.eval_exp_1.evaluate()
 
         # Create detailed follow up experiment
         eval_cfg_2 = create_eval_episode_config(
@@ -803,11 +812,11 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
 
         # If we made it this far, we have the correct parameters. Now run the experiment
         self.eval_exp_2 = MontyObjectRecognitionExperiment()
-        self.eval_exp_2.setup_experiment(eval_cfg_2)
+        with self.eval_exp_2:
+            self.eval_exp_2.setup_experiment(eval_cfg_2)
 
-        pprint("...evaluating (second time) ...")
-        self.eval_exp_2.evaluate()
-        self.eval_exp_2.close()
+            pprint("...evaluating (second time) ...")
+            self.eval_exp_2.evaluate()
 
         ###
         # Check that basic csv stats are the same
@@ -862,11 +871,11 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
+        with self.exp:
+            self.exp.setup_experiment(config)
 
-        pprint("...training...")
-        self.exp.train()
-        self.exp.close()
+            pprint("...training...")
+            self.exp.train()
 
         # Create a separate experiment for evaluation to mimic the us case of re-running
         # eval episodes from a pretrained model
@@ -876,11 +885,11 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             "2",  # latest checkpoint
         )
         self.eval_exp_1 = MontyObjectRecognitionExperiment()
-        self.eval_exp_1.setup_experiment(eval_cfg_1)
+        with self.eval_exp_1:
+            self.eval_exp_1.setup_experiment(eval_cfg_1)
 
-        pprint("...evaluating (first time) ...")
-        self.eval_exp_1.evaluate()
-        self.eval_exp_1.close()
+            pprint("...evaluating (first time) ...")
+            self.eval_exp_1.evaluate()
 
         # Create detailed follow up experiment
         eval_cfg_2 = create_eval_config_multiple_episodes(
@@ -922,11 +931,11 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
 
         # If we made it this far, we have the correct parameters. Now run the experiment
         self.eval_exp_2 = MontyObjectRecognitionExperiment()
-        self.eval_exp_2.setup_experiment(eval_cfg_2)
+        with self.eval_exp_2:
+            self.eval_exp_2.setup_experiment(eval_cfg_2)
 
-        pprint("...evaluating (second time) ...")
-        self.eval_exp_2.evaluate()
-        self.eval_exp_2.close()
+            pprint("...evaluating (second time) ...")
+            self.eval_exp_2.evaluate()
 
         ###
         # Check that basic csv stats are the same
@@ -982,11 +991,11 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
+        with self.exp:
+            self.exp.setup_experiment(config)
 
-        pprint("...training...")
-        self.exp.train()
-        self.exp.close()
+            pprint("...training...")
+            self.exp.train()
 
         # Create a separate experiment for evaluation to mimic the us case of re-running
         # eval episodes from a pretrained model
@@ -996,11 +1005,11 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             "2",  # latest checkpoint
         )
         self.eval_exp_1 = MontyObjectRecognitionExperiment()
-        self.eval_exp_1.setup_experiment(eval_cfg_1)
+        with self.eval_exp_1:
+            self.eval_exp_1.setup_experiment(eval_cfg_1)
 
-        pprint("...evaluating (first time) ...")
-        self.eval_exp_1.evaluate()
-        self.eval_exp_1.close()
+            pprint("...evaluating (first time) ...")
+            self.eval_exp_1.evaluate()
 
         # Create detailed follow up experiment
         eval_cfg_2 = create_eval_config_multiple_episodes(
@@ -1030,11 +1039,11 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
 
         # If we made it this far, we have the correct parameters. Now run the experiment
         self.eval_exp_2 = MontyObjectRecognitionExperiment()
-        self.eval_exp_2.setup_experiment(eval_cfg_2)
+        with self.eval_exp_2:
+            self.eval_exp_2.setup_experiment(eval_cfg_2)
 
-        pprint("...evaluating (second time) ...")
-        self.eval_exp_2.evaluate()
-        self.eval_exp_2.close()
+            pprint("...evaluating (second time) ...")
+            self.eval_exp_2.evaluate()
 
         ###
         # Check that basic csv stats are the same
@@ -1090,11 +1099,11 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_ppf)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        # self.exp.model.set_experiment_mode("eval")
-        pprint("...training...")
-        self.exp.train()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            # self.exp.model.set_experiment_mode("eval")
+            pprint("...training...")
+            self.exp.train()
 
         # We are training for 3 epochs by default, load most recent indexing from 0
         print("Loading a saved checkpoint")
@@ -1104,21 +1113,22 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             "2",  # latest checkpoint
         )
         self.exp2 = MontyObjectRecognitionExperiment()
-        self.exp2.setup_experiment(cfg2)
+        with self.exp2:
+            self.exp2.setup_experiment(cfg2)
 
-        graph_memory_1 = self.exp.model.learning_modules[
-            0
-        ].graph_memory.get_all_models_in_memory()
-        graph_memory_2 = self.exp2.model.learning_modules[
-            0
-        ].graph_memory.get_all_models_in_memory()
+            graph_memory_1 = self.exp.model.learning_modules[
+                0
+            ].graph_memory.get_all_models_in_memory()
+            graph_memory_2 = self.exp2.model.learning_modules[
+                0
+            ].graph_memory.get_all_models_in_memory()
 
-        # Loop over each graph model and check they have the exact same data
-        for obj_name in graph_memory_1.keys():
-            for input_channel in graph_memory_1[obj_name].keys():
-                graph_1 = graph_memory_1[obj_name][input_channel]
-                graph_2 = graph_memory_2[obj_name][input_channel]
-                self.check_graphs_equal(graph_1, graph_2)
+            # Loop over each graph model and check they have the exact same data
+            for obj_name in graph_memory_1.keys():
+                for input_channel in graph_memory_1[obj_name].keys():
+                    graph_1 = graph_memory_1[obj_name][input_channel]
+                    graph_2 = graph_memory_2[obj_name][input_channel]
+                    self.check_graphs_equal(graph_1, graph_2)
 
     def test_time_out(self):
         """Test time_out and pose_time_out detection and logging.
@@ -1133,26 +1143,27 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_time_out)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        self.exp.model.set_experiment_mode("train")
-        pprint("...training...")
-        # self.exp.train()
-        for e in range(6):
-            if e % 2 == 0:
-                self.exp.pre_epoch()
-            if e == 2:
-                # Set max steps low & raise mmd to get pose time outs
-                self.exp.max_train_steps = 3
-                self.exp.model.learning_modules[0].max_match_distance = 0.1
-            if e == 4:
-                # set curvature threshold high to get time outs
-                self.exp.model.learning_modules[0].tolerances["patch"][
-                    "principal_curvatures_log"
-                ] = [10, 10]
-            self.exp.run_episode()
-            if e % 2 == 1:
-                self.exp.post_epoch()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            self.exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            # self.exp.train()
+            for e in range(6):
+                if e % 2 == 0:
+                    self.exp.pre_epoch()
+                if e == 2:
+                    # Set max steps low & raise mmd to get pose time outs
+                    self.exp.max_train_steps = 3
+                    self.exp.model.learning_modules[0].max_match_distance = 0.1
+                if e == 4:
+                    # set curvature threshold high to get time outs
+                    self.exp.model.learning_modules[0].tolerances["patch"][
+                        "principal_curvatures_log"
+                    ] = [10, 10]
+                self.exp.run_episode()
+                if e % 2 == 1:
+                    self.exp.post_epoch()
+
         pprint("...check time out logging...")
         train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
         self.assertEqual(
@@ -1197,20 +1208,21 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        self.exp.model.set_experiment_mode("train")
-        pprint("...training...")
-        self.exp.pre_epoch()
-        # Overwrite target with a false name to test confused logging.
-        for e in range(4):
-            self.exp.pre_episode()
-            self.exp.model.primary_target = str(e)
-            for lm in self.exp.model.learning_modules:
-                lm.primary_target = str(e)
-            last_step = self.exp.run_episode_steps()
-            self.exp.post_episode(last_step)
-        self.exp.post_epoch()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            self.exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            self.exp.pre_epoch()
+            # Overwrite target with a false name to test confused logging.
+            for e in range(4):
+                self.exp.pre_episode()
+                self.exp.model.primary_target = str(e)
+                for lm in self.exp.model.learning_modules:
+                    lm.primary_target = str(e)
+                last_step = self.exp.run_episode_steps()
+                self.exp.post_episode(last_step)
+            self.exp.post_epoch()
+
         pprint("...checking run stats...")
         train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
         for i in [0, 1]:
@@ -1252,70 +1264,71 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_off_object)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        # First episode will be used to learn object (no_match is triggered before
-        # min_steps is reached and the sensor moves off the object). In the second
-        # episode the sensor moves off the sphere on episode steps 6+
-        # Eventually, we circle round and come back to the object; recognition
-        # does not take place before then because when off the object, matching
-        # steps are no longer incremented, while it is an unfamiliar part of
-        # the object that we return to
-        self.exp.train()
-        self.assertEqual(
-            len(
-                self.exp.model.learning_modules[0].buffer.get_all_locations_on_object(
-                    input_channel="patch"
-                )
-            ),
-            len(
-                self.exp.model.learning_modules[0].buffer.get_all_features_on_object()[
-                    "patch"
-                ]["pose_vectors"]
-            ),
-            "Did not retrieve same amount of feature and locations on object.",
-        )
-        self.assertEqual(
-            sum(
-                self.exp.model.learning_modules[0].buffer.get_all_features_on_object()[
-                    "patch"
-                ]["on_object"]
-            ),
-            len(
-                self.exp.model.learning_modules[0].buffer.get_all_features_on_object()[
-                    "patch"
-                ]["on_object"]
-            ),
-            "not all retrieved features were collected on the object.",
-        )
-        # Since we don't add observations to the buffer that are off the object
-        # there should only be 8 observations stored for the 12 matching steps
-        # and all of them should be on the object.
-        num_matching_steps = len(
-            self.exp.model.learning_modules[0].buffer.stats["possible_matches"]
-        )
-        self.assertEqual(
-            num_matching_steps,
-            sum(
-                self.exp.model.learning_modules[0].buffer.features["patch"][
-                    "on_object"
-                ][:num_matching_steps]
-            ),
-            "Number of match steps does not match with stored observations on object",
-        )
-
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            # First episode will be used to learn object (no_match is triggered before
+            # min_steps is reached and the sensor moves off the object). In the second
+            # episode the sensor moves off the sphere on episode steps 6+
+            # Eventually, we circle round and come back to the object; recognition
+            # does not take place before then because when off the object, matching
+            # steps are no longer incremented, while it is an unfamiliar part of
+            # the object that we return to
+            self.exp.train()
+            self.assertEqual(
+                len(
+                    self.exp.model.learning_modules[
+                        0
+                    ].buffer.get_all_locations_on_object(input_channel="patch")
+                ),
+                len(
+                    self.exp.model.learning_modules[
+                        0
+                    ].buffer.get_all_features_on_object()["patch"]["pose_vectors"]
+                ),
+                "Did not retrieve same amount of feature and locations on object.",
+            )
+            self.assertEqual(
+                sum(
+                    self.exp.model.learning_modules[
+                        0
+                    ].buffer.get_all_features_on_object()["patch"]["on_object"]
+                ),
+                len(
+                    self.exp.model.learning_modules[
+                        0
+                    ].buffer.get_all_features_on_object()["patch"]["on_object"]
+                ),
+                "not all retrieved features were collected on the object.",
+            )
+            # Since we don't add observations to the buffer that are off the object
+            # there should only be 8 observations stored for the 12 matching steps
+            # and all of them should be on the object.
+            num_matching_steps = len(
+                self.exp.model.learning_modules[0].buffer.stats["possible_matches"]
+            )
+            self.assertEqual(
+                num_matching_steps,
+                sum(
+                    self.exp.model.learning_modules[0].buffer.features["patch"][
+                        "on_object"
+                    ][:num_matching_steps]
+                ),
+                "Number of match steps does not match with stored observations "
+                "on object",
+            )
 
     def test_detailed_logging(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_off_object)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...evaluating...")
+            self.exp.evaluate()
+
         pprint("...loading stats files...")
         train_stats, eval_stats, detailed_stats, lm_models = load_stats(
             self.exp.output_dir,
@@ -1352,7 +1365,8 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         self.assertEqual(
             len(detailed_stats["1"]["LM_0"]["possible_matches"]),
             train_stats.loc[1]["monty_matching_steps"],
-            "matching steps in detailed stats don't match with those in train stats.",
+            "matching steps in detailed stats don't match with those in "
+            "train stats.",
         )
         self.assertEqual(
             sum(np.array(detailed_stats["1"]["LM_0"]["patch"]["on_object"])),
@@ -1367,17 +1381,20 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feat_test_uniform_initial_poses)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...loading and checking train statistics...")
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...loading and checking train statistics...")
 
-        train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
-        self.check_train_results(train_stats)
+            train_stats = pd.read_csv(
+                os.path.join(self.exp.output_dir, "train_stats.csv")
+            )
+            self.check_train_results(train_stats)
 
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+            pprint("...evaluating...")
+            self.exp.evaluate()
+
         pprint("...loading and checking eval statistics...")
         eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
         self.check_eval_results(eval_stats)
@@ -1691,16 +1708,19 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.ppf_displacement_5lm_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
 
-        train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
-        self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
+            train_stats = pd.read_csv(
+                os.path.join(self.exp.output_dir, "train_stats.csv")
+            )
+            self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
 
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+            pprint("...evaluating...")
+            self.exp.evaluate()
+
         pprint("...loading and checking eval statistics...")
         eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
         self.check_multilm_eval_results(
@@ -1712,19 +1732,22 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_5lm_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
 
-        train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
-        # The following check is brittle and depends on sensor arrangement. Leaving
-        # the rest of the test intact to detect run failures, but disabling checking
-        # of particular results.
-        # self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
+            train_stats = pd.read_csv(
+                os.path.join(self.exp.output_dir, "train_stats.csv")
+            )
+            # The following check is brittle and depends on sensor arrangement. Leaving
+            # the rest of the test intact to detect run failures, but disabling checking
+            # of particular results.
+            # self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
 
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+            pprint("...evaluating...")
+            self.exp.evaluate()
+
         pprint("...loading and checking eval statistics...")
         eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
         # Just testing 1 episode here. Somehow the second rotation doesn't get

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -452,85 +452,85 @@ class PolicyTest(unittest.TestCase):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.base_dist_agent_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...evaluating...")
+            self.exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_spiral_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.spiral_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        # TODO: test that no two locations are the same
-        self.exp.train()
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            # TODO: test that no two locations are the same
+            self.exp.train()
+            pprint("...evaluating...")
+            self.exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_dist_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.dist_agent_hypo_driven_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...evaluating...")
+            self.exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_surface_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.base_surf_agent_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...evaluating...")
+            self.exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_curv_informed_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.curv_informed_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...evaluating...")
+            self.exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_surf_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.surf_agent_hypo_driven_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...evaluating...")
+            self.exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_multi_lm_dist_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.dist_agent_hypo_driven_multi_lm_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            pprint("...evaluating...")
+            self.exp.evaluate()
 
     # ==== MORE INVOLVED TESTS OF ACTION POLICIES ====
 
@@ -597,45 +597,44 @@ class PolicyTest(unittest.TestCase):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_dist_agent_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        self.exp.model.set_experiment_mode("train")
-        self.exp.pre_epoch()
-        self.exp.pre_episode()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            self.exp.model.set_experiment_mode("train")
+            self.exp.pre_epoch()
+            self.exp.pre_episode()
 
-        pprint("...stepping through observations...")
+            pprint("...stepping through observations...")
 
-        # Check the initial view
-        observation = next(self.exp.dataloader)
-        # TODO M remove the following train-wreck during refactor
-        view = observation[self.exp.model.motor_system.agent_id]["view_finder"]
-        semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
-        perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
+            # Check the initial view
+            observation = next(self.exp.dataloader)
+            # TODO M remove the following train-wreck during refactor
+            view = observation[self.exp.model.motor_system.agent_id]["view_finder"]
+            semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
+            perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
 
-        dict_config = config_to_dict(config)
+            dict_config = config_to_dict(config)
 
-        target_perc_on_target_obj = dict_config["monty_config"]["motor_system_config"][
-            "motor_system_args"
-        ]["good_view_percentage"]
+            target_perc_on_target_obj = dict_config["monty_config"][
+                "motor_system_config"
+            ]["motor_system_args"]["good_view_percentage"]
 
-        assert (
-            perc_on_target_obj >= target_perc_on_target_obj
-        ), f"Initial view is not good enough, {perc_on_target_obj}\
-            vs target of {target_perc_on_target_obj}"
+            assert (
+                perc_on_target_obj >= target_perc_on_target_obj
+            ), f"Initial view is not good enough, {perc_on_target_obj}\
+                vs target of {target_perc_on_target_obj}"
 
-        points_on_target_obj = semantic == 1
-        closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
+            points_on_target_obj = semantic == 1
+            closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
-        target_closest_point = dict_config["monty_config"]["motor_system_config"][
-            "motor_system_args"
-        ]["desired_object_distance"]
+            target_closest_point = dict_config["monty_config"]["motor_system_config"][
+                "motor_system_args"
+            ]["desired_object_distance"]
 
-        # Utility policy should not have moved too close to the object
-        assert (
-            closest_point_on_target_obj > target_closest_point
-        ), f"Initial view is too close, {closest_point_on_target_obj}\
-            vs target of {target_closest_point}"
-
-        self.exp.dataset.close()
+            # Utility policy should not have moved too close to the object
+            assert (
+                closest_point_on_target_obj > target_closest_point
+            ), f"Initial view is too close, {closest_point_on_target_obj}\
+                vs target of {target_closest_point}"
 
     def test_touch_object_basic_surf_agent(self):
         """Test ability to move a surface agent to touch an object.
@@ -649,47 +648,46 @@ class PolicyTest(unittest.TestCase):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_surf_agent_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        self.exp.model.set_experiment_mode("train")
-        self.exp.pre_epoch()
-        self.exp.pre_episode()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            self.exp.model.set_experiment_mode("train")
+            self.exp.pre_epoch()
+            self.exp.pre_episode()
 
-        pprint("...stepping through observations...")
+            pprint("...stepping through observations...")
 
-        # Get a first step to allow the surface agent to touch the object
-        observation_pre_touch = next(self.exp.dataloader)
-        self.exp.model.step(observation_pre_touch)
+            # Get a first step to allow the surface agent to touch the object
+            observation_pre_touch = next(self.exp.dataloader)
+            self.exp.model.step(observation_pre_touch)
 
-        # Check initial view post touch-attempt
-        observation_post_touch = next(self.exp.dataloader)
+            # Check initial view post touch-attempt
+            observation_post_touch = next(self.exp.dataloader)
 
-        # TODO M remove the following train-wreck during refactor
-        view = observation_post_touch[self.exp.model.motor_system.agent_id][
-            "view_finder"
-        ]
-        dict_config = config_to_dict(config)
+            # TODO M remove the following train-wreck during refactor
+            view = observation_post_touch[self.exp.model.motor_system.agent_id][
+                "view_finder"
+            ]
+            dict_config = config_to_dict(config)
 
-        points_on_target_obj = (
-            view["semantic_3d"][:, 3].reshape(view["depth"].shape) == 1
-        )
-        closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
+            points_on_target_obj = (
+                view["semantic_3d"][:, 3].reshape(view["depth"].shape) == 1
+            )
+            closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
-        assert (
-            closest_point_on_target_obj < 1.0
-        ), f"Should be within a meter of the object,\
-            closest point at {closest_point_on_target_obj}"
+            assert (
+                closest_point_on_target_obj < 1.0
+            ), f"Should be within a meter of the object,\
+                closest point at {closest_point_on_target_obj}"
 
-        target_closest_point = dict_config["monty_config"]["motor_system_config"][
-            "motor_system_args"
-        ]["desired_object_distance"]
+            target_closest_point = dict_config["monty_config"]["motor_system_config"][
+                "motor_system_args"
+            ]["desired_object_distance"]
 
-        # Utility policy should not have moved too close to the object
-        assert (
-            closest_point_on_target_obj > target_closest_point
-        ), f"Initial position is too close, {closest_point_on_target_obj}\
-            vs target of {target_closest_point}"
-
-        self.exp.dataset.close()
+            # Utility policy should not have moved too close to the object
+            assert (
+                closest_point_on_target_obj > target_closest_point
+            ), f"Initial position is too close, {closest_point_on_target_obj}\
+                vs target of {target_closest_point}"
 
     def test_get_good_view_multi_object(self):
         """Test ability to move a distant agent to a good view of an object.
@@ -706,56 +704,57 @@ class PolicyTest(unittest.TestCase):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_multi_object_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
 
-        # Manually go through evaluation (i.e. methods in .evaluate() and run_epoch())
-        self.exp.model.set_experiment_mode("eval")
-        self.exp.pre_epoch()
-        self.exp.pre_episode()
+            # Manually go through evaluation (i.e. methods in .evaluate()
+            # and run_epoch())
+            self.exp.model.set_experiment_mode("eval")
+            self.exp.pre_epoch()
+            self.exp.pre_episode()
 
-        pprint("...stepping through observations...")
-        # Check the initial view
-        observation = next(self.exp.dataloader)
-        # TODO M remove the following train-wreck during refactor
-        view = observation[self.exp.model.motor_system.agent_id]["view_finder"]
-        semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
-        perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
+            pprint("...stepping through observations...")
+            # Check the initial view
+            observation = next(self.exp.dataloader)
+            # TODO M remove the following train-wreck during refactor
+            view = observation[self.exp.model.motor_system.agent_id]["view_finder"]
+            semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
+            perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
 
-        dict_config = config_to_dict(config)
-        target_perc_on_target_obj = dict_config["monty_config"]["motor_system_config"][
-            "motor_system_args"
-        ]["good_view_percentage"]
+            dict_config = config_to_dict(config)
+            target_perc_on_target_obj = dict_config["monty_config"][
+                "motor_system_config"
+            ]["motor_system_args"]["good_view_percentage"]
 
-        assert (
-            perc_on_target_obj >= target_perc_on_target_obj
-        ), f"Initial view is not good enough, {perc_on_target_obj}\
-            vs target of {target_perc_on_target_obj}"
+            assert (
+                perc_on_target_obj >= target_perc_on_target_obj
+            ), f"Initial view is not good enough, {perc_on_target_obj}\
+                vs target of {target_perc_on_target_obj}"
 
-        points_on_target_obj = semantic == 1
-        closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
+            points_on_target_obj = semantic == 1
+            closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
-        target_closest_point = dict_config["monty_config"]["motor_system_config"][
-            "motor_system_args"
-        ]["desired_object_distance"]
+            target_closest_point = dict_config["monty_config"]["motor_system_config"][
+                "motor_system_args"
+            ]["desired_object_distance"]
 
-        # Utility policy should not have moved too close to the object
-        assert (
-            closest_point_on_target_obj > target_closest_point
-        ), f"Initial view is too close to target, {closest_point_on_target_obj}\
-            vs target of {target_closest_point}"
+            # Utility policy should not have moved too close to the object
+            assert (
+                closest_point_on_target_obj > target_closest_point
+            ), f"Initial view is too close to target, {closest_point_on_target_obj}\
+                vs target of {target_closest_point}"
 
-        # Also calculate closest point on *any* object so that we don't get too close
-        # and clip into objects; NB that any object will have a semantic ID > 0
-        points_on_any_obj = view["semantic"] > 0
-        closest_point_on_any_obj = np.min(view["depth"][points_on_any_obj])
-        assert (
-            closest_point_on_any_obj > target_closest_point / 6
-        ), f"Initial view too cloase to other objects, {closest_point_on_any_obj}\
-            vs target of {target_closest_point / 6}"
-
-        self.exp.dataset.close()
+            # Also calculate closest point on *any* object so that we don't get
+            # too close and clip into objects; NB that any object will have a
+            # semantic ID > 0
+            points_on_any_obj = view["semantic"] > 0
+            closest_point_on_any_obj = np.min(view["depth"][points_on_any_obj])
+            assert (
+                closest_point_on_any_obj > target_closest_point / 6
+            ), f"Initial view too cloase to other objects, {closest_point_on_any_obj}\
+                vs target of {target_closest_point / 6}"
 
     def test_distant_policy_moves_back_to_object(self):
         """Test ability of distant agent to move back to an object.
@@ -769,106 +768,105 @@ class PolicyTest(unittest.TestCase):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_action_distant_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        self.exp.model.set_experiment_mode("train")
-        pprint("...training...")
-        self.exp.pre_epoch()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            self.exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            self.exp.pre_epoch()
 
-        # Only do a single episode
-        self.exp.pre_episode()
+            # Only do a single episode
+            self.exp.pre_episode()
 
-        pprint("...stepping through observations...")
-        # Manually step through part of run_episode function
-        for loader_step, observation in enumerate(self.exp.dataloader):
-            self.exp.model.step(observation)
+            pprint("...stepping through observations...")
+            # Manually step through part of run_episode function
+            for loader_step, observation in enumerate(self.exp.dataloader):
+                self.exp.model.step(observation)
 
-            last_action = self.exp.model.motor_system.last_action()
+                last_action = self.exp.model.motor_system.last_action()
 
-            if loader_step == 3:
-                stored_action = last_action
-                assert not self.exp.model.learning_modules[
-                    0
-                ].buffer.get_last_obs_processed(), "Should be off object"
+                if loader_step == 3:
+                    stored_action = last_action
+                    assert not self.exp.model.learning_modules[
+                        0
+                    ].buffer.get_last_obs_processed(), "Should be off object"
 
-            if loader_step == 4:
-                should_have_moved_back = (
-                    "Should have moved back by reversing last movement"
-                )
-                self.assertIsInstance(
-                    last_action, type(stored_action), should_have_moved_back
-                )
-                if isinstance(stored_action, (LookDown, LookUp)):
-                    self.assertEqual(
-                        last_action.rotation_degrees,
-                        -stored_action.rotation_degrees,
-                        should_have_moved_back,
+                if loader_step == 4:
+                    should_have_moved_back = (
+                        "Should have moved back by reversing last movement"
                     )
-                    self.assertEqual(
-                        last_action.constraint_degrees,
-                        stored_action.constraint_degrees,
-                        should_have_moved_back,
+                    self.assertIsInstance(
+                        last_action, type(stored_action), should_have_moved_back
                     )
-                elif isinstance(stored_action, (TurnLeft, TurnRight)):
-                    self.assertEqual(
-                        last_action.rotation_degrees,
-                        -stored_action.rotation_degrees,
-                        should_have_moved_back,
-                    )
-                elif isinstance(stored_action, MoveForward):
-                    self.assertEqual(
-                        last_action.distance,
-                        -stored_action.distance,
-                        should_have_moved_back,
-                    )
-                elif isinstance(stored_action, MoveTangentially):
-                    self.assertEqual(
-                        last_action.distance,
-                        -stored_action.distance,
-                        should_have_moved_back,
-                    )
-                    self.assertEqual(
-                        last_action.direction,
-                        stored_action.direction,
-                        should_have_moved_back,
-                    )
-                elif isinstance(stored_action, OrientHorizontal):
-                    self.assertEqual(
-                        last_action.rotation_degrees,
-                        -stored_action.rotation_degrees,
-                        should_have_moved_back,
-                    )
-                    self.assertEqual(
-                        last_action.left_distance,
-                        -stored_action.left_distance,
-                        should_have_moved_back,
-                    )
-                    self.assertEqual(
-                        last_action.forward_distance,
-                        -stored_action.forward_distance,
-                        should_have_moved_back,
-                    )
-                elif isinstance(stored_action, OrientVertical):
-                    self.assertEqual(
-                        last_action.rotation_degrees,
-                        -stored_action.rotation_degrees,
-                        should_have_moved_back,
-                    )
-                    self.assertEqual(
-                        last_action.down_distance,
-                        -stored_action.down_distance,
-                        should_have_moved_back,
-                    )
-                    self.assertEqual(
-                        last_action.forward_distance,
-                        -stored_action.forward_distance,
-                        should_have_moved_back,
-                    )
-                assert self.exp.model.learning_modules[
-                    0
-                ].buffer.get_last_obs_processed(), "Should be back on object"
-                break  # Don't go into exploratory mode
-
-        self.exp.dataset.close()
+                    if isinstance(stored_action, (LookDown, LookUp)):
+                        self.assertEqual(
+                            last_action.rotation_degrees,
+                            -stored_action.rotation_degrees,
+                            should_have_moved_back,
+                        )
+                        self.assertEqual(
+                            last_action.constraint_degrees,
+                            stored_action.constraint_degrees,
+                            should_have_moved_back,
+                        )
+                    elif isinstance(stored_action, (TurnLeft, TurnRight)):
+                        self.assertEqual(
+                            last_action.rotation_degrees,
+                            -stored_action.rotation_degrees,
+                            should_have_moved_back,
+                        )
+                    elif isinstance(stored_action, MoveForward):
+                        self.assertEqual(
+                            last_action.distance,
+                            -stored_action.distance,
+                            should_have_moved_back,
+                        )
+                    elif isinstance(stored_action, MoveTangentially):
+                        self.assertEqual(
+                            last_action.distance,
+                            -stored_action.distance,
+                            should_have_moved_back,
+                        )
+                        self.assertEqual(
+                            last_action.direction,
+                            stored_action.direction,
+                            should_have_moved_back,
+                        )
+                    elif isinstance(stored_action, OrientHorizontal):
+                        self.assertEqual(
+                            last_action.rotation_degrees,
+                            -stored_action.rotation_degrees,
+                            should_have_moved_back,
+                        )
+                        self.assertEqual(
+                            last_action.left_distance,
+                            -stored_action.left_distance,
+                            should_have_moved_back,
+                        )
+                        self.assertEqual(
+                            last_action.forward_distance,
+                            -stored_action.forward_distance,
+                            should_have_moved_back,
+                        )
+                    elif isinstance(stored_action, OrientVertical):
+                        self.assertEqual(
+                            last_action.rotation_degrees,
+                            -stored_action.rotation_degrees,
+                            should_have_moved_back,
+                        )
+                        self.assertEqual(
+                            last_action.down_distance,
+                            -stored_action.down_distance,
+                            should_have_moved_back,
+                        )
+                        self.assertEqual(
+                            last_action.forward_distance,
+                            -stored_action.forward_distance,
+                            should_have_moved_back,
+                        )
+                    assert self.exp.model.learning_modules[
+                        0
+                    ].buffer.get_last_obs_processed(), "Should be back on object"
+                    break  # Don't go into exploratory mode
 
     def test_surface_policy_moves_back_to_object(self):
         """Test ability of surface agent to move back to an object.
@@ -882,33 +880,32 @@ class PolicyTest(unittest.TestCase):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_action_surface_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        self.exp.model.set_experiment_mode("train")
-        pprint("...training...")
-        self.exp.pre_epoch()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            self.exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            self.exp.pre_epoch()
 
-        # Only do a single episode
-        self.exp.pre_episode()
+            # Only do a single episode
+            self.exp.pre_episode()
 
-        pprint("...stepping through observations...")
-        # Take several steps in a fixed direction until we fall off the object, then
-        # ensure we get back on to it
-        for loader_step, observation in enumerate(self.exp.dataloader):
-            self.exp.model.step(observation)
+            pprint("...stepping through observations...")
+            # Take several steps in a fixed direction until we fall off the object, then
+            # ensure we get back on to it
+            for loader_step, observation in enumerate(self.exp.dataloader):
+                self.exp.model.step(observation)
 
-            if loader_step == 24:  # Last step we take before getting back onto the
-                # object
-                assert not self.exp.model.learning_modules[
-                    0
-                ].buffer.get_last_obs_processed(), "Should be off object"
+                if loader_step == 24:  # Last step we take before getting back onto the
+                    # object
+                    assert not self.exp.model.learning_modules[
+                        0
+                    ].buffer.get_last_obs_processed(), "Should be off object"
 
-            if loader_step == 25:
-                assert self.exp.model.learning_modules[
-                    0
-                ].buffer.get_last_obs_processed(), "Should be back on object"
-                break  # Don't go into exploratory mode
-
-        self.exp.dataset.close()
+                if loader_step == 25:
+                    assert self.exp.model.learning_modules[
+                        0
+                    ].buffer.get_last_obs_processed(), "Should be back on object"
+                    break  # Don't go into exploratory mode
 
     def test_surface_policy_orientation(self):
         """Test ability of surface agent to orient to a point-normal.
@@ -922,46 +919,45 @@ class PolicyTest(unittest.TestCase):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.rotated_cube_view_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        self.exp.model.set_experiment_mode("train")
-        pprint("...training...")
-        self.exp.pre_epoch()
-        self.exp.pre_episode()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            self.exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            self.exp.pre_epoch()
+            self.exp.pre_episode()
 
-        pprint("...stepping through observations...")
-        for loader_step, observation in enumerate(self.exp.dataloader):
-            self.exp.model.step(observation)
-            self.exp.post_step(loader_step, observation)
+            pprint("...stepping through observations...")
+            for loader_step, observation in enumerate(self.exp.dataloader):
+                self.exp.model.step(observation)
+                self.exp.post_step(loader_step, observation)
 
-            if loader_step == 3:  # Surface agent should have re-oriented
-                break
+                if loader_step == 3:  # Surface agent should have re-oriented
+                    break
 
-        # Most recently observed point-normal sent to the learning module
-        current_pose = self.exp.model.learning_modules[0].buffer.get_current_pose(
-            input_channel="first"
-        )
-
-        # Rotate vector representing agent's pointing direction by the agent's current
-        # orientation
-        agent_direction = np.array(
-            hab_utils.quat_rotate_vector(
-                self.exp.model.motor_system.state["agent_id_0"]["rotation"],
-                [
-                    0,
-                    0,
-                    -1,
-                ],  # The initial direction vector corresponding to the agent's
-                # orientation
+            # Most recently observed point-normal sent to the learning module
+            current_pose = self.exp.model.learning_modules[0].buffer.get_current_pose(
+                input_channel="first"
             )
-        )
 
-        assert np.all(
-            np.isclose(
-                current_pose[1], agent_direction * (-1), rtol=1.0e-3, atol=1.0e-2
+            # Rotate vector representing agent's pointing direction by the agent's
+            # current orientation
+            agent_direction = np.array(
+                hab_utils.quat_rotate_vector(
+                    self.exp.model.motor_system.state["agent_id_0"]["rotation"],
+                    [
+                        0,
+                        0,
+                        -1,
+                    ],  # The initial direction vector corresponding to the agent's
+                    # orientation
+                )
             )
-        ), "Agent should be (approximately) looking down on the point-normal"
 
-        self.exp.dataset.close()
+            assert np.all(
+                np.isclose(
+                    current_pose[1], agent_direction * (-1), rtol=1.0e-3, atol=1.0e-2
+                )
+            ), "Agent should be (approximately) looking down on the point-normal"
 
     def test_core_following_principal_curvature(self):
         """Test ability of surface agent to follow principal curvature.

--- a/tests/unit/run_parallel_test.py
+++ b/tests/unit/run_parallel_test.py
@@ -171,12 +171,12 @@ class RunParallelTest(unittest.TestCase):
         ###
         pprint("...Setting up serial experiment...")
         self.exp = MontySupervisedObjectPretrainingExperiment()
-        self.exp.setup_experiment(self.supervised_pre_training)
-        self.exp.model.set_experiment_mode("train")
+        with self.exp:
+            self.exp.setup_experiment(self.supervised_pre_training)
+            self.exp.model.set_experiment_mode("train")
 
-        pprint("...Training in serial...")
-        self.exp.train()
-        self.exp.dataset.close()
+            pprint("...Training in serial...")
+            self.exp.train()
 
         ###
         # Run training with run_parallel
@@ -242,11 +242,11 @@ class RunParallelTest(unittest.TestCase):
         # In serial like normal
         pprint("...Setting up serial experiment...")
         self.eval_exp = MontyObjectRecognitionExperiment()
-        self.eval_exp.setup_experiment(self.eval_config)
+        with self.eval_exp:
+            self.eval_exp.setup_experiment(self.eval_config)
 
-        pprint("...Evaluating in serial...")
-        self.eval_exp.evaluate()
-        self.eval_exp.dataset.close()
+            pprint("...Evaluating in serial...")
+            self.eval_exp.evaluate()
 
         # Using run_parallel
         pprint("...Setting up parallel experiment...")
@@ -293,11 +293,11 @@ class RunParallelTest(unittest.TestCase):
         # In serial like normal
         pprint("...Setting up serial experiment...")
         self.eval_exp_lt = MontyObjectRecognitionExperiment()
-        self.eval_exp_lt.setup_experiment(self.eval_config_lt)
+        with self.eval_exp_lt:
+            self.eval_exp_lt.setup_experiment(self.eval_config_lt)
 
-        pprint("...Evaluating in serial...")
-        self.eval_exp_lt.evaluate()
-        self.eval_exp_lt.dataset.close()
+            pprint("...Evaluating in serial...")
+            self.eval_exp_lt.evaluate()
 
         # Using run_parallel
         pprint("...Setting up parallel experiment...")
@@ -333,11 +333,11 @@ class RunParallelTest(unittest.TestCase):
         # In serial like normal
         pprint("...Setting up serial experiment...")
         self.eval_exp_gt = MontyObjectRecognitionExperiment()
-        self.eval_exp_gt.setup_experiment(self.eval_config_gt)
+        with self.eval_exp_gt:
+            self.eval_exp_gt.setup_experiment(self.eval_config_gt)
 
-        pprint("...Evaluating in serial...")
-        self.eval_exp_gt.evaluate()
-        self.eval_exp_gt.dataset.close()
+            pprint("...Evaluating in serial...")
+            self.eval_exp_gt.evaluate()
 
         # Using run_parallel
         pprint("...Setting up parallel experiment...")

--- a/tests/unit/sensor_module_test.py
+++ b/tests/unit/sensor_module_test.py
@@ -126,16 +126,16 @@ class SensorModuleTest(unittest.TestCase):
         print("...parsing experiment...")
         base_config = copy.deepcopy(self.sensor_feature_test)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(base_config)
-        self.exp.model.set_experiment_mode("train")
-        pprint("...training...")
-        self.exp.pre_epoch()
-        self.exp.pre_episode()
-        for step, observation in enumerate(self.exp.dataloader):
-            self.exp.model.step(observation)
-            if step == 1:
-                break
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(base_config)
+            self.exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            self.exp.pre_epoch()
+            self.exp.pre_episode()
+            for step, observation in enumerate(self.exp.dataloader):
+                self.exp.model.step(observation)
+                if step == 1:
+                    break
 
     # @unittest.skip("debugging")
     def test_features_in_sensor(self):
@@ -143,46 +143,46 @@ class SensorModuleTest(unittest.TestCase):
         print("...parsing experiment...")
         base_config = copy.deepcopy(self.sensor_feature_test)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(base_config)
-        self.exp.model.set_experiment_mode("train")
-        pprint("...training...")
-        self.exp.pre_epoch()
-        self.exp.pre_episode()
-        for _, observation in enumerate(self.exp.dataloader):
-            self.exp.model.aggregate_sensory_inputs(observation)
+        with self.exp:
+            self.exp.setup_experiment(base_config)
+            self.exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            self.exp.pre_epoch()
+            self.exp.pre_episode()
+            for _, observation in enumerate(self.exp.dataloader):
+                self.exp.model.aggregate_sensory_inputs(observation)
 
-            pprint(self.exp.model.sensor_module_outputs)
-            for feature in self.tested_features:
-                if feature in ["pose_vectors", "pose_fully_defined", "on_object"]:
-                    self.assertIn(
-                        feature,
-                        self.exp.model.sensor_module_outputs[
-                            0
-                        ].morphological_features.keys(),
-                        f"{feature} not returned by SM",
-                    )
-                else:
-                    self.assertIn(
-                        feature,
-                        self.exp.model.sensor_module_outputs[
-                            0
-                        ].non_morphological_features.keys(),
-                        f"{feature} not returned by SM",
-                    )
-            break
-        self.exp.dataset.close()
+                pprint(self.exp.model.sensor_module_outputs)
+                for feature in self.tested_features:
+                    if feature in ["pose_vectors", "pose_fully_defined", "on_object"]:
+                        self.assertIn(
+                            feature,
+                            self.exp.model.sensor_module_outputs[
+                                0
+                            ].morphological_features.keys(),
+                            f"{feature} not returned by SM",
+                        )
+                    else:
+                        self.assertIn(
+                            feature,
+                            self.exp.model.sensor_module_outputs[
+                                0
+                            ].non_morphological_features.keys(),
+                            f"{feature} not returned by SM",
+                        )
+                break
 
     def test_feature_change_sm(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_change_sensor_config)
         self.exp = MontyObjectRecognitionExperiment()
-        self.exp.setup_experiment(config)
-        pprint("...training...")
-        self.exp.train()
-        # TODO: test that only new features are given to LM
-        pprint("...evaluating...")
-        self.exp.evaluate()
-        self.exp.dataset.close()
+        with self.exp:
+            self.exp.setup_experiment(config)
+            pprint("...training...")
+            self.exp.train()
+            # TODO: test that only new features are given to LM
+            pprint("...evaluating...")
+            self.exp.evaluate()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Not using a context manager means if an exception is thrown before `close` is called, the dataset isn't closed. In some environments, we're getting KeyErrors from one of the tests and this leads to crashing workers in other tests.

This change adds some basic context manager methods to MontyExperiment and updates its uses in the tests to use `with` expressions to ensure that `close` is called correctly. This is only a first step though, and we should probably consider some more changes to make MontyExperiment use the context manager pattern more fully.