### PR TITLE
chore: version 0.0.1

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.0.0"
+__version__ = "0.0.1"


### PR DESCRIPTION
This is a test version bump to exercise Monty Publish workflow fully executing on version change.

The workflow already triggers and does not proceed when the version is not updated, e.g., https://github.com/thousandbrainsproject/tbp.monty/actions/runs/13575067493/job/37949221067