### PR TITLE
build: set target platform before capturing (platform-dependent) path

### DIFF
--- a/.github/workflows/monty_publish.yml
+++ b/.github/workflows/monty_publish.yml
@@ -49,14 +49,14 @@ jobs:
         id: expected_output_location
         working-directory: tbp.monty
         run: |
+          echo "target_platform:" > recipe/conda_build_config.yaml
+          echo "  - linux-64" >> recipe/conda_build_config.yaml
           export PATH="$HOME/miniconda/bin:$PATH"
           echo "path=$(conda build recipe --output)" >> $GITHUB_OUTPUT
       - name: Build conda package
         if: ${{ steps.version_updated.outputs.version_updated == 'true' || github.event_name == 'workflow_dispatch' }}
         working-directory: tbp.monty
         run: |
-          echo "target_platform:" > recipe/conda_build_config.yaml
-          echo "  - linux-64" >> recipe/conda_build_config.yaml
           export PATH="$HOME/miniconda/bin:$PATH"
           conda build recipe
       - name: Upload conda package
@@ -104,14 +104,14 @@ jobs:
         id: expected_output_location
         working-directory: tbp.monty
         run: |
+          echo "target_platform:" > recipe/conda_build_config.yaml
+          echo "  - osx-64" >> recipe/conda_build_config.yaml
           export PATH="$HOME/miniconda/bin:$PATH"
           echo "path=$(conda build recipe --output)" >> $GITHUB_OUTPUT
       - name: Build conda package
         if: ${{ steps.version_updated.outputs.version_updated == 'true' || github.event_name == 'workflow_dispatch' }}
         working-directory: tbp.monty
         run: |
-          echo "target_platform:" > recipe/conda_build_config.yaml
-          echo "  - osx-64" >> recipe/conda_build_config.yaml
           export PATH="$HOME/miniconda/bin:$PATH"
           conda build recipe
       - name: Upload conda package


### PR DESCRIPTION
Because I'm capturing the output path before setting target platform in the configuration, the output does not correspond to the actual target platform and nothing is found when trying to upload. In `osx` case, platform is `osx-arm64` but builds for `osx-64` and things don't line up.

This pull request ensures configuration is present before we read the output path.

This should get `osx-64` upload to work.