### PR TITLE
build: tag version commit with version tag

### DIFF
--- a/.github/actions/version_updated/action.yml
+++ b/.github/actions/version_updated/action.yml
@@ -10,6 +10,9 @@ inputs:
     required: true
 
 outputs:
+  version:
+    description: "The version of the project."
+    value: ${{ steps.version_updated.outputs.version }}
   version_updated:
     description: "Whether the version has been updated."
     value: ${{ steps.version_updated.outputs.version_updated }}

--- a/.github/actions/version_updated/check_version_updated.sh
+++ b/.github/actions/version_updated/check_version_updated.sh
@@ -5,6 +5,8 @@ do
   echo $changed_file
   if [[ $changed_file == src/tbp/monty/__init__.py ]]; then
     echo "version_updated=true" >> $GITHUB_OUTPUT
+    version=$(grep '__version__\s*=\s*' src/tbp/monty/__init__.py | awk -F'"' '{print $2}')
+    echo "version=$version" >> $GITHUB_OUTPUT
     exit 0
   fi
 done < changed_files.txt

--- a/.github/actions/version_updated/check_version_updated.sh
+++ b/.github/actions/version_updated/check_version_updated.sh
@@ -5,6 +5,9 @@ do
   echo $changed_file
   if [[ $changed_file == src/tbp/monty/__init__.py ]]; then
     echo "version_updated=true" >> $GITHUB_OUTPUT
+    # grep finds the version line. It will only have two quotes. Then awk uses
+    # the quotes as separators and prints the middle value, which corresponds to
+    # the version inside the quotes.
     version=$(grep '__version__\s*=\s*' src/tbp/monty/__init__.py | awk -F'"' '{print $2}')
     echo "version=$version" >> $GITHUB_OUTPUT
     exit 0

--- a/.github/workflows/monty_publish.yml
+++ b/.github/workflows/monty_publish.yml
@@ -147,5 +147,6 @@ jobs:
         if: ${{ steps.version_updated.outputs.version_updated == 'true' }}
         working-directory: tbp.monty
         run: |
+          git checkout ${{ github.sha }}
           git tag v${{ steps.version_updated.outputs.version }}
           git push origin v${{ steps.version_updated.outputs.version }}

--- a/.github/workflows/monty_publish.yml
+++ b/.github/workflows/monty_publish.yml
@@ -122,3 +122,30 @@ jobs:
         run: |
           export PATH="$HOME/miniconda/bin:$PATH"
           anaconda --token $ANACONDA_TOKEN upload ${{ steps.expected_output_location.outputs.path }}
+
+  tag_version_monty_publish:
+    name: tag-version-monty-publish
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on:
+      group: tbp.monty
+      labels: tbp-linux-x64-ubuntu2204-2core
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout tbp.monty
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          path: tbp.monty
+      - name: Version updated
+        id: version_updated
+        uses: ./tbp.monty/.github/actions/version_updated
+        with:
+          git_sha: ${{ github.sha }}
+          working_directory: tbp.monty
+      - name: Tag version
+        if: ${{ steps.version_updated.outputs.version_updated == 'true' }}
+        working-directory: tbp.monty
+        run: |
+          git tag v${{ steps.version_updated.outputs.version }}
+          git push origin v${{ steps.version_updated.outputs.version }}


### PR DESCRIPTION
This pull request introduces a `tag_version_monty_publish` job to the Monty Publish workflow.

The job is only triggered when Monty workflow on the `main` branch succeeds, which is after a commit is merged to `main`.
```yml
  tag_version_monty_publish:
    name: tag-version-monty-publish
    if: ${{ github.event.workflow_run.conclusion == 'success' }}
    ...
```

The version is tagged only when that commit contains a version change in `src/tbp/monty/__init__.py`.
```yml
      ...
      - name: Tag version
        if: ${{ steps.version_updated.outputs.version_updated == 'true' }}
        working-directory: tbp.monty
        run: |
          git tag v${{ steps.version_updated.outputs.version }}
          git push origin v${{ steps.version_updated.outputs.version }}
```

The Version updated action now additionally returns `version` from `src/tbp/monty/__init__.py` (in addition to currently returning the `version_updated` boolean). This `version` is used in the tag name. For example, if the version is `0.0.7` then the tag will be `v0.0.7`

There are fewer `if:` conditionals in this job because it only triggers on the conclusion of Monty workflow and will not run on the manual trigger.
