### PR TITLE
build: source dependencies from conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - conda-forge::cmake>=3.14.0
   - conda-forge::importlib_resources
   - conda-forge::matplotlib
+  - conda-forge::mkl==2024.0.0 # see https://github.com/pytorch/pytorch/issues/123097
   - conda-forge::numpy
   - conda-forge::pandas
   - conda-forge::pillow

--- a/environment.yml
+++ b/environment.yml
@@ -18,20 +18,31 @@ channels:
   - aihabitat
   - pytorch
   - pyg
-  - defaults
   - conda-forge
+  - defaults
 
 dependencies:
   - python=3.8
-  - cmake>=3.14.0
-  - pyg::pyg
-  - wget
 
   - aihabitat::habitat-sim=0.2.2
-  - pytorch::pytorch=1.11.0
-  - conda-forge::quaternion=2023.0.3 # later versions missing np.long
-  - pytorch::torchvision
   - aihabitat::withbullet
+  - conda-forge::cmake>=3.14.0
+  - conda-forge::importlib_resources
+  - conda-forge::matplotlib
+  - conda-forge::numpy
+  - conda-forge::pandas
+  - conda-forge::pillow
+  - conda-forge::quaternion=2023.0.3 # later versions missing np.long
+  - conda-forge::scikit-image
+  - conda-forge::scikit-learn=1.3.2
+  - conda-forge::scipy
+  - conda-forge::sympy
+  - conda-forge::tqdm
+  - conda-forge::wandb
+  - conda-forge::wget
+  - pyg::pyg
+  - pytorch::pytorch=1.11.0
+  - pytorch::torchvision
 
   - pip
   - pip:

--- a/environment_arm64.yml
+++ b/environment_arm64.yml
@@ -26,26 +26,37 @@
 #     $ conda activate tbp.monty
 #
 # platform: osx-arm64
-name: tbp.monty
+name: tbp.monty_test
 channels:
   - aihabitat
   - pytorch
   - pyg
-  - defaults
   - conda-forge
+  - defaults
 
 dependencies:
   - python=3.8
-  - cmake>=3.14.0
-  - pyg::pyg
-  - wget
 
   - aihabitat::habitat-sim=0.2.2
-  - mkl<2022 # prevents Intel errors when osx-64 environment is running on osx-arm64 platform
-  - pytorch::pytorch=1.11.0
-  - conda-forge::quaternion=2023.0.3 # later versions missing np.long
-  - pytorch::torchvision
   - aihabitat::withbullet
+  - conda-forge::cmake>=3.14.0
+  - conda-forge::importlib_resources
+  - conda-forge::matplotlib
+  - conda-forge::mkl<2022 # prevents Intel errors when osx-64 environment is running on osx-arm64 platform
+  - conda-forge::numpy
+  - conda-forge::pandas
+  - conda-forge::pillow
+  - conda-forge::quaternion=2023.0.3 # later versions missing np.long
+  - conda-forge::scikit-image
+  - conda-forge::scikit-learn=1.3.2
+  - conda-forge::scipy
+  - conda-forge::sympy
+  - conda-forge::tqdm
+  - conda-forge::wandb
+  - conda-forge::wget
+  - pyg::pyg
+  - pytorch::pytorch=1.11.0
+  - pytorch::torchvision
 
   - pip
   - pip:

--- a/environment_arm64.yml
+++ b/environment_arm64.yml
@@ -26,7 +26,7 @@
 #     $ conda activate tbp.monty
 #
 # platform: osx-arm64
-name: tbp.monty_test
+name: tbp.monty
 channels:
   - aihabitat
   - pytorch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,18 +16,21 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Artificial Intelligence'
 ]
 dependencies = [
-    'importlib_resources',
-    'matplotlib',
-    'numpy',
-    'pandas',
-    'pillow',
-    'scikit-image',
-    'scikit-learn==1.3.2',
-    'scipy',
-    'sympy',
-    'torch-geometric',
-    'tqdm',
-    'wandb',
+    'habitat_sim', # imported via conda (aihabitat::habitat-sim)
+    'importlib_resources', # imported via conda (conda-forge::importlib_resources)
+    'matplotlib', # imported via conda (conda-forge::matplotlib)
+    'numpy', # imported via conda (conda-forge::numpy)
+    'pandas', # imported via conda (conda-forge::pandas)
+    'pillow', # imported via conda (conda-forge::pillow)
+    'scikit-image', # imported via conda (conda-forge::scikit-image)
+    'scikit-learn==1.3.2', # imported via conda (conda-forge::scikit-learn)
+    'scipy', # imported via conda (conda-forge::scipy)
+    'sympy', # imported via conda (conda-forge::sympy)
+    'torch', # imported via conda (pytorch::pytorch)
+    'torchvision', # imported via conda (pytorch::torchvision)
+    'torch-geometric', # imported via conda (pyg::pyg)
+    'tqdm', # imported via conda (conda-forge::tqdm)
+    'wandb', # imported via conda (conda-forge::wandb)
 ]
 description = 'Thousand Brains Project Monty'
 dynamic = ['version']
@@ -97,13 +100,10 @@ ignore = ['DEP002']
 known_first_party = [
     'attr', # transitive dependency bundled with habitat-sim
     'benchmarks', # benchmark configurations and scripts
-    'habitat_sim', # imported via conda (habitat-sim)
     'magnum', # transitive dependency bundled with habitat-sim
-    'quaternion', # imported via conda (quaternion)
+    'quaternion', # transitive add-on for numpy installed via conda (conda-forge::quaternion)
     'tests',
-    'tools',
-    'torch', # imported via conda (pytorch)
-    'torchvision', # imported via conda (torchvision)
+    'tools'
 ]
 
 [tool.deptry.package_module_name_map]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,15 +20,26 @@ requirements:
     - pip
   run:
     - python==3.8
-    - cmake>=3.14.0
-    - pyg::pyg
-    - wget
     - aihabitat::habitat-sim=0.2.2 # [linux64 or osx]
-    - mkl<2022 # [osx]
-    - pytorch::pytorch=1.11.0
-    - conda-forge::quaternion=2023.0.3 # later versions missing np.long
-    - pytorch::torchvision
     - aihabitat::withbullet
+    - conda-forge::cmake>=3.14.0
+    - conda-forge::importlib_resources
+    - conda-forge::matplotlib
+    - conda-forge::mkl<2022 # [osx]
+    - conda-forge::numpy
+    - conda-forge::pandas
+    - conda-forge::pillow
+    - conda-forge::quaternion=2023.0.3 # later versions missing np.long
+    - conda-forge::scikit-image
+    - conda-forge::scikit-learn=1.3.2
+    - conda-forge::scipy
+    - conda-forge::sympy
+    - conda-forge::tqdm
+    - conda-forge::wandb
+    - conda-forge::wget
+    - pyg::pyg
+    - pytorch::pytorch=1.11.0
+    - pytorch::torchvision
 
 about:
   home: https://github.com/thousandbrainsproject/tbp.monty

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - conda-forge::importlib_resources
     - conda-forge::matplotlib
     - conda-forge::mkl<2022 # [osx]
+    - conda-forge::mkl==2024.0.0 # [linux64]
     - conda-forge::numpy
     - conda-forge::pandas
     - conda-forge::pillow


### PR DESCRIPTION
In our current setup, we use two package managers to satisfy Monty dependencies: `conda` and `pip`. This was fine when we were not distributing Monty. However, to publish and distribute Monty, we need to pick a single source for our dependencies. Today, this needs to be `conda` as not all dependencies are available on `pip` (e.g., `habitat_sim`).

By using `conda` to source all dependencies, when we publish `thousandbrainsproject::tbp.monty`, we can specify dependencies that should be installed when someone installs `thousandbrainsproject::tbp.monty`. If we do not do this, there is no standard install method for Monty on either `conda` or `pip`. (Without a standard install method, we would be asking users to execute a custom sequence of steps; not impossible, but not as accessible as `conda env create`).

With the changes in this pull request, the following conda `environment.yml` is expected to work out of the box (once this version is published) and install _all_ dependencies needed for Monty to run:
```yml
name: monty_lab
channels:
  - aihabitat
  - pytorch
  - pyg
  - defaults
  - conda-forge
  - thousandbrainsproject

dependencies:
  - thousandbrainsproject::tbp.monty
```
> [!NOTE]
> In `environment.yml` above, we need to specify all the channels that `tbp.monty` depends on because `conda` dependency file does not support specifying channels (see: https://github.com/conda/conda-build/issues/532). For example, even though `tbp.monty` depends on `aihabitat::habitat-sim`, in the `conda` dependency file this will be truncated to `habitat-sim`. Without specifying the necessary channels, installation will fail as `habitat-sim` is not in the `defaults`. When we specify `aihabitat` in the `channels:` property, `conda` install will include `aihabitat::habitat-sim` in the search for `habitat-sim`.