### PR TITLE
docs: update instructions in environment_arm64.yml to match latest

### DIFF
--- a/environment_arm64.yml
+++ b/environment_arm64.yml
@@ -1,6 +1,6 @@
 # This file may be used to create an environment using:
 #
-# ## Miniconda
+# ## Miniconda or Anaconda
 #     $ conda env create --file environment_arm64.yml --subdir=osx-64
 # If you are using the zsh shell, run:
 #     $ conda init zsh
@@ -12,18 +12,6 @@
 # Finally, activate the environment with:
 #     $ conda activate tbp.monty
 #     $ conda config --env --set subdir osx-64
-#
-# ## Anaconda (omit --subdir=osx-64)
-#     $ conda env create --file environment_arm64.yml
-# If you are using the zsh shell, run:
-#     $ conda init zsh
-# Or, if you are using a different shell, run:
-#     $ conda init
-# After init, if you do not want conda to change your global shell when
-# you open a new terminal, run:
-#     $ conda config --set auto_activate_base false
-# Finally, activate the environment with:
-#     $ conda activate tbp.monty
 #
 # platform: osx-arm64
 name: tbp.monty


### PR DESCRIPTION
In the pull request https://github.com/thousandbrainsproject/tbp.monty/pull/118, we updated the OSX instructions to no longer distinguish between Miniconda and Anaconda. This pull request makes the same update for instructions inlined into `environment_arm64.yml`.