### PR TITLE
chore: version 0.0.2

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"


### PR DESCRIPTION
Publish recent changes and test the latest builds.

Only `build:`, one `refactor:`, and one `docs:` changes since `0.0.1`. As this is a backward-compatible change without any new features, the patch version is incremented.

<img width="772" alt="Screenshot 2025-03-05 at 18 01 36" src="https://github.com/user-attachments/assets/0b12fc11-771d-46d3-ae26-47e958661657" />
