### PR TITLE
Fix reproduce episode

### DIFF
--- a/benchmarks/make_detailed_follow_up_configs.py
+++ b/benchmarks/make_detailed_follow_up_configs.py
@@ -11,14 +11,21 @@
 import os
 import pathlib
 import pickle
+import sys
 
 import pandas as pd
 
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.expanduser(os.path.realpath(__file__))))
+)
 # Load all experiment configurations from local project
-from configs import CONFIGS
+from benchmarks.configs.load import load_configs
+from benchmarks.configs.names import NAMES
+from tbp.monty.frameworks.run_env import setup_env
+
+setup_env()
 
 from tbp.monty.frameworks.config_utils.cmd_parser import create_rerun_parser
-from tbp.monty.frameworks.utils.dataclass_utils import config_to_dict
 from tbp.monty.frameworks.utils.follow_up_configs import (
     create_eval_config_multiple_episodes,
     recover_output_dir,
@@ -48,15 +55,15 @@ experiment uses it.
 """
 
 if __name__ == "__main__":
-    cmd_parser = create_rerun_parser(experiments=list(CONFIGS.keys()))
+    cmd_parser = create_rerun_parser(experiments=NAMES)
     cmd_args = cmd_parser.parse_args()
     experiment = cmd_args.experiment
     follow_up_suffix = cmd_args.name
     rerun_episodes = cmd_args.episodes
 
     # Load results from experiment and find episodes of interest
+    CONFIGS = load_configs([experiment])
     config = CONFIGS[experiment]
-    config = config_to_dict(config)
     output_dir = recover_output_dir(config, experiment)
 
     if not rerun_episodes:

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -140,6 +140,9 @@ class BasePolicy(MotorSystem):
         # is in addition to, rather than in replacement of, file_name
         if file_names_per_episode is not None:
             self.file_names_per_episode = file_names_per_episode
+            # Have to set this here bc file_names_per_episode is used for loading in
+            # post_episode so won't do anything for the first episode.
+            file_name = file_names_per_episode[0]
             self.is_predefined = True
 
         if file_name is not None:
@@ -168,6 +171,8 @@ class BasePolicy(MotorSystem):
                 return action
 
     def predefined_call(self) -> Action:
+        print(self.episode_step)
+        print(len(self.action_list))
         return self.action_list[self.episode_step % len(self.action_list)]
 
     def post_action(self, action: Action) -> None:
@@ -186,6 +191,7 @@ class BasePolicy(MotorSystem):
         if self.file_names_per_episode is not None:
             if self.episode_count in self.file_names_per_episode:
                 file_name = self.file_names_per_episode[self.episode_count]
+                print(f"reading action file {file_name}.")
                 self.action_list = read_action_file(file_name)
 
     ###

--- a/src/tbp/monty/frameworks/utils/follow_up_configs.py
+++ b/src/tbp/monty/frameworks/utils/follow_up_configs.py
@@ -239,5 +239,8 @@ def create_eval_config_multiple_episodes(
             change_every_episode=True,
         )
     )
+    new_config["monty_config"]["motor_system_config"]["motor_system_args"][
+        "file_names_per_episode"
+    ] = file_names_per_episode
 
     return new_config

--- a/src/tbp/monty/frameworks/utils/follow_up_configs.py
+++ b/src/tbp/monty/frameworks/utils/follow_up_configs.py
@@ -191,13 +191,15 @@ def create_eval_config_multiple_episodes(
     # Add detailed handlers
     if DetailedJSONHandler not in new_config["logging_config"]["monty_handlers"]:
         new_config["logging_config"]["monty_handlers"].append(DetailedJSONHandler)
-    if (
-        DetailedWandbMarkedObsHandler
-        not in new_config["logging_config"]["wandb_handlers"]
-    ):
-        new_config["logging_config"]["wandb_handlers"].append(
-            DetailedWandbMarkedObsHandler
-        )
+    # This handler requires moviepy to be installed which is currently not in our
+    # default requirements.
+    # if (
+    #     DetailedWandbMarkedObsHandler
+    #     not in new_config["logging_config"]["wandb_handlers"]
+    # ):
+    #     new_config["logging_config"]["wandb_handlers"].append(
+    #         DetailedWandbMarkedObsHandler
+    #     )
 
     ###
     # Accumulate episode-specific data: actions and object params


### PR DESCRIPTION
The `make_detailed_follow_up_configs.py` script was not working anymore after this PR https://github.com/thousandbrainsproject/tbp.monty/pull/153 The changes here should fix this.

Loading the config is a bit more involved now. Previously, the script would print instructions for running the follow-up config, which was simply `python run.py -e {follow_up_name}`. Now, as far as I understand, one needs to add the `follow_up_name` to one of the classes in `names.py` and then add
```
from benchmarks.configs.follow_ups import CONFIGS as FOLLOW_UP_CONFIGS
experiments = YcbExperiments(
    follow_up_name=FOLLOW_UP_CONFIGS["follow_up_name"],
)
```
to the corresponding experiment config script (here `ycb_experiments.py`). This is a lot more complicated. 
@tristanls is there a simpler way that I am missing? Otherwise, I will update the instructions in `make_detailed_follow_up_configs.py`.

I also noticed that the predefined action sequence wasn't applied properly, and a wandb handler was used that doesn't have all its dependencies in the environment setup, so I fixed those two. 

I am looking into why I am still not getting the exact episode reproduced, hence the draft PR.