### PR TITLE
build: pin numpy version, later ones are missing np.long

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - conda-forge::importlib_resources
   - conda-forge::matplotlib
   - conda-forge::mkl==2024.0.0 # see https://github.com/pytorch/pytorch/issues/123097
-  - conda-forge::numpy
+  - conda-forge::numpy<=1.23.5 # numpy >=1.24.0 missing np.long
   - conda-forge::pandas
   - conda-forge::pillow
   - conda-forge::quaternion=2023.0.3 # later versions missing np.long

--- a/environment_arm64.yml
+++ b/environment_arm64.yml
@@ -31,7 +31,7 @@ dependencies:
   - conda-forge::importlib_resources
   - conda-forge::matplotlib
   - conda-forge::mkl<2022 # prevents Intel errors when osx-64 environment is running on osx-arm64 platform
-  - conda-forge::numpy
+  - conda-forge::numpy<=1.23.5 # numpy >=1.24.0 missing np.long
   - conda-forge::pandas
   - conda-forge::pillow
   - conda-forge::quaternion=2023.0.3 # later versions missing np.long

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - conda-forge::matplotlib
     - conda-forge::mkl<2022 # [osx]
     - conda-forge::mkl==2024.0.0 # [linux64]
-    - conda-forge::numpy
+    - conda-forge::numpy<=1.23.5 # numpy >=1.24.0 missing np.long
     - conda-forge::pandas
     - conda-forge::pillow
     - conda-forge::quaternion=2023.0.3 # later versions missing np.long


### PR DESCRIPTION
When testing `thousandbrainsproject::tbp.monty==0.0.2`, it is possible to install a `numpy>1.23.5`. However, `numpy` versions `>=1.24` are missing `np.long` used by the code. This pull request pins `numpy<=1.23.5` to prevent `np.long` missing errors.

Example failure:
```
/home/me/.conda/envs/monty_lab/lib/python3.8/site-packages/numba/core/types/__init__.py:108: FutureWarning: In the future `np.long` will be defined as the corresponding NumPy scalar.
  long_ = _make_signed(np.long)
Traceback (most recent call last):
  File "dmc/run_parallel.py", line 16, in <module>
    from configs import CONFIGS  # noqa: E402
  File "/home/me/tbp/monty_lab/dmc/configs/__init__.py", line 1, in <module>
    from .fig3_robust_sensorimotor_inference import CONFIGS as FIG_3_CONFIGS
  File "/home/me/tbp/monty_lab/dmc/configs/fig3_robust_sensorimotor_inference.py", line 30, in <module>
    from tbp.monty.frameworks.config_utils.config_args import (
  File "/home/me/.conda/envs/monty_lab/lib/python3.8/site-packages/tbp/monty/frameworks/config_utils/config_args.py", line 22, in <module>
    from tbp.monty.frameworks.actions.action_samplers import (
  File "/home/me/.conda/envs/monty_lab/lib/python3.8/site-packages/tbp/monty/frameworks/actions/action_samplers.py", line 15, in <module>
    import quaternion as qt
  File "/home/me/.conda/envs/monty_lab/lib/python3.8/site-packages/quaternion/__init__.py", line 31, in <module>
    from .quaternion_time_series import (
  File "/home/me/.conda/envs/monty_lab/lib/python3.8/site-packages/quaternion/quaternion_time_series.py", line 10, in <module>
    from quaternion.numba_wrapper import njit
  File "/home/me/.conda/envs/monty_lab/lib/python3.8/site-packages/quaternion/numba_wrapper.py", line 13, in <module>
    from numba import njit, jit, vectorize, int64, float64, complex128
  File "/home/me/.conda/envs/monty_lab/lib/python3.8/site-packages/numba/__init__.py", line 16, in <module>
    from numba.core import types, errors
  File "/home/me/.conda/envs/monty_lab/lib/python3.8/site-packages/numba/core/types/__init__.py", line 108, in <module>
    long_ = _make_signed(np.long)
  File "/home/me/.conda/envs/monty_lab/lib/python3.8/site-packages/numpy/__init__.py", line 320, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'long'
```