### PR TITLE
chore: version 0.0.3

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"


### PR DESCRIPTION
Patch version to release tbp.monty with pinned numpy dependency from https://github.com/thousandbrainsproject/tbp.monty/commit/81c61738ab83ba5a7ae2da7c3604f6deac775f32.

<img width="873" alt="Screenshot 2025-03-14 at 10 36 37" src="https://github.com/user-attachments/assets/01e0e8c9-8752-4a12-bc8b-c05c4b19fd9f" />
