### PR TITLE
chore: fix for bug where glossary has old description

### DIFF
--- a/docs/overview/faq-thousand-brains-project.md
+++ b/docs/overview/faq-thousand-brains-project.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ - Thousand Brains Project
-description: Frequently asked question about the project.
+description: Frequently asked question about the project 2222
 ---
 # What Kind of Applications Will This Project Tackle?
 

--- a/docs/overview/faq-thousand-brains-project.md
+++ b/docs/overview/faq-thousand-brains-project.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ - Thousand Brains Project
-description: Frequently asked question about the project 2222
+description: Frequently asked question about the project.
 ---
 # What Kind of Applications Will This Project Tackle?
 

--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -6,6 +6,10 @@ description: This section aims to provide concise definitions of terms commonly 
 
 Implement pattern recognizers to identify patterns such as a specific SDR. One neuron is typically associated with multiple dendrites such that it can identify multiple patterns. In biology, dendrites of a postsynaptic cell receive information from the axons of other presynaptic cells. The axons of these presynaptic cells connect to the dendrites of postsynaptic cells at a junction called a "synapse". An SDR can be thought of as a pattern which is represented by a set of synapses that are collocated on a single dendritic segment.
 
+
+# Displacement
+The spatial difference between two locations. In 3D space, this would be a 3D vector.
+
 # Efference Copy
 
 A copy of the motor command that was output by the policy and sent to the actuators. This copy can be used by learning modules to update their states or make predictions.
@@ -55,8 +59,6 @@ Defines the function used to select actions. Selected actions can be dependent o
 # Pose
 
 An object's location and orientation (in a given reference frame). The location can for example be x, y, z coordinates and the orientation can be represented as a quaternion, Euler angles, or a rotation matrix.
-
-**displacement:** The spatial difference between two locations. In 3D space, this would be a 3D vector.
 
 # Reference Frame
 

--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -6,7 +6,6 @@ description: This section aims to provide concise definitions of terms commonly 
 
 Implement pattern recognizers to identify patterns such as a specific SDR. One neuron is typically associated with multiple dendrites such that it can identify multiple patterns. In biology, dendrites of a postsynaptic cell receive information from the axons of other presynaptic cells. The axons of these presynaptic cells connect to the dendrites of postsynaptic cells at a junction called a "synapse". An SDR can be thought of as a pattern which is represented by a set of synapses that are collocated on a single dendritic segment.
 
-
 # Displacement
 The spatial difference between two locations. In 3D space, this would be a 3D vector.
 

--- a/tools/github_readme_sync/md.py
+++ b/tools/github_readme_sync/md.py
@@ -18,6 +18,8 @@ def process_markdown(body: str, slug: str) -> dict:
         raise ValueError("No frontmatter found in the document")
     doc["title"] = frontmatter.get("title", "")
     doc["hidden"] = frontmatter.get("hidden", False)
+    if "description" in frontmatter:
+        doc["description"] = frontmatter.get("description", "")
 
     body = body.split("---\n", maxsplit=2)
     if len(body) > 2:

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -96,10 +96,14 @@ class ReadMe:
 
         front_matter_str = (
             f"---\n"
-            f"""{yaml.dump(front_matter,
-                           Dumper=OrderedDumper,
-                           default_flow_style=False,
-                           width=float('inf')).strip()}\n"""
+            f"""{
+                yaml.dump(
+                    front_matter,
+                    Dumper=OrderedDumper,
+                    default_flow_style=False,
+                    width=float("inf"),
+                ).strip()
+            }\n"""
             f"---\n"
         )
 
@@ -274,6 +278,10 @@ class ReadMe:
             "order": order,
             "parentDoc": parent_id,
         }
+
+        # Include description field if it exists in the document
+        if "description" in doc:
+            create_doc_request["description"] = doc["description"]
 
         doc_id = self.get_doc_id(doc["slug"])
         created = doc_id is None
@@ -471,7 +479,7 @@ class ReadMe:
                     f'style="border-radius: 10px;" controls '
                     f'poster="{new_url.replace(".mp4", ".jpg")}">'
                     f'<source src="{new_url}" type="video/mp4">'
-                    f'Your browser does not support the video tag.</video></div>'
+                    f"Your browser does not support the video tag.</video></div>"
                 )
             }
             return f"[block:html]\n{json.dumps(block, indent=2)}\n[/block]"

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -279,9 +279,9 @@ class ReadMe:
             "parentDoc": parent_id,
         }
 
-        # Include description field if it exists in the document
+        # Include description field as excerpt if it exists in the document
         if "description" in doc:
-            create_doc_request["description"] = doc["description"]
+            create_doc_request["excerpt"] = doc["description"]
 
         doc_id = self.get_doc_id(doc["slug"])
         created = doc_id is None

--- a/tools/github_readme_sync/tests/md_test.py
+++ b/tools/github_readme_sync/tests/md_test.py
@@ -91,6 +91,27 @@ This is the body of the markdown.
         result["body"] = result["body"].strip()
         self.assertEqual(result, expected)
 
+    def test_description_field_in_frontmatter_is_processed(self):
+        body = """---
+title: Glossary
+description: A collection of terms and definitions used in the Thousand Brains Project
+---
+
+This is the glossary content.
+"""
+        slug = "glossary"
+        result = process_markdown(body, slug)
+        self.assertIn(
+            "description",
+            result,
+            "Description field is missing from processed markdown",
+        )
+        self.assertEqual(
+            result["description"],
+            "A collection of terms and definitions used in the Thousand Brains Project",
+            "Description field value is incorrect",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/github_readme_sync/tests/readme_test.py
+++ b/tools/github_readme_sync/tests/readme_test.py
@@ -339,7 +339,7 @@ This is a test document.""",
             "title": "Glossary",
             "body": "Glossary content",
             "slug": "glossary",
-            "description": "A collection of terms and definitions used in the Thousand Brains Project",
+            "description": "A collection of terms",
         }
 
         doc_id, created = self.readme.create_or_update_doc(
@@ -350,16 +350,15 @@ This is a test document.""",
             file_path="docs/glossary.md",
         )
 
-        # Verify the description field is included in the request to readme.io as "excerpt"
         self.assertIn(
             "excerpt",
             mock_post.call_args[0][1],
-            "Excerpt field is missing from the request to readme.io",
+            "Excerpt field is missing",
         )
         self.assertEqual(
             mock_post.call_args[0][1]["excerpt"],
-            "A collection of terms and definitions used in the Thousand Brains Project",
-            "Excerpt field value is incorrect in the request to readme.io",
+            "A collection of terms",
+            "Excerpt field value is incorrect",
         )
 
     @patch.dict(os.environ, {"IMAGE_PATH": "user/repo/refs/head/main/docs/figures"})

--- a/tools/github_readme_sync/tests/readme_test.py
+++ b/tools/github_readme_sync/tests/readme_test.py
@@ -324,12 +324,47 @@ This is a test document.""",
         )
         mock_put.assert_not_called()
 
+    @patch("tools.github_readme_sync.readme.get")
+    @patch("tools.github_readme_sync.readme.put")
+    @patch("tools.github_readme_sync.readme.post")
+    @patch.dict(os.environ, {"IMAGE_PATH": "user/repo"})
+    def test_description_field_is_sent_to_readme(self, mock_post, mock_put, mock_get):
+        mock_get.return_value = None  # Doc does not exist
+        mock_post.return_value = json.dumps({"_id": "glossary-id"})
+
+        # Create a document with a description field
+        doc_with_description = {
+            "title": "Glossary",
+            "body": "Glossary content",
+            "slug": "glossary",
+            "description": "A collection of terms and definitions used in the Thousand Brains Project",
+        }
+
+        doc_id, created = self.readme.create_or_update_doc(
+            order=1,
+            category_id="category-id",
+            doc=doc_with_description,
+            parent_id="parent-doc-id",
+            file_path="docs/glossary.md",
+        )
+
+        # Verify the description field is included in the request to readme.io
+        self.assertIn(
+            "description",
+            mock_post.call_args[0][1],
+            "Description field is missing from the request to readme.io",
+        )
+        self.assertEqual(
+            mock_post.call_args[0][1]["description"],
+            "A collection of terms and definitions used in the Thousand Brains Project",
+            "Description field value is incorrect in the request to readme.io",
+        )
+
     @patch.dict(os.environ, {"IMAGE_PATH": "user/repo/refs/head/main/docs/figures"})
     def test_correct_image_locations_markdown(self):
         """Test image location correction for Markdown image paths."""
         base_expected = (
-            f"![Image 1]({GITHUB_RAW}"
-            f"/user/repo/refs/head/main/docs/figures/image1.png)"
+            f"![Image 1]({GITHUB_RAW}/user/repo/refs/head/main/docs/figures/image1.png)"
         )
 
         # Test cases for Markdown image paths

--- a/tools/github_readme_sync/tests/readme_test.py
+++ b/tools/github_readme_sync/tests/readme_test.py
@@ -328,7 +328,9 @@ This is a test document.""",
     @patch("tools.github_readme_sync.readme.put")
     @patch("tools.github_readme_sync.readme.post")
     @patch.dict(os.environ, {"IMAGE_PATH": "user/repo"})
-    def test_description_field_is_sent_to_readme(self, mock_post, mock_put, mock_get):
+    def test_description_field_is_sent_to_readme_as_excerpt(
+        self, mock_post, mock_put, mock_get
+    ):
         mock_get.return_value = None  # Doc does not exist
         mock_post.return_value = json.dumps({"_id": "glossary-id"})
 
@@ -348,16 +350,16 @@ This is a test document.""",
             file_path="docs/glossary.md",
         )
 
-        # Verify the description field is included in the request to readme.io
+        # Verify the description field is included in the request to readme.io as "excerpt"
         self.assertIn(
-            "description",
+            "excerpt",
             mock_post.call_args[0][1],
-            "Description field is missing from the request to readme.io",
+            "Excerpt field is missing from the request to readme.io",
         )
         self.assertEqual(
-            mock_post.call_args[0][1]["description"],
+            mock_post.call_args[0][1]["excerpt"],
             "A collection of terms and definitions used in the Thousand Brains Project",
-            "Description field value is incorrect in the request to readme.io",
+            "Excerpt field value is incorrect in the request to readme.io",
         )
 
     @patch.dict(os.environ, {"IMAGE_PATH": "user/repo/refs/head/main/docs/figures"})


### PR DESCRIPTION
This PR fixes a bug where the description was not updating from the frontmatter in the document pages.

This was two fold
1. Because in readme.io it is called except, not description.
1. The description was not being read in from the document's frontmatter.

A term in the glossary page was also corrected to move to the right location and become a heading.