### PR TITLE
refactor: Avoid possible locations double initialization.

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -1841,24 +1841,6 @@ class EvidenceGraphMemory(GraphMemory):
     # ------------------- Main Algorithm -----------------------
 
     # ------------------ Getters & Setters ---------------------
-    def get_initial_hypotheses(self):
-        possible_matches = self.get_memory_ids()
-        possible_locations = {}
-        for graph_id in possible_matches:
-            # Initialize vertical shape of np array so we can easily stack it. Will be
-            # removed after concatenating loop.
-            all_locations_for_graph = np.zeros(3)
-            for input_channel in self.get_input_channels_in_graph(graph_id):
-                # All locations stored in graph
-                all_locations_for_graph = np.vstack(
-                    [
-                        all_locations_for_graph,
-                        self.get_locations_in_graph(graph_id, input_channel),
-                    ]
-                )
-            possible_locations[graph_id] = all_locations_for_graph[1:]
-        return possible_matches, possible_locations
-
     def get_rotation_features_at_all_nodes(self, graph_id, input_channel):
         """Get rotation features from all N nodes. shape=(N, 3, 3).
 

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -212,7 +212,7 @@ class EvidenceGraphLM(GraphLM):
             2) Within one object, possible poses are considered possible if their
                 evidence is larger than the most likely pose of this object - x percent
                 of this poses evidence.
-            # TODO: should we use a separate theshold for within and between objects?
+            # TODO: should we use a separate threshold for within and between objects?
             If this value is larger, the model is usually more robust to noise and
             reaches a better performance but also requires a lot more steps to reach a
             terminal condition, especially if there are many similar object in the data
@@ -222,7 +222,7 @@ class EvidenceGraphLM(GraphLM):
         pose_similarity_threshold: difference between two poses to be considered
             unique when checking for the terminal condition (in radians).
         required_symmetry_evidence: number of steps with unchanged possible poses
-            to classify an object as symetric and go into terminal condition.
+            to classify an object as symmetric and go into terminal condition.
 
     Model Attributes:
         graph_delta_thresholds: Thresholds used to compare nodes in the graphs being
@@ -251,7 +251,7 @@ class EvidenceGraphLM(GraphLM):
         use_multithreading: Whether to calculate evidence updates for different
             objects in parallel using multithreading. This can be done since the
             updates to different objects are completely independent of each other. In
-            general it is recommended to use this but it can be usefull to turn it off
+            general it is recommended to use this but it can be useful to turn it off
             for debugging purposes.
     """
 
@@ -359,7 +359,7 @@ class EvidenceGraphLM(GraphLM):
         """Reset evidence count and other variables."""
         # Now here, as opposed to the displacement and feature-location LMs,
         # possible_matches is a list of IDs, not a dictionary with the object graphs.
-        self.possible_matches = self.graph_memory.get_memory_ids()
+        self.possible_matches = self.graph_memory.get_initial_hypotheses()
 
         if self.tolerances is not None:
             # TODO H: Differentiate between features from different input channels
@@ -1174,7 +1174,7 @@ class EvidenceGraphLM(GraphLM):
         First, the search locations are used to find the nearest nodes in the graph
         model. Then we calculate the error between the stored pose features and the
         sensed ones. Additionally we look at whether the non-pose features match at the
-        neigboring nodes. Everything is weighted by the nodes distance from the search
+        neighboring nodes. Everything is weighted by the nodes distance from the search
         location.
         If there are no nodes in the search radius (max_match_distance), evidence = -1.
 
@@ -1666,7 +1666,7 @@ class EvidenceGraphLM(GraphLM):
         Args:
             x_percent_scale_factor: If desired, can check possible matches using a
                 scaled threshold; can be used to e.g. check whether hypothesis-testing
-                policy should focus on descriminating a single object's pose, vs.
+                policy should focus on discriminating a single object's pose, vs.
                 between different object IDs, when we are half-way to the threshold
                 required for classification; "mod" --> modifier
                 By default set to identity and has no effect
@@ -1841,6 +1841,9 @@ class EvidenceGraphMemory(GraphMemory):
     # ------------------- Main Algorithm -----------------------
 
     # ------------------ Getters & Setters ---------------------
+    def get_initial_hypotheses(self):
+        return self.get_memory_ids()
+
     def get_rotation_features_at_all_nodes(self, graph_id, input_channel):
         """Get rotation features from all N nodes. shape=(N, 3, 3).
 
@@ -1879,7 +1882,7 @@ class EvidenceGraphMemory(GraphMemory):
             try:
                 if type(channel_model) == GraphObjectModel:
                     # When loading a model trained with a different LM, need to convert
-                    # it to the GridObjectModel (with use_orginal_graph == True)
+                    # it to the GridObjectModel (with use_original_graph == True)
                     loaded_graph = channel_model._graph
                     channel_model = self._initialize_model_with_graph(
                         graph_id, loaded_graph
@@ -1899,16 +1902,16 @@ class EvidenceGraphMemory(GraphMemory):
             max_size=self.max_graph_size,
             num_voxels_per_dim=self.num_model_voxels_per_dim,
         )
-        # Keep benchmark results constant by still using orginal graph for
+        # Keep benchmark results constant by still using original graph for
         # matching when loading pretrained models.
-        model.use_orginal_graph = True
+        model.use_original_graph = True
         model.set_graph(graph)
         return model
 
     def _build_graph(self, locations, features, graph_id, input_channel):
         """Build a graph from a list of features at locations and add to memory.
 
-        This initialzes a new GridObjectModel and calls model.build_graph.
+        This initializes a new GridObjectModel and calls model.build_graph.
 
         Args:
             locations: List of x,y,z locations.

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -17,9 +17,7 @@ import numpy as np
 from scipy.spatial import KDTree
 from scipy.spatial.transform import Rotation
 
-from tbp.monty.frameworks.models.goal_state_generation import (
-    EvidenceGoalStateGenerator,
-)
+from tbp.monty.frameworks.models.goal_state_generation import EvidenceGoalStateGenerator
 from tbp.monty.frameworks.models.graph_matching import (
     GraphLM,
     GraphMemory,
@@ -361,10 +359,7 @@ class EvidenceGraphLM(GraphLM):
         """Reset evidence count and other variables."""
         # Now here, as opposed to the displacement and feature-location LMs,
         # possible_matches is a list of IDs, not a dictionary with the object graphs.
-        (
-            self.possible_matches,
-            self.possible_locations,
-        ) = self.graph_memory.get_initial_hypotheses()
+        self.possible_matches = self.graph_memory.get_memory_ids()
 
         if self.tolerances is not None:
             # TODO H: Differentiate between features from different input channels

--- a/src/tbp/monty/frameworks/models/object_model.py
+++ b/src/tbp/monty/frameworks/models/object_model.py
@@ -33,9 +33,7 @@ from tbp.monty.frameworks.utils.object_model_utils import (
     remove_close_points,
     torch_graph_to_numpy,
 )
-from tbp.monty.frameworks.utils.spatial_arithmetics import (
-    apply_rf_transform_to_points,
-)
+from tbp.monty.frameworks.utils.spatial_arithmetics import apply_rf_transform_to_points
 
 
 class GraphObjectModel(ObjectModel):
@@ -366,7 +364,7 @@ class GridObjectModel(GraphObjectModel):
         # For backward compatibility. May remove later on.
         # This will be true if we load a pretrained graph. If True, grids are not
         # filled or used to constrain nodes in graph.
-        self.use_orginal_graph = False
+        self.use_original_graph = False
         self._location_tree = None
 
     # =============== Public Interface Functions ===============
@@ -471,7 +469,7 @@ class GridObjectModel(GraphObjectModel):
             # could also check if is type torch_geometric.data.data.Data
             logging.debug(f"turning graph of type {type(graph)} into numpy graph")
             graph = torch_graph_to_numpy(graph)
-        if self.use_orginal_graph:
+        if self.use_original_graph:
             # Just use pretrained graph. Do not use grids to constrain nodes.
             self._graph = graph
             self._location_tree = KDTree(


### PR DESCRIPTION
This is a 1 line PR to remove unnecessary initialization of possible locations in `EvidenceGraphLM`.

We should not need to set the `self.possible_locations` using `self.graph_memory.get_initial_hypotheses` in the `EvidenceGraphLM.reset` [function](https://github.com/thousandbrainsproject/tbp.monty/blob/e62e1bca981f7ef3a4e2832e11f80056ce189981/src/tbp/monty/frameworks/models/evidence_matching.py#L366). Whatever we set here at reset will be overwritten later in `_update_evidence` initialization of hypothesis space [here](https://github.com/thousandbrainsproject/tbp.monty/blob/e62e1bca981f7ef3a4e2832e11f80056ce189981/src/tbp/monty/frameworks/models/evidence_matching.py#L987).

It's not a big thing, but it causes `self.possible_locations` and `self.possible_poses` to be out of sync (i.e., locations are initialized and poses are empty) for some part of the code.

*Unit tests and a couple of benchmarks still ran fine.*