### PR TITLE
refactor!: MontyExperiment context manager part 2

### DIFF
--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -51,19 +51,25 @@ class MontyExperiment:
     the outermost loops for training and evaluating (including run epoch and episode)
     """
 
+    def __init__(self, config):
+        """Initialize the experiment based on the provide configuration.
+
+        Args:
+            config: config specifying variables of the experiment.
+        """
+        # Copy the config and store it so we can modify it freely
+        config = copy.deepcopy(config)
+        config = config_to_dict(config)
+        self.config = config
+
+        self.unpack_experiment_args(config["experiment_args"])
+
     def setup_experiment(self, config):
         """Set up the basic elements of a Monty experiment and initialize counters.
 
         Args:
             config: config specifying variables of the experiment.
         """
-        # Save a copy of the config used to specify the experiment before modifying
-        config = copy.deepcopy(config)
-        # Convert any dataclass back to dict for backward compatibility
-        config = config_to_dict(config)
-        self.config = config
-
-        self.unpack_experiment_args(config["experiment_args"])
         self.model = self.init_model(
             monty_config=config["monty_config"],
             model_path=self.model_path,
@@ -530,9 +536,6 @@ class MontyExperiment:
             self.run_epoch()
         self.logger_handler.post_train(self.logger_args)
 
-        if not self.do_eval:
-            self.close()
-
     def evaluate(self):
         """Run n_eval_epochs."""
         # TODO: check that number of eval epochs is at least as many as length
@@ -542,7 +545,6 @@ class MontyExperiment:
         for _ in range(self.n_eval_epochs):
             self.run_epoch()
         self.logger_handler.post_eval(self.logger_args)
-        self.close()
 
     def state_dict(self):
         """Return state_dict with total steps."""
@@ -612,7 +614,7 @@ class MontyExperiment:
         Returns:
             MontyExperiment self to allow assignment in a with statement.
         """
-        # TODO: Move some of the initialization code from `setup_experiment` into this.
+        self.setup_experiment(self.config)
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
@@ -623,7 +625,5 @@ class MontyExperiment:
         Returns:
             bool to indicate whether to supress any exceptions that were raised.
         """
-        # TODO: We call self.close inside `train` and `evaluate`.
-        #   Those should probably be removed.
         self.close()
         return False  # don't silence exceptions inside the with block

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -52,7 +52,7 @@ class MontyExperiment:
     """
 
     def __init__(self, config):
-        """Initialize the experiment based on the provide configuration.
+        """Initialize the experiment based on the provided configuration.
 
         Args:
             config: config specifying variables of the experiment.
@@ -99,7 +99,7 @@ class MontyExperiment:
         """Initialize the Monty model.
 
         Args:
-            monty_config: confguration for the Monty class.
+            monty_config: configuration for the Monty class.
             model_path: Optional model checkpoint. Can be full file name or just the
                 directory containing the "model.pt" file saved from a previous run.
 
@@ -221,7 +221,7 @@ class MontyExperiment:
         Raises:
             TypeError: If `dataset_class` is not a subclass of `EnvironmentDataset`
         """
-        # Require dataset_class to be EnvironmentDataset now, generalzie later
+        # Require dataset_class to be EnvironmentDataset now, generalize later
         if not issubclass(dataset_class, EnvironmentDataset):
             raise TypeError("dataset class must be EnvironmentDataset (for now)")
 

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -30,14 +30,16 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
     NOTE: This is not really an experiment, it is more a pretraining step to generate
     models that can then be loaded at the beginning of an experiment.
     """
-
-    def setup_experiment(self, config):
+    def __init__(self, config):
         # If we just add "pretrained" to dir at save time, then logs are stored in one
         # place and models in another. Changing the config ensures every reference to
         # output_dir has "pretrained" added to it
         config = config_to_dict(config)
         output_dir = config["logging_config"]["output_dir"]
         config["logging_config"]["output_dir"] = os.path.join(output_dir, "pretrained")
+        super().__init__(config)
+
+    def setup_experiment(self, config):
         super().setup_experiment(config)
         self.sensor_pos = np.array(
             config["dataset_args"]["env_init_args"]["agents"][0]["agent_args"][

--- a/src/tbp/monty/frameworks/run.py
+++ b/src/tbp/monty/frameworks/run.py
@@ -43,10 +43,7 @@ def print_config(config):
 
 
 def run(config):
-    exp = config["experiment_class"]()
-    with exp:
-        exp.setup_experiment(config)
-
+    with config["experiment_class"](config) as exp:
         # TODO: Later will want to evaluate every x episodes or epochs
         # this could probably be solved with just setting the logging freqency
         # Since each trainng loop already does everything that eval does.

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -60,18 +60,14 @@ Assumptions and notes:
 
 def single_train(config):
     os.makedirs(config["logging_config"]["output_dir"], exist_ok=True)
-    exp = config["experiment_class"]()
-    with exp:
-        exp.setup_experiment(config)
+    with config["experiment_class"](config) as exp:
         print("---------training---------")
         exp.train()
 
 
 def single_evaluate(config):
     os.makedirs(config["logging_config"]["output_dir"], exist_ok=True)
-    exp = config["experiment_class"]()
-    with exp:
-        exp.setup_experiment(config)
+    with config["experiment_class"](config) as exp:
         print("---------evaluating---------")
         exp.evaluate()
         if config["logging_config"]["log_parallel_wandb"]:
@@ -294,9 +290,7 @@ def post_parallel_train(configs: List[Mapping], base_dir: str) -> None:
         post_parallel_profile_cleanup(parallel_dirs, base_dir, "train")
 
     config = configs[0]
-    exp = config["experiment_class"]()
-    with exp:
-        exp.setup_experiment(config)
+    with config["experiment_class"](config) as exp:
         exp.model.load_state_dict_from_parallel(parallel_dirs, True)
         output_dir = os.path.dirname(configs[0]["logging_config"]["output_dir"])
         if issubclass(

--- a/tests/unit/base_config_test.py
+++ b/tests/unit/base_config_test.py
@@ -79,17 +79,14 @@ class BaseConfigTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        self.exp = MontyExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
+        with MontyExperiment(base_config) as self.exp:
+            pass
 
     # @unittest.skip("debugging")
     def test_can_run_episode(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        self.exp = MontyExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
+        with MontyExperiment(base_config) as self.exp:
             pprint("...training...")
             self.exp.model.set_experiment_mode("train")
             self.exp.dataloader = self.exp.train_dataloader
@@ -99,9 +96,7 @@ class BaseConfigTest(unittest.TestCase):
     def test_can_run_train_epoch(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        self.exp = MontyExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
+        with MontyExperiment(base_config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             self.exp.run_epoch()
 
@@ -109,9 +104,7 @@ class BaseConfigTest(unittest.TestCase):
     def test_can_run_eval_epoch(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        self.exp = MontyExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
+        with MontyExperiment(base_config) as self.exp:
             self.exp.model.set_experiment_mode("eval")
             self.exp.run_epoch()
 
@@ -120,10 +113,7 @@ class BaseConfigTest(unittest.TestCase):
         """Make sure this test uses very small n_actions_per_epoch for speed."""
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        self.exp = MontyExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
-
+        with MontyExperiment(base_config) as self.exp:
             monty_module_sids = set(
                 [s.sensor_module_id for s in self.exp.model.sensor_modules]
             )
@@ -168,10 +158,7 @@ class BaseConfigTest(unittest.TestCase):
         self.assertDictEqual(config_1, self.base_config)
 
         pprint("...parsing experiment in save and load test...")
-        self.exp = MontyExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config_1)
-
+        with MontyExperiment(config_1) as self.exp:
             # change something about exp.state that will be saved via state_dict
             new_attr = False
             self.exp.model.learning_modules[0].test_attr_2 = new_attr
@@ -183,10 +170,7 @@ class BaseConfigTest(unittest.TestCase):
         # checkpoint_dir = self.exp.experiment_args.output_dir
         config_2 = copy.deepcopy(self.base_config)
         config_2["experiment_args"].model_name_or_path = self.exp.output_dir
-        exp_2 = MontyExperiment()
-        with exp_2:
-            exp_2.setup_experiment(config_2)
-
+        with MontyExperiment(config_2) as exp_2:
             # Test 1: untouched attributes are saved and loaded correctly
             prev_attr_1_value = prev_model.learning_modules[0].test_attr_1
             new_attr_1_value = exp_2.model.learning_modules[0].test_attr_1
@@ -211,10 +195,7 @@ class BaseConfigTest(unittest.TestCase):
     def test_logging_debug_level(self):
         """Check that logs go to a file, we can load them, and they have basic info."""
         base_config = copy.deepcopy(self.base_config)
-        self.exp = MontyExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
-
+        with MontyExperiment(base_config) as self.exp:
             # Add some stuff to the logs, verify it shows up
             info_message = "INFO is in the log"
             warning_message = "WARNING is in the log"
@@ -231,10 +212,7 @@ class BaseConfigTest(unittest.TestCase):
         """Check that if we set logging level to info, debug logs do not show up."""
         base_config = copy.deepcopy(self.base_config)
         base_config["logging_config"].python_log_level = logging.INFO
-        self.exp = MontyExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
-
+        with MontyExperiment(base_config) as self.exp:
             # Add some stuff to the logs, verify it shows up
             debug_message = "DEBUG is in the log"
             warning_message = "WARNING is in the log"

--- a/tests/unit/base_config_test.py
+++ b/tests/unit/base_config_test.py
@@ -79,49 +79,49 @@ class BaseConfigTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with MontyExperiment(base_config) as self.exp:
+        with MontyExperiment(base_config) as exp:
             pass
 
     # @unittest.skip("debugging")
     def test_can_run_episode(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with MontyExperiment(base_config) as self.exp:
+        with MontyExperiment(base_config) as exp:
             pprint("...training...")
-            self.exp.model.set_experiment_mode("train")
-            self.exp.dataloader = self.exp.train_dataloader
-            self.exp.run_episode()
+            exp.model.set_experiment_mode("train")
+            exp.dataloader = exp.train_dataloader
+            exp.run_episode()
 
     # @unittest.skip("speed")
     def test_can_run_train_epoch(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with MontyExperiment(base_config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
-            self.exp.run_epoch()
+        with MontyExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("train")
+            exp.run_epoch()
 
     # @unittest.skip("debugging")
     def test_can_run_eval_epoch(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with MontyExperiment(base_config) as self.exp:
-            self.exp.model.set_experiment_mode("eval")
-            self.exp.run_epoch()
+        with MontyExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("eval")
+            exp.run_epoch()
 
     # @unittest.skip("debugging")
     def test_observation_unpacking(self):
         """Make sure this test uses very small n_actions_per_epoch for speed."""
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with MontyExperiment(base_config) as self.exp:
+        with MontyExperiment(base_config) as exp:
             monty_module_sids = set(
-                [s.sensor_module_id for s in self.exp.model.sensor_modules]
+                [s.sensor_module_id for s in exp.model.sensor_modules]
             )
 
             # Handle the training loop manually for this interim test
             max_count = 5
             count = 0
-            for observation in self.exp.train_dataloader:
+            for observation in exp.train_dataloader:
                 agent_keys = set(observation.keys())
                 sensor_keys = []
                 for agent in agent_keys:
@@ -137,8 +137,8 @@ class BaseConfigTest(unittest.TestCase):
                     break
 
             # Verify we can skip the loop and just run a single
-            for s in self.exp.model.sensor_modules:
-                s_obs = self.exp.model.get_observations(observation, s.sensor_module_id)
+            for s in exp.model.sensor_modules:
+                s_obs = exp.model.get_observations(observation, s.sensor_module_id)
                 feature = s.step(s_obs)
                 self.assertIn(
                     "rgba",
@@ -158,18 +158,18 @@ class BaseConfigTest(unittest.TestCase):
         self.assertDictEqual(config_1, self.base_config)
 
         pprint("...parsing experiment in save and load test...")
-        with MontyExperiment(config_1) as self.exp:
+        with MontyExperiment(config_1) as exp:
             # change something about exp.state that will be saved via state_dict
             new_attr = False
-            self.exp.model.learning_modules[0].test_attr_2 = new_attr
+            exp.model.learning_modules[0].test_attr_2 = new_attr
 
-            self.exp.save_state_dict()
-            prev_model = self.exp.model
+            exp.save_state_dict()
+            prev_model = exp.model
 
         pprint(f"\n\n\n loading second experiment\n\n\n")
         # checkpoint_dir = self.exp.experiment_args.output_dir
         config_2 = copy.deepcopy(self.base_config)
-        config_2["experiment_args"].model_name_or_path = self.exp.output_dir
+        config_2["experiment_args"].model_name_or_path = exp.output_dir
         with MontyExperiment(config_2) as exp_2:
             # Test 1: untouched attributes are saved and loaded correctly
             prev_attr_1_value = prev_model.learning_modules[0].test_attr_1
@@ -181,7 +181,7 @@ class BaseConfigTest(unittest.TestCase):
             self.assertEqual(new_lm.test_attr_2, new_attr, "attrs did not match")
 
             # Use explicit load_state_dict function instead of setup_experiment
-            exp_2.load_state_dict(self.exp.output_dir)
+            exp_2.load_state_dict(exp.output_dir)
 
             # Test 1: untouched attributes are saved and loaded correctly
             prev_attr_1_value = prev_model.learning_modules[0].test_attr_1
@@ -195,14 +195,14 @@ class BaseConfigTest(unittest.TestCase):
     def test_logging_debug_level(self):
         """Check that logs go to a file, we can load them, and they have basic info."""
         base_config = copy.deepcopy(self.base_config)
-        with MontyExperiment(base_config) as self.exp:
+        with MontyExperiment(base_config) as exp:
             # Add some stuff to the logs, verify it shows up
             info_message = "INFO is in the log"
             warning_message = "WARNING is in the log"
             logging.info(info_message)
             logging.warning(warning_message)
 
-            with open(os.path.join(self.exp.output_dir, "log.txt"), "r") as f:
+            with open(os.path.join(exp.output_dir, "log.txt"), "r") as f:
                 log = f.read()
 
             self.assertTrue(info_message in log)
@@ -212,14 +212,14 @@ class BaseConfigTest(unittest.TestCase):
         """Check that if we set logging level to info, debug logs do not show up."""
         base_config = copy.deepcopy(self.base_config)
         base_config["logging_config"].python_log_level = logging.INFO
-        with MontyExperiment(base_config) as self.exp:
+        with MontyExperiment(base_config) as exp:
             # Add some stuff to the logs, verify it shows up
             debug_message = "DEBUG is in the log"
             warning_message = "WARNING is in the log"
             logging.debug(debug_message)
             logging.warning(warning_message)
 
-            with open(os.path.join(self.exp.output_dir, "log.txt"), "r") as f:
+            with open(os.path.join(exp.output_dir, "log.txt"), "r") as f:
                 log = f.read()
 
             self.assertTrue(debug_message not in log)

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -805,32 +805,32 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
     def test_can_run_evidence_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     def test_fixed_actions_evidence(self):
         """Test 3 train and 3 eval epochs with 2 objects and 2 rotations."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_evidence)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             # self.exp.model.set_experiment_mode("eval")
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
         for key in [
@@ -841,11 +841,11 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         ]:
             self.assertIn(
                 key,
-                self.exp.model.learning_modules[0].buffer.stats.keys(),
+                exp.model.learning_modules[0].buffer.stats.keys(),
                 f"{key} should be stored in buffer when using DETAILED logging.",
             )
         self.assertGreater(
-            len(self.exp.model.learning_modules[0].buffer.stats["possible_matches"]),
+            len(exp.model.learning_modules[0].buffer.stats["possible_matches"]),
             1,
             "When using detailed logging we should store matches at every steps.",
         )
@@ -858,20 +858,20 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_evidence)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
-            self.exp.pre_epoch()
-            self.exp.pre_episode()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
+            exp.pre_epoch()
+            exp.pre_episode()
             pprint("...removing all objects...")
-            self.exp.dataset.env._env.remove_all_objects()
-            self.exp.dataloader.reset_agent()
+            exp.dataset.env._env.remove_all_objects()
+            exp.dataloader.reset_agent()
             pprint("...training...")
-            last_step = self.exp.run_episode_steps()
-            self.exp.post_episode(last_step)
-            self.exp.post_epoch()
+            last_step = exp.run_episode_steps()
+            exp.post_episode(last_step)
+            exp.post_epoch()
 
         pprint("...checking run stats...")
-        train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
+        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
         self.assertEqual(
             train_stats["primary_performance"][0],
             "patch_off_object",
@@ -882,7 +882,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test logging when moving off the object for some steps during an episode."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_tests_off_object)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
             # First episode will be used to learn object (no_match is triggered before
             # min_steps is reached and the sensor moves off the object). In the second
@@ -893,16 +893,16 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             # a full circle and arrives on the other side of the object. From there
             # we can continue to try and recognize the object.
 
-            self.exp.train()
+            exp.train()
 
         self.assertEqual(
             len(
-                self.exp.model.learning_modules[0].buffer.get_all_locations_on_object(
+                exp.model.learning_modules[0].buffer.get_all_locations_on_object(
                     input_channel="patch"
                 )
             ),
             len(
-                self.exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                exp.model.learning_modules[0].buffer.get_all_features_on_object()[
                     "patch"
                 ]["pose_vectors"]
             ),
@@ -910,12 +910,12 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         )
         self.assertEqual(
             sum(
-                self.exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                exp.model.learning_modules[0].buffer.get_all_features_on_object()[
                     "patch"
                 ]["on_object"]
             ),
             len(
-                self.exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                exp.model.learning_modules[0].buffer.get_all_features_on_object()[
                     "patch"
                 ]["on_object"]
             ),
@@ -925,12 +925,12 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         # there should only be 8 observations stored for the 12 matching steps
         # and all of them should be on the object.
         num_matching_steps = len(
-            self.exp.model.learning_modules[0].buffer.stats["possible_matches"]
+            exp.model.learning_modules[0].buffer.stats["possible_matches"]
         )
         self.assertEqual(
             num_matching_steps,
             sum(
-                self.exp.model.learning_modules[0].buffer.features["patch"][
+                exp.model.learning_modules[0].buffer.features["patch"][
                     "on_object"
                 ][:num_matching_steps]
             ),
@@ -939,24 +939,24 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         )
         # Since min_train_steps==12 we should have taken 13 steps.
         self.assertEqual(
-            self.exp.model.matching_steps,
+            exp.model.matching_steps,
             13,
             "Did not take correct amount of matching steps. Perhaps "
             "process_all_obs or min_train_steps was not applied correctly.",
         )
         self.assertGreater(
-            self.exp.model.episode_steps,
-            self.exp.model.matching_steps + 80,
+            exp.model.episode_steps,
+            exp.model.matching_steps + 80,
             "number of episode steps should be larger than matching steps + "
             "exploration steps since we don't count off object observations as"
             "as matching steps (but do count them as episode steps).",
         )
 
         self.assertGreater(
-            self.exp.model.learning_modules[0].buffer.stats["current_mlh"][-1][
+            exp.model.learning_modules[0].buffer.stats["current_mlh"][-1][
                 "evidence"
             ],
-            self.exp.model.learning_modules[0].buffer.stats["current_mlh"][6][
+            exp.model.learning_modules[0].buffer.stats["current_mlh"][6][
                 "evidence"
             ],
             "evidence should have increased after moving back on the object.",
@@ -965,12 +965,12 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
     def test_evidence_time_out(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_tests_time_out)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...check time out logging...")
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             self.assertEqual(
                 train_stats["individual_ts_performance"][0],
@@ -995,22 +995,22 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 "unknown object should be logged as confused_mlh at time out",
             )
             self.assertEqual(
-                len(self.exp.model.learning_modules[0].get_all_known_object_ids()),
+                len(exp.model.learning_modules[0].get_all_known_object_ids()),
                 1,
                 "No new objects should be added to memory after time out.",
             )
             self.assertLessEqual(
-                self.exp.model.learning_modules[0]
+                exp.model.learning_modules[0]
                 .get_graph("new_object0", input_channel="first")
                 .x.shape[1],
                 32,  # max_train_steps + exploratory_steps
                 "No new points should be added to an existing graph after time out.",
             )
 
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         for i in range(3):
             self.assertEqual(
                 eval_stats["individual_ts_performance"][i],
@@ -1028,22 +1028,22 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         # anymore. Setting min_steps would also avoid this probably.
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_evidence)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
             pprint("...training...")
-            self.exp.pre_epoch()
+            exp.pre_epoch()
             # Overwrite target with a false name to test confused logging.
             for e in range(4):
-                self.exp.pre_episode()
-                self.exp.model.primary_target = str(e)
-                for lm in self.exp.model.learning_modules:
+                exp.pre_episode()
+                exp.model.primary_target = str(e)
+                for lm in exp.model.learning_modules:
                     lm.primary_target = str(e)
-                last_step = self.exp.run_episode_steps()
-                self.exp.post_episode(last_step)
-            self.exp.post_epoch()
+                last_step = exp.run_episode_steps()
+                exp.post_episode(last_step)
+            exp.post_epoch()
 
         pprint("...checking run stats...")
-        train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
+        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
         for i in [0, 1]:
             self.assertEqual(
                 train_stats["primary_performance"][i],
@@ -1081,22 +1081,22 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test same scenario as test_fixed_actions_evidence with uniform poses."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_test_uniform_initial_poses)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             print(train_stats)
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
@@ -1104,22 +1104,22 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test same scenario as test_fixed_actions_evidence with predefined poses."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_possible_poses_evidence)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             print(train_stats)
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
@@ -1684,21 +1684,21 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Standard evaluation setup but using only pose features."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.no_features_evidence)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
@@ -1706,37 +1706,36 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test 5 evidence LMs voting with two evaluation settings."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             print(train_stats)
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
-            # not running self.exp.evaluate here to avoid exp.close being called.
-            self.exp.logger_handler.pre_eval(self.exp.logger_args)
-            self.exp.model.set_experiment_mode("eval")
-            for _ in range(self.exp.n_eval_epochs):
-                self.exp.run_epoch()
-            self.exp.logger_handler.post_eval(self.exp.logger_args)
+            exp.logger_handler.pre_eval(exp.logger_args)
+            exp.model.set_experiment_mode("eval")
+            for _ in range(exp.n_eval_epochs):
+                exp.run_epoch()
+            exp.logger_handler.post_eval(exp.logger_args)
             pprint("...loading and checking eval statistics...")
             eval_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "eval_stats.csv")
+                os.path.join(exp.output_dir, "eval_stats.csv")
             )
             self.check_eval_results(eval_stats, num_lms=5)
 
             pprint("checking that evaluation also works with larger mmd.")
-            for lm in self.exp.model.learning_modules:
+            for lm in exp.model.learning_modules:
                 lm.max_match_distance = 0.01
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats, num_lms=5)
 
@@ -1744,22 +1743,22 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test 5 evidence LMs voting works with lower min_lms_match setting."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_3done_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
             # Same as in previous test we make it a bit more difficult during eval
-            for lm in self.exp.model.learning_modules:
+            for lm in exp.model.learning_modules:
                 lm.max_match_distance = 0.01
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_multilm_eval_results(eval_stats, num_lms=5, min_done=3)
 
@@ -1773,12 +1772,12 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_off_object_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
 
-            self.exp.train()
+            exp.train()
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             # Just checking that objects are still recognized correctly when moving off
             # the object.
@@ -1798,10 +1797,10 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                     " overall steps since some steps were off the object.",
                 )
 
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats, num_lms=5)
 
@@ -1841,20 +1840,20 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
-            self.exp.pre_epoch()
-            self.exp.pre_episode()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
+            exp.pre_epoch()
+            exp.pre_episode()
             pprint("...removing all objects...")
-            self.exp.dataset.env._env.remove_all_objects()
-            self.exp.dataloader.reset_agent()
+            exp.dataset.env._env.remove_all_objects()
+            exp.dataloader.reset_agent()
             pprint("...training...")
-            last_step = self.exp.run_episode_steps()
-            self.exp.post_episode(last_step)
-            self.exp.post_epoch()
+            last_step = exp.run_episode_steps()
+            exp.post_episode(last_step)
+            exp.post_epoch()
 
         pprint("...checking run stats...")
-        train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
+        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
         self.assertEqual(
             train_stats["primary_performance"][0],
             "patch_off_object",
@@ -1865,9 +1864,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test that 5LM setup works with BASIC logging and stores correct data."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_basic_logging)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             for key in [
                 "possible_rotations",
                 "possible_locations",
@@ -1876,13 +1875,13 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             ]:
                 self.assertNotIn(
                     key,
-                    self.exp.model.learning_modules[0].buffer.stats.keys(),
+                    exp.model.learning_modules[0].buffer.stats.keys(),
                     f"{key} should not be stored in buffer when using "
                     f"BASIC logging.",
                 )
             self.assertEqual(
                 len(
-                    self.exp.model.learning_modules[0].buffer.stats["possible_matches"]
+                    exp.model.learning_modules[0].buffer.stats["possible_matches"]
                 ),
                 1,
                 "When using basic logging we don't append stats for every step.",
@@ -1895,21 +1894,21 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.no_multithreding_5lm_evidence)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats, num_lms=5)
 
@@ -1920,21 +1919,21 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.maxnn1_5lm_evidence)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats, num_lms=5)
 
@@ -1942,21 +1941,21 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Standard evaluation setup with 5lm and bounded evidence."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.bounded_evidence_5lm_evidence)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats, num_lms=5)
 
@@ -1970,14 +1969,14 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.noise_mixin_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             # self.exp.model.set_experiment_mode("eval")
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             # NOTE: This might fail if the model becomes more noise robust or
             # better able to deal with few incomplete objects in memory.
@@ -1990,10 +1989,10 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 )
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         for i in range(3):
             self.assertEqual(
                 eval_stats["primary_performance"][i],
@@ -2012,14 +2011,14 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.noisy_sensor_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             # self.exp.model.set_experiment_mode("eval")
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             # NOTE: This might fail if the model becomes more noise robust or
             # better able to deal with few incomplete objects in memory.
@@ -2032,10 +2031,10 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 )
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         for i in range(3):
             self.assertEqual(
                 eval_stats["primary_performance"][i],
@@ -2053,7 +2052,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         LM0 can store smaller models at a higher resolution and receives higher
         frequency input from SM0.
         LM1 can store larger models and a lower resolution and receives lower frequency
-        input from SM1. It also recieves input from LM0 once this one has a high
+        input from SM1. It also receives input from LM0 once this one has a high
         confidence hypothesis.
 
         What happens in this experiment:
@@ -2062,12 +2061,12 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         Episode 5: LM0 recognizes cubeSolid (new_object0) and updates its memory. LM1
             reaches a time out and does not update its memory (but has correct mlh).
         Evaluation:
-            In each episde LM0 first recognizes the correct object. Since LM1 gets such
+            In each episode LM0 first recognizes the correct object. Since LM1 gets such
             low frequency input and stores very few points in its models it reaches
             no_match.
 
         NOTE: LM1 usually reaches no_match even if it knows about the object already. I
-        think this is because for the first few observations it does not store feaures
+        think this is because for the first few observations it does not store features
         from LM0 yet. This would be different with a longer exploration phase that
         builds a full model of the object.
 
@@ -2083,21 +2082,21 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.two_lms_heterarchy_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             self.check_hierarchical_lm_train_results(train_stats)
 
-            models = load_models_from_dir(self.exp.output_dir)
+            models = load_models_from_dir(exp.output_dir)
             self.check_hierarchical_models(models)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
             eval_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "eval_stats.csv")
+                os.path.join(exp.output_dir, "eval_stats.csv")
             )
             self.check_hierarchical_lm_eval_results(eval_stats)
 

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -805,9 +805,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
     def test_can_run_evidence_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...evaluating...")
@@ -817,9 +815,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test 3 train and 3 eval epochs with 2 objects and 2 rotations."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_evidence)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             # self.exp.model.set_experiment_mode("eval")
             pprint("...training...")
             self.exp.train()
@@ -862,9 +858,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_evidence)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             self.exp.pre_epoch()
             self.exp.pre_episode()
@@ -888,10 +882,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test logging when moving off the object for some steps during an episode."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_tests_off_object)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
-
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             # First episode will be used to learn object (no_match is triggered before
             # min_steps is reached and the sensor moves off the object). In the second
@@ -974,9 +965,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
     def test_evidence_time_out(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_tests_time_out)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...check time out logging...")
@@ -1039,9 +1028,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         # anymore. Setting min_steps would also avoid this probably.
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_evidence)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             pprint("...training...")
             self.exp.pre_epoch()
@@ -1094,9 +1081,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test same scenario as test_fixed_actions_evidence with uniform poses."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_test_uniform_initial_poses)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...loading and checking train statistics...")
@@ -1119,9 +1104,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test same scenario as test_fixed_actions_evidence with predefined poses."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_possible_poses_evidence)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...loading and checking train statistics...")
@@ -1701,9 +1684,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Standard evaluation setup but using only pose features."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.no_features_evidence)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...loading and checking train statistics...")
@@ -1725,9 +1706,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test 5 evidence LMs voting with two evaluation settings."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
 
@@ -1765,9 +1744,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test 5 evidence LMs voting works with lower min_lms_match setting."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_3done_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
 
@@ -1796,10 +1773,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_off_object_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
-
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
 
             self.exp.train()
@@ -1867,9 +1841,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             self.exp.pre_epoch()
             self.exp.pre_episode()
@@ -1893,9 +1865,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Test that 5LM setup works with BASIC logging and stores correct data."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_basic_logging)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             for key in [
@@ -1925,9 +1895,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.no_multithreding_5lm_evidence)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...loading and checking train statistics...")
@@ -1952,9 +1920,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.maxnn1_5lm_evidence)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...loading and checking train statistics...")
@@ -1976,9 +1942,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """Standard evaluation setup with 5lm and bounded evidence."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.bounded_evidence_5lm_evidence)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...loading and checking train statistics...")
@@ -2006,9 +1970,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.noise_mixin_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             # self.exp.model.set_experiment_mode("eval")
             pprint("...training...")
             self.exp.train()
@@ -2050,9 +2012,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.noisy_sensor_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             # self.exp.model.set_experiment_mode("eval")
             pprint("...training...")
             self.exp.train()
@@ -2123,10 +2083,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.two_lms_heterarchy_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
-
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             train_stats = pd.read_csv(

--- a/tests/unit/graph_building_test.py
+++ b/tests/unit/graph_building_test.py
@@ -225,19 +225,21 @@ class GraphLearningTest(unittest.TestCase):
     def build_and_save_supervised_graph(self):
         pprint("...parsing experiment...")
         config = self.supervised_pre_training_in_habitat
-        with MontySupervisedObjectPretrainingExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontySupervisedObjectPretrainingExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
 
             pprint("...training...")
-            self.exp.train()
+            exp.train()
+        return exp
 
     def build_and_save_supervised_graph_feat(self):
         pprint("...parsing experiment...")
-        with MontySupervisedObjectPretrainingExperiment(self.spth_feat) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontySupervisedObjectPretrainingExperiment(self.spth_feat) as exp:
+            exp.model.set_experiment_mode("train")
 
             pprint("...training...")
-            self.exp.train()
+            exp.train()
+        return exp
 
     def test_get_correct_k_n(self):
         # enough data points sampled, just add 1 to remove self connection
@@ -248,25 +250,25 @@ class GraphLearningTest(unittest.TestCase):
         self.assertEqual(get_correct_k_n(5, 2), None)
 
     def test_can_build_graph_habitat_supervised(self):
-        self.build_and_save_supervised_graph()
+        exp = self.build_and_save_supervised_graph()
         pprint("...Checking graphs...")
 
         self.assertListEqual(
             self.supervised_pre_training_in_habitat[
                 "train_dataloader_args"
             ].object_names,
-            self.exp.model.learning_modules[0].get_all_known_object_ids(),
+            exp.model.learning_modules[0].get_all_known_object_ids(),
             "Object ids of learned objects and graphs in memory.",
         )
-        for graph_id in self.exp.model.learning_modules[0].get_all_known_object_ids():
-            graph = self.exp.model.learning_modules[0].get_graph(
+        for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
+            graph = exp.model.learning_modules[0].get_graph(
                 graph_id, input_channel="first"
             )
             # Make sure that all features that are extracted by the SM are stored in
             # the graph.
             self.check_graph_formatting(
                 graph,
-                features_to_check=self.exp.model.sensor_modules[0].features,
+                features_to_check=exp.model.sensor_modules[0].features,
             )
             self.assertIsNot(
                 graph.edge_index,
@@ -283,36 +285,36 @@ class GraphLearningTest(unittest.TestCase):
         self.build_and_save_supervised_graph()
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.load_habitat_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("checking loaded graphs")
-            for graph_id in self.exp.model.learning_modules[
+            for graph_id in exp.model.learning_modules[
                 0
             ].get_all_known_object_ids():
-                graph = self.exp.model.learning_modules[0].get_graph(
+                graph = exp.model.learning_modules[0].get_graph(
                     graph_id, input_channel="first"
                 )
                 self.check_graph_formatting(
                     graph,
-                    features_to_check=self.exp.model.sensor_modules[0].features,
+                    features_to_check=exp.model.sensor_modules[0].features,
                 )
             pprint("...evaluating on loaded models...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     def test_can_load_disp_graph_for_ppf_matching(self):
         self.build_and_save_supervised_graph()
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.load_habitat_for_ppf)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("checking loaded graphs")
-            for graph_id in self.exp.model.learning_modules[
+            for graph_id in exp.model.learning_modules[
                 0
             ].get_all_known_object_ids():
-                graph = self.exp.model.learning_modules[0].get_graph(
+                graph = exp.model.learning_modules[0].get_graph(
                     graph_id, input_channel="first"
                 )
                 self.check_graph_formatting(
                     graph,
-                    features_to_check=self.exp.model.sensor_modules[0].features,
+                    features_to_check=exp.model.sensor_modules[0].features,
                 )
                 self.assertEqual(
                     graph.edge_attr.shape[1],
@@ -320,23 +322,23 @@ class GraphLearningTest(unittest.TestCase):
                     "Edge attributes don't store 4d PPF (should be added when loading)",
                 )
             pprint("...evaluating on loaded models...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     def test_can_load_disp_graph_for_feature_matching(self):
         self.build_and_save_supervised_graph()
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.load_habitat_for_feat)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("checking loaded graphs")
-            for graph_id in self.exp.model.learning_modules[
+            for graph_id in exp.model.learning_modules[
                 0
             ].get_all_known_object_ids():
-                graph = self.exp.model.learning_modules[0].get_graph(
+                graph = exp.model.learning_modules[0].get_graph(
                     graph_id, input_channel="first"
                 )
                 self.check_graph_formatting(
                     graph,
-                    features_to_check=self.exp.model.sensor_modules[0].features,
+                    features_to_check=exp.model.sensor_modules[0].features,
                 )
                 self.assertEqual(
                     graph.edge_attr.shape[1],
@@ -344,22 +346,22 @@ class GraphLearningTest(unittest.TestCase):
                     "Edge attributes don't store 3d displacements",
                 )
             pprint("...evaluating on loaded models...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     def test_can_extend_and_save_feat_graph(self):
         self.build_and_save_supervised_graph_feat()
         config = copy.deepcopy(self.load_habitat_for_feat)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("checking loaded graphs")
-            for graph_id in self.exp.model.learning_modules[
+            for graph_id in exp.model.learning_modules[
                 0
             ].get_all_known_object_ids():
-                graph = self.exp.model.learning_modules[0].get_graph(
+                graph = exp.model.learning_modules[0].get_graph(
                     graph_id, input_channel="first"
                 )
                 self.check_graph_formatting(
                     graph,
-                    features_to_check=self.exp.model.sensor_modules[0].features,
+                    features_to_check=exp.model.sensor_modules[0].features,
                 )
                 # TODO: not sure if we want this check. Right now it doesn't but I
                 # also don't see a reason why it couldn't in the future.
@@ -369,7 +371,7 @@ class GraphLearningTest(unittest.TestCase):
                     "feature at location graph should not contain edges.",
                 )
             pprint("...evaluating on loaded models...")
-            self.exp.train()
+            exp.train()
 
 
 if __name__ == "__main__":

--- a/tests/unit/graph_building_test.py
+++ b/tests/unit/graph_building_test.py
@@ -224,9 +224,8 @@ class GraphLearningTest(unittest.TestCase):
 
     def build_and_save_supervised_graph(self):
         pprint("...parsing experiment...")
-        self.exp = MontySupervisedObjectPretrainingExperiment()
-        with self.exp:
-            self.exp.setup_experiment(self.supervised_pre_training_in_habitat)
+        config = self.supervised_pre_training_in_habitat
+        with MontySupervisedObjectPretrainingExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
 
             pprint("...training...")
@@ -234,9 +233,7 @@ class GraphLearningTest(unittest.TestCase):
 
     def build_and_save_supervised_graph_feat(self):
         pprint("...parsing experiment...")
-        self.exp = MontySupervisedObjectPretrainingExperiment()
-        with self.exp:
-            self.exp.setup_experiment(self.spth_feat)
+        with MontySupervisedObjectPretrainingExperiment(self.spth_feat) as self.exp:
             self.exp.model.set_experiment_mode("train")
 
             pprint("...training...")
@@ -286,9 +283,7 @@ class GraphLearningTest(unittest.TestCase):
         self.build_and_save_supervised_graph()
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.load_habitat_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("checking loaded graphs")
             for graph_id in self.exp.model.learning_modules[
                 0
@@ -307,9 +302,7 @@ class GraphLearningTest(unittest.TestCase):
         self.build_and_save_supervised_graph()
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.load_habitat_for_ppf)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("checking loaded graphs")
             for graph_id in self.exp.model.learning_modules[
                 0
@@ -333,9 +326,7 @@ class GraphLearningTest(unittest.TestCase):
         self.build_and_save_supervised_graph()
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.load_habitat_for_feat)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("checking loaded graphs")
             for graph_id in self.exp.model.learning_modules[
                 0
@@ -358,9 +349,7 @@ class GraphLearningTest(unittest.TestCase):
     def test_can_extend_and_save_feat_graph(self):
         self.build_and_save_supervised_graph_feat()
         config = copy.deepcopy(self.load_habitat_for_feat)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("checking loaded graphs")
             for graph_id in self.exp.model.learning_modules[
                 0

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -539,15 +539,15 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Code that gets executed after every test."""
         shutil.rmtree(self.output_dir)
 
-    def test_can_set_up(self):
-        """Canary for setup_experiment.
+    def test_can_initialize(self):
+        """Canary to confirm we can initialize an experiment.
 
         This could be part of the setUp method, but it's easier to debug if something
         breaks the setup_experiment method if there's a separate test for it.
         """
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with MontyObjectRecognitionExperiment(base_config) as exp:
+        with MontyObjectRecognitionExperiment(base_config):
             pass
 
     def test_can_run_train_episode(self):
@@ -675,7 +675,6 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_disp)
         with MontyObjectRecognitionExperiment(config) as exp:
-            # exp.model.set_experiment_mode("eval")
             pprint("...training...")
             exp.train()
             pprint("...loading and checking train statistics...")
@@ -697,7 +696,6 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_ppf)
         with MontyObjectRecognitionExperiment(config) as exp:
-            # exp.model.set_experiment_mode("eval")
             pprint("...training...")
             exp.train()
             pprint("...loading and checking train statistics...")
@@ -752,14 +750,14 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.output_dir,
             "2",  # latest checkpoint
         )
-        with MontyObjectRecognitionExperiment(eval_cfg_1) as self.eval_exp_1:
+        with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
             # TODO: update so it only runs one episode
             pprint("...evaluating (first time) ...")
-            self.eval_exp_1.evaluate()
+            eval_exp_1.evaluate()
 
         # Create detailed follow up experiment
         eval_cfg_2 = create_eval_episode_config(
-            parent_config=self.eval_exp_1.config,  # already converted to dict in exp
+            parent_config=eval_exp_1.config,  # already converted to dict in exp
             parent_config_name="eval_cfg_1",
             episode=0,
             update_run_dir=False,  # we are running direct; no run.py
@@ -784,18 +782,18 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         )
 
         # If we made it this far, we have the correct parameters. Now run the experiment
-        with MontyObjectRecognitionExperiment(eval_cfg_2) as self.eval_exp_2:
+        with MontyObjectRecognitionExperiment(eval_cfg_2) as eval_exp_2:
             pprint("...evaluating (second time) ...")
-            self.eval_exp_2.evaluate()
+            eval_exp_2.evaluate()
 
         ###
         # Check that basic csv stats are the same
         ###
         original_eval_stats_file = os.path.join(
-            self.eval_exp_1.output_dir, "eval_stats.csv"
+            eval_exp_1.output_dir, "eval_stats.csv"
         )
         new_eval_stats_file = os.path.join(
-            self.eval_exp_1.output_dir, "eval_episode_0_rerun", "eval_stats.csv"
+            eval_exp_1.output_dir, "eval_episode_0_rerun", "eval_stats.csv"
         )
 
         original_stats = pd.read_csv(original_eval_stats_file)
@@ -812,10 +810,10 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
 
         # TODO: Once json file i/o code has been updated, only load single episode
         original_json_file = os.path.join(
-            self.eval_exp_1.output_dir, "detailed_run_stats.json"
+            eval_exp_1.output_dir, "detailed_run_stats.json"
         )
         new_json_file = os.path.join(
-            self.eval_exp_1.output_dir,
+            eval_exp_1.output_dir,
             "eval_episode_0_rerun",
             "detailed_run_stats.json",
         )
@@ -851,13 +849,13 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.output_dir,
             "2",  # latest checkpoint
         )
-        with MontyObjectRecognitionExperiment(eval_cfg_1) as self.eval_exp_1:
+        with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
             pprint("...evaluating (first time) ...")
-            self.eval_exp_1.evaluate()
+            eval_exp_1.evaluate()
 
         # Create detailed follow up experiment
         eval_cfg_2 = create_eval_config_multiple_episodes(
-            parent_config=self.eval_exp_1.config,  # already converted to dict in exp
+            parent_config=eval_exp_1.config,  # already converted to dict in exp
             parent_config_name="eval_cfg_1",
             episodes=[
                 0,
@@ -891,18 +889,18 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         )
 
         # If we made it this far, we have the correct parameters. Now run the experiment
-        with MontyObjectRecognitionExperiment(eval_cfg_2) as self.eval_exp_2:
+        with MontyObjectRecognitionExperiment(eval_cfg_2) as eval_exp_2:
             pprint("...evaluating (second time) ...")
-            self.eval_exp_2.evaluate()
+            eval_exp_2.evaluate()
 
         ###
         # Check that basic csv stats are the same
         ###
         original_eval_stats_file = os.path.join(
-            self.eval_exp_1.output_dir, "eval_stats.csv"
+            eval_exp_1.output_dir, "eval_stats.csv"
         )
         new_eval_stats_file = os.path.join(
-            self.eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
+            eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
         )
 
         original_stats = pd.read_csv(original_eval_stats_file)
@@ -919,10 +917,10 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
 
         # TODO: Once json file i/o code has been updated, only load single episode
         original_json_file = os.path.join(
-            self.eval_exp_1.output_dir, "detailed_run_stats.json"
+            eval_exp_1.output_dir, "detailed_run_stats.json"
         )
         new_json_file = os.path.join(
-            self.eval_exp_1.output_dir,
+            eval_exp_1.output_dir,
             "eval_rerun_episodes",
             "detailed_run_stats.json",
         )
@@ -959,13 +957,13 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.output_dir,
             "2",  # latest checkpoint
         )
-        with MontyObjectRecognitionExperiment(eval_cfg_1) as self.eval_exp_1:
+        with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
             pprint("...evaluating (first time) ...")
-            self.eval_exp_1.evaluate()
+            eval_exp_1.evaluate()
 
         # Create detailed follow up experiment
         eval_cfg_2 = create_eval_config_multiple_episodes(
-            parent_config=self.eval_exp_1.config,  # already converted to dict in exp
+            parent_config=eval_exp_1.config,  # already converted to dict in exp
             parent_config_name="eval_cfg_1",
             episodes=[0],
             update_run_dir=False,  # we are running direct; no run.py
@@ -982,18 +980,18 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         )
 
         # If we made it this far, we have the correct parameters. Now run the experiment
-        with MontyObjectRecognitionExperiment(eval_cfg_2) as self.eval_exp_2:
+        with MontyObjectRecognitionExperiment(eval_cfg_2) as eval_exp_2:
             pprint("...evaluating (second time) ...")
-            self.eval_exp_2.evaluate()
+            eval_exp_2.evaluate()
 
         ###
         # Check that basic csv stats are the same
         ###
         original_eval_stats_file = os.path.join(
-            self.eval_exp_1.output_dir, "eval_stats.csv"
+            eval_exp_1.output_dir, "eval_stats.csv"
         )
         new_eval_stats_file = os.path.join(
-            self.eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
+            eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
         )
 
         original_stats = pd.read_csv(original_eval_stats_file)
@@ -1010,10 +1008,10 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
 
         # TODO: Once json file i/o code has been updated, only load single episode
         original_json_file = os.path.join(
-            self.eval_exp_1.output_dir, "detailed_run_stats.json"
+            eval_exp_1.output_dir, "detailed_run_stats.json"
         )
         new_json_file = os.path.join(
-            self.eval_exp_1.output_dir,
+            eval_exp_1.output_dir,
             "eval_rerun_episodes",
             "detailed_run_stats.json",
         )
@@ -1040,7 +1038,6 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_ppf)
         with MontyObjectRecognitionExperiment(config) as exp:
-            # exp.model.set_experiment_mode("eval")
             pprint("...training...")
             exp.train()
 
@@ -1081,7 +1078,6 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         with MontyObjectRecognitionExperiment(config) as exp:
             exp.model.set_experiment_mode("train")
             pprint("...training...")
-            # exp.train()
             for e in range(6):
                 if e % 2 == 0:
                     exp.pre_epoch()

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -547,37 +547,37 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with MontyObjectRecognitionExperiment(base_config) as self.exp:
+        with MontyObjectRecognitionExperiment(base_config) as exp:
             pass
 
     def test_can_run_train_episode(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with MontyObjectRecognitionExperiment(base_config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontyObjectRecognitionExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("train")
             pprint("...training...")
-            self.exp.pre_epoch()
-            self.exp.run_episode()
+            exp.pre_epoch()
+            exp.run_episode()
 
     def test_right_data_in_buffer(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with MontyObjectRecognitionExperiment(base_config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontyObjectRecognitionExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("train")
             pprint("...training...")
-            self.exp.pre_epoch()
-            self.exp.pre_episode()
-            for step, observation in enumerate(self.exp.dataloader):
-                self.exp.model.step(observation)
+            exp.pre_epoch()
+            exp.pre_episode()
+            for step, observation in enumerate(exp.dataloader):
+                exp.model.step(observation)
                 self.assertEqual(
                     step + 1,
-                    len(self.exp.model.learning_modules[0].buffer),
+                    len(exp.model.learning_modules[0].buffer),
                     "buffer does not contain the right amount of elements.",
                 )
                 self.assertEqual(
                     step + 1,
                     len(
-                        self.exp.model.learning_modules[
+                        exp.model.learning_modules[
                             0
                         ].buffer.get_all_locations_on_object(input_channel="first")
                     ),
@@ -586,7 +586,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
                 if step == 0:
                     self.assertListEqual(
                         list(
-                            self.exp.model.learning_modules[
+                            exp.model.learning_modules[
                                 0
                             ].buffer.get_nth_displacement(0, input_channel="first")
                         ),
@@ -596,15 +596,15 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
                 self.assertEqual(
                     step + 1,
                     len(
-                        self.exp.model.learning_modules[0].buffer.displacements[
+                        exp.model.learning_modules[0].buffer.displacements[
                             "patch"
                         ]["displacement"]
                     ),
                     "buffer does not contain the right amount of displacements.",
                 )
                 self.assertSetEqual(
-                    set(self.exp.model.sensor_modules[0].features),
-                    set(self.exp.model.learning_modules[0].buffer[-1]["patch"].keys()),
+                    set(exp.model.sensor_modules[0].features),
+                    set(exp.model.learning_modules[0].buffer[-1]["patch"].keys()),
                     "buffer doesn't contain all features required for matching.",
                 )
                 if step == 3:
@@ -613,47 +613,47 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_can_run_eval_episode(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with MontyObjectRecognitionExperiment(base_config) as self.exp:
-            self.exp.model.set_experiment_mode("eval")
+        with MontyObjectRecognitionExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("eval")
             pprint("...training...")
-            self.exp.pre_epoch()
-            self.exp.run_episode()
+            exp.pre_epoch()
+            exp.run_episode()
 
     def test_can_run_eval_episode_with_surface_agent(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.surface_agent_eval_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("eval")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("eval")
             pprint("...training...")
-            self.exp.pre_epoch()
-            self.exp.run_episode()
+            exp.pre_epoch()
+            exp.run_episode()
 
     def test_can_run_ppf_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.ppf_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     def test_can_run_disp_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.disp_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     def test_can_run_feature_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     def test_fixed_actions_disp(self):
         """Runs three test episodes on capsule3DSolid and cubeSolid.
@@ -674,21 +674,21 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_disp)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            # self.exp.model.set_experiment_mode("eval")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            # exp.model.set_experiment_mode("eval")
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
@@ -696,22 +696,22 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Like test_fixed_actions_disp but using point pair features for matching."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_ppf)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            # self.exp.model.set_experiment_mode("eval")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            # exp.model.set_experiment_mode("eval")
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
 
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
@@ -719,37 +719,37 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Like test_fixed_actions_disp but using point pair features for matching."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
 
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
     def test_reproduce_single_episode(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
 
         # Create a separate experiment for evaluation to mimic the us case of re-running
         # eval episodes from a pretrained model
         eval_cfg_1 = copy.deepcopy(config)
         eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
-            self.exp.output_dir,
+            exp.output_dir,
             "2",  # latest checkpoint
         )
         with MontyObjectRecognitionExperiment(eval_cfg_1) as self.eval_exp_1:
@@ -840,15 +840,15 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_reproduce_multiple_episodes(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
 
         # Create a separate experiment for evaluation to mimic the us case of re-running
         # eval episodes from a pretrained model
         eval_cfg_1 = copy.deepcopy(config)
         eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
-            self.exp.output_dir,
+            exp.output_dir,
             "2",  # latest checkpoint
         )
         with MontyObjectRecognitionExperiment(eval_cfg_1) as self.eval_exp_1:
@@ -948,15 +948,15 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Verify create_eval_config_multiple_episodes for a single episode."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
 
         # Create a separate experiment for evaluation to mimic the us case of re-running
         # eval episodes from a pretrained model
         eval_cfg_1 = copy.deepcopy(config)
         eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
-            self.exp.output_dir,
+            exp.output_dir,
             "2",  # latest checkpoint
         )
         with MontyObjectRecognitionExperiment(eval_cfg_1) as self.eval_exp_1:
@@ -1039,10 +1039,10 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         # Move this to graph_building_test.py?
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_ppf)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            # self.exp.model.set_experiment_mode("eval")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            # exp.model.set_experiment_mode("eval")
             pprint("...training...")
-            self.exp.train()
+            exp.train()
 
         # We are training for 3 epochs by default, load most recent indexing from 0
         print("Loading a saved checkpoint")
@@ -1051,11 +1051,11 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             config["logging_config"].output_dir,
             "2",  # latest checkpoint
         )
-        with MontyObjectRecognitionExperiment(cfg2) as self.exp2:
-            graph_memory_1 = self.exp.model.learning_modules[
+        with MontyObjectRecognitionExperiment(cfg2) as exp2:
+            graph_memory_1 = exp.model.learning_modules[
                 0
             ].graph_memory.get_all_models_in_memory()
-            graph_memory_2 = self.exp2.model.learning_modules[
+            graph_memory_2 = exp2.model.learning_modules[
                 0
             ].graph_memory.get_all_models_in_memory()
 
@@ -1078,28 +1078,28 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_time_out)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
             pprint("...training...")
-            # self.exp.train()
+            # exp.train()
             for e in range(6):
                 if e % 2 == 0:
-                    self.exp.pre_epoch()
+                    exp.pre_epoch()
                 if e == 2:
                     # Set max steps low & raise mmd to get pose time outs
-                    self.exp.max_train_steps = 3
-                    self.exp.model.learning_modules[0].max_match_distance = 0.1
+                    exp.max_train_steps = 3
+                    exp.model.learning_modules[0].max_match_distance = 0.1
                 if e == 4:
                     # set curvature threshold high to get time outs
-                    self.exp.model.learning_modules[0].tolerances["patch"][
+                    exp.model.learning_modules[0].tolerances["patch"][
                         "principal_curvatures_log"
                     ] = [10, 10]
-                self.exp.run_episode()
+                exp.run_episode()
                 if e % 2 == 1:
-                    self.exp.post_epoch()
+                    exp.post_epoch()
 
         pprint("...check time out logging...")
-        train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
+        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
         self.assertEqual(
             train_stats["primary_performance"][2],
             "pose_time_out",
@@ -1141,22 +1141,22 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         # anymore. Setting min_steps would also avoid this probably.
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
             pprint("...training...")
-            self.exp.pre_epoch()
+            exp.pre_epoch()
             # Overwrite target with a false name to test confused logging.
             for e in range(4):
-                self.exp.pre_episode()
-                self.exp.model.primary_target = str(e)
-                for lm in self.exp.model.learning_modules:
+                exp.pre_episode()
+                exp.model.primary_target = str(e)
+                for lm in exp.model.learning_modules:
                     lm.primary_target = str(e)
-                last_step = self.exp.run_episode_steps()
-                self.exp.post_episode(last_step)
-            self.exp.post_epoch()
+                last_step = exp.run_episode_steps()
+                exp.post_episode(last_step)
+            exp.post_epoch()
 
         pprint("...checking run stats...")
-        train_stats = pd.read_csv(os.path.join(self.exp.output_dir, "train_stats.csv"))
+        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
         for i in [0, 1]:
             self.assertEqual(
                 train_stats["primary_performance"][i],
@@ -1195,7 +1195,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         # to logging of observations when off the object
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_off_object)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
             # First episode will be used to learn object (no_match is triggered before
             # min_steps is reached and the sensor moves off the object). In the second
@@ -1204,15 +1204,15 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             # does not take place before then because when off the object, matching
             # steps are no longer incremented, while it is an unfamiliar part of
             # the object that we return to
-            self.exp.train()
+            exp.train()
             self.assertEqual(
                 len(
-                    self.exp.model.learning_modules[
+                    exp.model.learning_modules[
                         0
                     ].buffer.get_all_locations_on_object(input_channel="patch")
                 ),
                 len(
-                    self.exp.model.learning_modules[
+                    exp.model.learning_modules[
                         0
                     ].buffer.get_all_features_on_object()["patch"]["pose_vectors"]
                 ),
@@ -1220,12 +1220,12 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             )
             self.assertEqual(
                 sum(
-                    self.exp.model.learning_modules[
+                    exp.model.learning_modules[
                         0
                     ].buffer.get_all_features_on_object()["patch"]["on_object"]
                 ),
                 len(
-                    self.exp.model.learning_modules[
+                    exp.model.learning_modules[
                         0
                     ].buffer.get_all_features_on_object()["patch"]["on_object"]
                 ),
@@ -1235,12 +1235,12 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             # there should only be 8 observations stored for the 12 matching steps
             # and all of them should be on the object.
             num_matching_steps = len(
-                self.exp.model.learning_modules[0].buffer.stats["possible_matches"]
+                exp.model.learning_modules[0].buffer.stats["possible_matches"]
             )
             self.assertEqual(
                 num_matching_steps,
                 sum(
-                    self.exp.model.learning_modules[0].buffer.features["patch"][
+                    exp.model.learning_modules[0].buffer.features["patch"][
                         "on_object"
                     ][:num_matching_steps]
                 ),
@@ -1251,15 +1251,15 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_detailed_logging(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_off_object)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading stats files...")
         train_stats, eval_stats, detailed_stats, lm_models = load_stats(
-            self.exp.output_dir,
+            exp.output_dir,
             load_train=True,
             load_eval=True,
             load_detailed=True,
@@ -1308,21 +1308,21 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Test same scenario as test_fixed_actions_feat with uniform poses."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feat_test_uniform_initial_poses)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...loading and checking train statistics...")
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         self.check_eval_results(eval_stats)
 
     def get_gm_with_fake_object(self):
@@ -1633,20 +1633,20 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Test 5 displacement LMs voting with two evaluation settings."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.ppf_displacement_5lm_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         self.check_multilm_eval_results(
             eval_stats, num_lms=5, min_done=3, num_episodes=1
         )
@@ -1655,12 +1655,12 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Test 5 feature LMs voting with two evaluation settings."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_5lm_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
 
             train_stats = pd.read_csv(
-                os.path.join(self.exp.output_dir, "train_stats.csv")
+                os.path.join(exp.output_dir, "train_stats.csv")
             )
             # The following check is brittle and depends on sensor arrangement. Leaving
             # the rest of the test intact to detect run failures, but disabling checking
@@ -1668,10 +1668,10 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             # self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
 
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(self.exp.output_dir, "eval_stats.csv"))
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         # Just testing 1 episode here. Somehow the second rotation doesn't get
         # recognized. Probably just some parameter setting due to flaws in old
         # LM but didn't want to dig too deep into that for now.

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -547,16 +547,13 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
+        with MontyObjectRecognitionExperiment(base_config) as self.exp:
+            pass
 
     def test_can_run_train_episode(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
+        with MontyObjectRecognitionExperiment(base_config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             pprint("...training...")
             self.exp.pre_epoch()
@@ -565,9 +562,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_right_data_in_buffer(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
+        with MontyObjectRecognitionExperiment(base_config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             pprint("...training...")
             self.exp.pre_epoch()
@@ -618,9 +613,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_can_run_eval_episode(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
+        with MontyObjectRecognitionExperiment(base_config) as self.exp:
             self.exp.model.set_experiment_mode("eval")
             pprint("...training...")
             self.exp.pre_epoch()
@@ -629,9 +622,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_can_run_eval_episode_with_surface_agent(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.surface_agent_eval_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("eval")
             pprint("...training...")
             self.exp.pre_epoch()
@@ -640,9 +631,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_can_run_ppf_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.ppf_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...evaluating...")
@@ -651,9 +640,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_can_run_disp_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.disp_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...evaluating...")
@@ -662,9 +649,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_can_run_feature_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...evaluating...")
@@ -689,9 +674,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_disp)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             # self.exp.model.set_experiment_mode("eval")
             pprint("...training...")
             self.exp.train()
@@ -713,9 +696,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Like test_fixed_actions_disp but using point pair features for matching."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_ppf)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             # self.exp.model.set_experiment_mode("eval")
             pprint("...training...")
             self.exp.train()
@@ -738,9 +719,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Like test_fixed_actions_disp but using point pair features for matching."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...loading and checking train statistics...")
@@ -762,10 +741,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_reproduce_single_episode(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
-
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
 
@@ -776,11 +752,8 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             self.exp.output_dir,
             "2",  # latest checkpoint
         )
-        self.eval_exp_1 = MontyObjectRecognitionExperiment()
-        with self.eval_exp_1:
-            self.eval_exp_1.setup_experiment(eval_cfg_1)
+        with MontyObjectRecognitionExperiment(eval_cfg_1) as self.eval_exp_1:
             # TODO: update so it only runs one episode
-
             pprint("...evaluating (first time) ...")
             self.eval_exp_1.evaluate()
 
@@ -811,10 +784,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         )
 
         # If we made it this far, we have the correct parameters. Now run the experiment
-        self.eval_exp_2 = MontyObjectRecognitionExperiment()
-        with self.eval_exp_2:
-            self.eval_exp_2.setup_experiment(eval_cfg_2)
-
+        with MontyObjectRecognitionExperiment(eval_cfg_2) as self.eval_exp_2:
             pprint("...evaluating (second time) ...")
             self.eval_exp_2.evaluate()
 
@@ -870,10 +840,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_reproduce_multiple_episodes(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
-
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
 
@@ -884,10 +851,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             self.exp.output_dir,
             "2",  # latest checkpoint
         )
-        self.eval_exp_1 = MontyObjectRecognitionExperiment()
-        with self.eval_exp_1:
-            self.eval_exp_1.setup_experiment(eval_cfg_1)
-
+        with MontyObjectRecognitionExperiment(eval_cfg_1) as self.eval_exp_1:
             pprint("...evaluating (first time) ...")
             self.eval_exp_1.evaluate()
 
@@ -927,10 +891,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         )
 
         # If we made it this far, we have the correct parameters. Now run the experiment
-        self.eval_exp_2 = MontyObjectRecognitionExperiment()
-        with self.eval_exp_2:
-            self.eval_exp_2.setup_experiment(eval_cfg_2)
-
+        with MontyObjectRecognitionExperiment(eval_cfg_2) as self.eval_exp_2:
             pprint("...evaluating (second time) ...")
             self.eval_exp_2.evaluate()
 
@@ -987,10 +948,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Verify create_eval_config_multiple_episodes for a single episode."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
-
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
 
@@ -1001,10 +959,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             self.exp.output_dir,
             "2",  # latest checkpoint
         )
-        self.eval_exp_1 = MontyObjectRecognitionExperiment()
-        with self.eval_exp_1:
-            self.eval_exp_1.setup_experiment(eval_cfg_1)
-
+        with MontyObjectRecognitionExperiment(eval_cfg_1) as self.eval_exp_1:
             pprint("...evaluating (first time) ...")
             self.eval_exp_1.evaluate()
 
@@ -1027,10 +982,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         )
 
         # If we made it this far, we have the correct parameters. Now run the experiment
-        self.eval_exp_2 = MontyObjectRecognitionExperiment()
-        with self.eval_exp_2:
-            self.eval_exp_2.setup_experiment(eval_cfg_2)
-
+        with MontyObjectRecognitionExperiment(eval_cfg_2) as self.eval_exp_2:
             pprint("...evaluating (second time) ...")
             self.eval_exp_2.evaluate()
 
@@ -1087,9 +1039,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         # Move this to graph_building_test.py?
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_ppf)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             # self.exp.model.set_experiment_mode("eval")
             pprint("...training...")
             self.exp.train()
@@ -1101,10 +1051,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             config["logging_config"].output_dir,
             "2",  # latest checkpoint
         )
-        self.exp2 = MontyObjectRecognitionExperiment()
-        with self.exp2:
-            self.exp2.setup_experiment(cfg2)
-
+        with MontyObjectRecognitionExperiment(cfg2) as self.exp2:
             graph_memory_1 = self.exp.model.learning_modules[
                 0
             ].graph_memory.get_all_models_in_memory()
@@ -1131,9 +1078,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_time_out)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             pprint("...training...")
             # self.exp.train()
@@ -1196,9 +1141,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         # anymore. Setting min_steps would also avoid this probably.
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             pprint("...training...")
             self.exp.pre_epoch()
@@ -1252,9 +1195,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         # to logging of observations when off the object
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_off_object)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             # First episode will be used to learn object (no_match is triggered before
             # min_steps is reached and the sensor moves off the object). In the second
@@ -1310,9 +1251,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
     def test_detailed_logging(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_off_object)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...evaluating...")
@@ -1369,9 +1308,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Test same scenario as test_fixed_actions_feat with uniform poses."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feat_test_uniform_initial_poses)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...loading and checking train statistics...")
@@ -1696,9 +1633,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Test 5 displacement LMs voting with two evaluation settings."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.ppf_displacement_5lm_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
 
@@ -1720,9 +1655,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Test 5 feature LMs voting with two evaluation settings."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_5lm_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
 

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -451,9 +451,7 @@ class PolicyTest(unittest.TestCase):
     def test_can_run_informed_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.base_dist_agent_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...evaluating...")
@@ -463,9 +461,7 @@ class PolicyTest(unittest.TestCase):
     def test_can_run_spiral_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.spiral_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             # TODO: test that no two locations are the same
             self.exp.train()
@@ -476,9 +472,7 @@ class PolicyTest(unittest.TestCase):
     def test_can_run_dist_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.dist_agent_hypo_driven_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...evaluating...")
@@ -488,9 +482,7 @@ class PolicyTest(unittest.TestCase):
     def test_can_run_surface_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.base_surf_agent_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...evaluating...")
@@ -500,9 +492,7 @@ class PolicyTest(unittest.TestCase):
     def test_can_run_curv_informed_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.curv_informed_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...evaluating...")
@@ -512,9 +502,7 @@ class PolicyTest(unittest.TestCase):
     def test_can_run_surf_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.surf_agent_hypo_driven_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...evaluating...")
@@ -524,9 +512,7 @@ class PolicyTest(unittest.TestCase):
     def test_can_run_multi_lm_dist_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.dist_agent_hypo_driven_multi_lm_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             pprint("...evaluating...")
@@ -596,9 +582,7 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_dist_agent_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             self.exp.pre_epoch()
             self.exp.pre_episode()
@@ -647,9 +631,7 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_surf_agent_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             self.exp.pre_epoch()
             self.exp.pre_episode()
@@ -703,9 +685,7 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_multi_object_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
 
@@ -767,9 +747,7 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_action_distant_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             pprint("...training...")
             self.exp.pre_epoch()
@@ -879,9 +857,7 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_action_surface_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             pprint("...training...")
             self.exp.pre_epoch()
@@ -918,9 +894,7 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.rotated_cube_view_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             pprint("...training...")
             self.exp.pre_epoch()

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -451,72 +451,72 @@ class PolicyTest(unittest.TestCase):
     def test_can_run_informed_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.base_dist_agent_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_spiral_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.spiral_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
             # TODO: test that no two locations are the same
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_dist_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.dist_agent_hypo_driven_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_surface_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.base_surf_agent_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_curv_informed_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.curv_informed_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_surf_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.surf_agent_hypo_driven_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_multi_lm_dist_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.dist_agent_hypo_driven_multi_lm_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
     # ==== MORE INVOLVED TESTS OF ACTION POLICIES ====
 
@@ -582,17 +582,17 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_dist_agent_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
-            self.exp.pre_epoch()
-            self.exp.pre_episode()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
+            exp.pre_epoch()
+            exp.pre_episode()
 
             pprint("...stepping through observations...")
 
             # Check the initial view
-            observation = next(self.exp.dataloader)
+            observation = next(exp.dataloader)
             # TODO M remove the following train-wreck during refactor
-            view = observation[self.exp.model.motor_system.agent_id]["view_finder"]
+            view = observation[exp.model.motor_system.agent_id]["view_finder"]
             semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
             perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
 
@@ -631,22 +631,22 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_surf_agent_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
-            self.exp.pre_epoch()
-            self.exp.pre_episode()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
+            exp.pre_epoch()
+            exp.pre_episode()
 
             pprint("...stepping through observations...")
 
             # Get a first step to allow the surface agent to touch the object
-            observation_pre_touch = next(self.exp.dataloader)
-            self.exp.model.step(observation_pre_touch)
+            observation_pre_touch = next(exp.dataloader)
+            exp.model.step(observation_pre_touch)
 
             # Check initial view post touch-attempt
-            observation_post_touch = next(self.exp.dataloader)
+            observation_post_touch = next(exp.dataloader)
 
             # TODO M remove the following train-wreck during refactor
-            view = observation_post_touch[self.exp.model.motor_system.agent_id][
+            view = observation_post_touch[exp.model.motor_system.agent_id][
                 "view_finder"
             ]
             dict_config = config_to_dict(config)
@@ -685,21 +685,21 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_multi_object_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
 
             # Manually go through evaluation (i.e. methods in .evaluate()
             # and run_epoch())
-            self.exp.model.set_experiment_mode("eval")
-            self.exp.pre_epoch()
-            self.exp.pre_episode()
+            exp.model.set_experiment_mode("eval")
+            exp.pre_epoch()
+            exp.pre_episode()
 
             pprint("...stepping through observations...")
             # Check the initial view
-            observation = next(self.exp.dataloader)
+            observation = next(exp.dataloader)
             # TODO M remove the following train-wreck during refactor
-            view = observation[self.exp.model.motor_system.agent_id]["view_finder"]
+            view = observation[exp.model.motor_system.agent_id]["view_finder"]
             semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
             perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
 
@@ -747,24 +747,24 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_action_distant_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
             pprint("...training...")
-            self.exp.pre_epoch()
+            exp.pre_epoch()
 
             # Only do a single episode
-            self.exp.pre_episode()
+            exp.pre_episode()
 
             pprint("...stepping through observations...")
             # Manually step through part of run_episode function
-            for loader_step, observation in enumerate(self.exp.dataloader):
-                self.exp.model.step(observation)
+            for loader_step, observation in enumerate(exp.dataloader):
+                exp.model.step(observation)
 
-                last_action = self.exp.model.motor_system.last_action()
+                last_action = exp.model.motor_system.last_action()
 
                 if loader_step == 3:
                     stored_action = last_action
-                    assert not self.exp.model.learning_modules[
+                    assert not exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), "Should be off object"
 
@@ -841,7 +841,7 @@ class PolicyTest(unittest.TestCase):
                             -stored_action.forward_distance,
                             should_have_moved_back,
                         )
-                    assert self.exp.model.learning_modules[
+                    assert exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), "Should be back on object"
                     break  # Don't go into exploratory mode
@@ -857,28 +857,28 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_action_surface_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
             pprint("...training...")
-            self.exp.pre_epoch()
+            exp.pre_epoch()
 
             # Only do a single episode
-            self.exp.pre_episode()
+            exp.pre_episode()
 
             pprint("...stepping through observations...")
             # Take several steps in a fixed direction until we fall off the object, then
             # ensure we get back on to it
-            for loader_step, observation in enumerate(self.exp.dataloader):
-                self.exp.model.step(observation)
+            for loader_step, observation in enumerate(exp.dataloader):
+                exp.model.step(observation)
 
                 if loader_step == 24:  # Last step we take before getting back onto the
                     # object
-                    assert not self.exp.model.learning_modules[
+                    assert not exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), "Should be off object"
 
                 if loader_step == 25:
-                    assert self.exp.model.learning_modules[
+                    assert exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), "Should be back on object"
                     break  # Don't go into exploratory mode
@@ -894,22 +894,22 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.rotated_cube_view_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
             pprint("...training...")
-            self.exp.pre_epoch()
-            self.exp.pre_episode()
+            exp.pre_epoch()
+            exp.pre_episode()
 
             pprint("...stepping through observations...")
-            for loader_step, observation in enumerate(self.exp.dataloader):
-                self.exp.model.step(observation)
-                self.exp.post_step(loader_step, observation)
+            for loader_step, observation in enumerate(exp.dataloader):
+                exp.model.step(observation)
+                exp.post_step(loader_step, observation)
 
                 if loader_step == 3:  # Surface agent should have re-oriented
                     break
 
             # Most recently observed point-normal sent to the learning module
-            current_pose = self.exp.model.learning_modules[0].buffer.get_current_pose(
+            current_pose = exp.model.learning_modules[0].buffer.get_current_pose(
                 input_channel="first"
             )
 
@@ -917,7 +917,7 @@ class PolicyTest(unittest.TestCase):
             # current orientation
             agent_direction = np.array(
                 hab_utils.quat_rotate_vector(
-                    self.exp.model.motor_system.state["agent_id_0"]["rotation"],
+                    exp.model.motor_system.state["agent_id_0"]["rotation"],
                     [
                         0,
                         0,

--- a/tests/unit/profile_experiment_mixin_test.py
+++ b/tests/unit/profile_experiment_mixin_test.py
@@ -127,8 +127,7 @@ class ProfileExperimentMixinTest(TestCase):
     def test_run_episode_is_profiled(self) -> None:
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with ProfiledExperiment() as exp:
-            exp.setup_experiment(base_config)
+        with ProfiledExperiment(base_config) as exp:
             pprint("...training...")
             exp.model.set_experiment_mode("train")
             exp.dataloader = exp.train_dataloader
@@ -143,8 +142,7 @@ class ProfileExperimentMixinTest(TestCase):
     def test_run_train_epoch_is_profiled(self) -> None:
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with ProfiledExperiment() as exp:
-            exp.setup_experiment(base_config)
+        with ProfiledExperiment(base_config) as exp:
             exp.model.set_experiment_mode("train")
             exp.run_epoch()
 
@@ -159,8 +157,7 @@ class ProfileExperimentMixinTest(TestCase):
     def test_run_eval_epoch_is_profiled(self) -> None:
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        with ProfiledExperiment() as exp:
-            exp.setup_experiment(base_config)
+        with ProfiledExperiment(base_config) as exp:
             exp.model.set_experiment_mode("eval")
             exp.run_epoch()
 

--- a/tests/unit/run_parallel_test.py
+++ b/tests/unit/run_parallel_test.py
@@ -170,9 +170,8 @@ class RunParallelTest(unittest.TestCase):
         # Run training like normal in serial
         ###
         pprint("...Setting up serial experiment...")
-        self.exp = MontySupervisedObjectPretrainingExperiment()
-        with self.exp:
-            self.exp.setup_experiment(self.supervised_pre_training)
+        config = self.supervised_pre_training
+        with MontySupervisedObjectPretrainingExperiment(config) as self.exp:
             self.exp.model.set_experiment_mode("train")
 
             pprint("...Training in serial...")
@@ -241,10 +240,7 @@ class RunParallelTest(unittest.TestCase):
 
         # In serial like normal
         pprint("...Setting up serial experiment...")
-        self.eval_exp = MontyObjectRecognitionExperiment()
-        with self.eval_exp:
-            self.eval_exp.setup_experiment(self.eval_config)
-
+        with MontyObjectRecognitionExperiment(self.eval_config) as self.eval_exp:
             pprint("...Evaluating in serial...")
             self.eval_exp.evaluate()
 
@@ -292,10 +288,7 @@ class RunParallelTest(unittest.TestCase):
 
         # In serial like normal
         pprint("...Setting up serial experiment...")
-        self.eval_exp_lt = MontyObjectRecognitionExperiment()
-        with self.eval_exp_lt:
-            self.eval_exp_lt.setup_experiment(self.eval_config_lt)
-
+        with MontyObjectRecognitionExperiment(self.eval_config_lt) as self.eval_exp_lt:
             pprint("...Evaluating in serial...")
             self.eval_exp_lt.evaluate()
 
@@ -332,10 +325,7 @@ class RunParallelTest(unittest.TestCase):
 
         # In serial like normal
         pprint("...Setting up serial experiment...")
-        self.eval_exp_gt = MontyObjectRecognitionExperiment()
-        with self.eval_exp_gt:
-            self.eval_exp_gt.setup_experiment(self.eval_config_gt)
-
+        with MontyObjectRecognitionExperiment(self.eval_config_gt) as self.eval_exp_gt:
             pprint("...Evaluating in serial...")
             self.eval_exp_gt.evaluate()
 

--- a/tests/unit/run_parallel_test.py
+++ b/tests/unit/run_parallel_test.py
@@ -240,9 +240,9 @@ class RunParallelTest(unittest.TestCase):
 
         # In serial like normal
         pprint("...Setting up serial experiment...")
-        with MontyObjectRecognitionExperiment(self.eval_config) as self.eval_exp:
+        with MontyObjectRecognitionExperiment(self.eval_config) as eval_exp:
             pprint("...Evaluating in serial...")
-            self.eval_exp.evaluate()
+            eval_exp.evaluate()
 
         # Using run_parallel
         pprint("...Setting up parallel experiment...")
@@ -288,9 +288,9 @@ class RunParallelTest(unittest.TestCase):
 
         # In serial like normal
         pprint("...Setting up serial experiment...")
-        with MontyObjectRecognitionExperiment(self.eval_config_lt) as self.eval_exp_lt:
+        with MontyObjectRecognitionExperiment(self.eval_config_lt) as eval_exp_lt:
             pprint("...Evaluating in serial...")
-            self.eval_exp_lt.evaluate()
+            eval_exp_lt.evaluate()
 
         # Using run_parallel
         pprint("...Setting up parallel experiment...")
@@ -325,9 +325,9 @@ class RunParallelTest(unittest.TestCase):
 
         # In serial like normal
         pprint("...Setting up serial experiment...")
-        with MontyObjectRecognitionExperiment(self.eval_config_gt) as self.eval_exp_gt:
+        with MontyObjectRecognitionExperiment(self.eval_config_gt) as eval_exp_gt:
             pprint("...Evaluating in serial...")
-            self.eval_exp_gt.evaluate()
+            eval_exp_gt.evaluate()
 
         # Using run_parallel
         pprint("...Setting up parallel experiment...")

--- a/tests/unit/run_parallel_test.py
+++ b/tests/unit/run_parallel_test.py
@@ -171,11 +171,11 @@ class RunParallelTest(unittest.TestCase):
         ###
         pprint("...Setting up serial experiment...")
         config = self.supervised_pre_training
-        with MontySupervisedObjectPretrainingExperiment(config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontySupervisedObjectPretrainingExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
 
             pprint("...Training in serial...")
-            self.exp.train()
+            exp.train()
 
         ###
         # Run training with run_parallel

--- a/tests/unit/sensor_module_test.py
+++ b/tests/unit/sensor_module_test.py
@@ -125,9 +125,7 @@ class SensorModuleTest(unittest.TestCase):
         """Check that correct features are returned by sensor module."""
         print("...parsing experiment...")
         base_config = copy.deepcopy(self.sensor_feature_test)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
+        with MontyObjectRecognitionExperiment(base_config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             pprint("...training...")
             self.exp.pre_epoch()
@@ -142,9 +140,7 @@ class SensorModuleTest(unittest.TestCase):
         """Check that correct features are returned by sensor module."""
         print("...parsing experiment...")
         base_config = copy.deepcopy(self.sensor_feature_test)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(base_config)
+        with MontyObjectRecognitionExperiment(base_config) as self.exp:
             self.exp.model.set_experiment_mode("train")
             pprint("...training...")
             self.exp.pre_epoch()
@@ -175,9 +171,7 @@ class SensorModuleTest(unittest.TestCase):
     def test_feature_change_sm(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_change_sensor_config)
-        self.exp = MontyObjectRecognitionExperiment()
-        with self.exp:
-            self.exp.setup_experiment(config)
+        with MontyObjectRecognitionExperiment(config) as self.exp:
             pprint("...training...")
             self.exp.train()
             # TODO: test that only new features are given to LM

--- a/tests/unit/sensor_module_test.py
+++ b/tests/unit/sensor_module_test.py
@@ -125,13 +125,13 @@ class SensorModuleTest(unittest.TestCase):
         """Check that correct features are returned by sensor module."""
         print("...parsing experiment...")
         base_config = copy.deepcopy(self.sensor_feature_test)
-        with MontyObjectRecognitionExperiment(base_config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontyObjectRecognitionExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("train")
             pprint("...training...")
-            self.exp.pre_epoch()
-            self.exp.pre_episode()
-            for step, observation in enumerate(self.exp.dataloader):
-                self.exp.model.step(observation)
+            exp.pre_epoch()
+            exp.pre_episode()
+            for step, observation in enumerate(exp.dataloader):
+                exp.model.step(observation)
                 if step == 1:
                     break
 
@@ -140,20 +140,20 @@ class SensorModuleTest(unittest.TestCase):
         """Check that correct features are returned by sensor module."""
         print("...parsing experiment...")
         base_config = copy.deepcopy(self.sensor_feature_test)
-        with MontyObjectRecognitionExperiment(base_config) as self.exp:
-            self.exp.model.set_experiment_mode("train")
+        with MontyObjectRecognitionExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("train")
             pprint("...training...")
-            self.exp.pre_epoch()
-            self.exp.pre_episode()
-            for _, observation in enumerate(self.exp.dataloader):
-                self.exp.model.aggregate_sensory_inputs(observation)
+            exp.pre_epoch()
+            exp.pre_episode()
+            for _, observation in enumerate(exp.dataloader):
+                exp.model.aggregate_sensory_inputs(observation)
 
-                pprint(self.exp.model.sensor_module_outputs)
+                pprint(exp.model.sensor_module_outputs)
                 for feature in self.tested_features:
                     if feature in ["pose_vectors", "pose_fully_defined", "on_object"]:
                         self.assertIn(
                             feature,
-                            self.exp.model.sensor_module_outputs[
+                            exp.model.sensor_module_outputs[
                                 0
                             ].morphological_features.keys(),
                             f"{feature} not returned by SM",
@@ -161,7 +161,7 @@ class SensorModuleTest(unittest.TestCase):
                     else:
                         self.assertIn(
                             feature,
-                            self.exp.model.sensor_module_outputs[
+                            exp.model.sensor_module_outputs[
                                 0
                             ].non_morphological_features.keys(),
                             f"{feature} not returned by SM",
@@ -171,12 +171,12 @@ class SensorModuleTest(unittest.TestCase):
     def test_feature_change_sm(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_change_sensor_config)
-        with MontyObjectRecognitionExperiment(config) as self.exp:
+        with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            self.exp.train()
+            exp.train()
             # TODO: test that only new features are given to LM
             pprint("...evaluating...")
-            self.exp.evaluate()
+            exp.evaluate()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is the second phase of [the work I proposed on Discourse][forum] to make MontyExperiment into a context manager.

This moves the config setup into a constructor for the class, leaving the part that initializes the model and datasets in the `setup_experiment` method. Then we call the simplified setup method in the context manager `__enter__` method.

The rest of this is updating the call sites to use the new context manager style more completely.

[forum]: https://thousandbrains.discourse.group/t/investigation-into-linux-test-failures-and-possible-improvements/468