### PR TITLE
docs: install rosetta on apple silicon instructions

### DIFF
--- a/docs/how-to-use-monty/getting-started.md
+++ b/docs/how-to-use-monty/getting-started.md
@@ -50,7 +50,8 @@ To setup Monty, **use the conda commands below**. Make sure to `cd` into the `tb
 
 Note that the commands are slightly different depending on whether you are setting up the environment on an Intel or ARM64 architecture, and whether you are using the zsh shell or another shell.
 
-> [!NOTE] On Apple Silicon we rely on Rosetta to run Intel binaries on ARM64 and include the `softwareupdate --install-rosetta` command in the commands below.
+> [!NOTE]
+> On Apple Silicon we rely on Rosetta to run Intel binaries on ARM64 and include the `softwareupdate --install-rosetta` command in the commands below.
 
 You can create the environment with the following commands:
 

--- a/docs/how-to-use-monty/getting-started.md
+++ b/docs/how-to-use-monty/getting-started.md
@@ -50,6 +50,8 @@ To setup Monty, **use the conda commands below**. Make sure to `cd` into the `tb
 
 Note that the commands are slightly different depending on whether you are setting up the environment on an Intel or ARM64 architecture, and whether you are using the zsh shell or another shell.
 
+> [!NOTE] On Applie Silicon we rely on Rosetta to run Intel binaries on ARM64 and include the `softwareupdate --install-rosetta` command in the commands below.
+
 You can create the environment with the following commands:
 
 ```shell Intel (zsh shell)
@@ -63,12 +65,14 @@ conda init
 conda activate tbp.monty
 ```
 ```shell ARM64 (Apple Silicon) (zsh shell)
+softwareupdate --install-rosetta
 conda env create -f environment_arm64.yml --subdir=osx-64
 conda init zsh
 conda activate tbp.monty
 conda config --env --set subdir osx-64
 ```
 ```shell ARM64 (Apple Silicon) (other shells)
+softwareupdate --install-rosetta
 conda env create -f environment_arm64.yml --subdir=osx-64
 conda init
 conda activate tbp.monty

--- a/docs/how-to-use-monty/getting-started.md
+++ b/docs/how-to-use-monty/getting-started.md
@@ -50,7 +50,7 @@ To setup Monty, **use the conda commands below**. Make sure to `cd` into the `tb
 
 Note that the commands are slightly different depending on whether you are setting up the environment on an Intel or ARM64 architecture, and whether you are using the zsh shell or another shell.
 
-> [!NOTE] On Applie Silicon we rely on Rosetta to run Intel binaries on ARM64 and include the `softwareupdate --install-rosetta` command in the commands below.
+> [!NOTE] On Apple Silicon we rely on Rosetta to run Intel binaries on ARM64 and include the `softwareupdate --install-rosetta` command in the commands below.
 
 You can create the environment with the following commands:
 


### PR DESCRIPTION
I noticed it is easy to get a broken experience installing `tbp.monty` on Apple Silicon if I don't have Rosetta installed.

This pull request updates install instructions to avoid the cryptic `Bad CPU type in executable` error when creating the conda `tbp.monty` environment.