### PR TITLE
chore: upgrade Python and HabitatSim

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -22,9 +22,9 @@ channels:
   - defaults
 
 dependencies:
-  - python=3.8
+  - python=3.9
 
-  - aihabitat::habitat-sim=0.2.2
+  - aihabitat::habitat-sim=0.2.4
   - aihabitat::withbullet
   - conda-forge::cmake>=3.14.0
   - conda-forge::importlib_resources
@@ -48,4 +48,3 @@ dependencies:
   - pip
   - pip:
       - -e .[dev]
-

--- a/environment_arm64.yml
+++ b/environment_arm64.yml
@@ -23,9 +23,9 @@ channels:
   - defaults
 
 dependencies:
-  - python=3.8
+  - python=3.9
 
-  - aihabitat::habitat-sim=0.2.2
+  - aihabitat::habitat-sim=0.2.4
   - aihabitat::withbullet
   - conda-forge::cmake>=3.14.0
   - conda-forge::importlib_resources


### PR DESCRIPTION
This updates the version of HabitatSim so that we can update to a newer, supported version of Python.