### PR TITLE
chore: updating ruff version and removing ANN101 and ANN102 from ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,7 +205,7 @@ ignore = [
     "ANN001", # ANN001: Missing type annotation for function argument
     "ANN002", # ANN002: Missing type annotation for `*args`
     "ANN003", # ANN003: Missing type annotation for `**kwargs`
-    "ANN101", # ANN101: Missing type annotation for `self` in method
+    # "ANN101", # ANN101: Missing type annotation for `self` in method
     "ANN102", # ANN102: Missing type annotation for `cls` in classmethod
     "ANN201", # ANN201: Missing return type annotation for public function
     "ANN202", # ANN202: Missing return type annotation for private function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,9 +206,6 @@ ignore = [
     "PTH208", # PTH208: os-listdir 
     "RUF022", # RUF022: unsorted-dunder-all
     "TC006", # TC006: runtime-cast-value
-    "I001", # I001: unsorted-imports
-    "F401", # F401: unused-imports
-    "RUF046", # RUF046: unncessary-cast-to-int
     "RUF100", # RUF100: unused-noqa
     ###
     # TODO: ruff=0.7.1 migration introduced errors ignored below, resolve these

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,6 @@ ignore = [
     "PTH208", # PTH208: os-listdir 
     "RUF022", # RUF022: unsorted-dunder-all
     "TC006", # TC006: runtime-cast-value
-    "RUF100", # RUF100: unused-noqa
     ###
     # TODO: ruff=0.7.1 migration introduced errors ignored below, resolve these
     "ANN001", # ANN001: Missing type annotation for function argument

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,16 @@ ignore = [
     "B026", # B026: find argument unpacking after keyword argument
     "B018", # B018: Found useless expression
     ###
+    # TODO: ruff=0.11.4 upgrade introduced the errors ignored below, resolve these
+    "LOG015", # LOG015: root-logger-call,
+    "PTH208", # PTH208: os-listdir 
+    "RUF022", # RUF022: unsorted-dunder-all
+    "TC006", # TC006: runtime-cast-value
+    "I001", # I001: unsorted-imports
+    "F401", # F401: unused-imports
+    "RUF046", # RUF046: unncessary-cast-to-int
+    "RUF100", # RUF100: unused-noqa
+    ###
     # TODO: ruff=0.7.1 migration introduced errors ignored below, resolve these
     "ANN001", # ANN001: Missing type annotation for function argument
     "ANN002", # ANN002: Missing type annotation for `*args`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dev = [
     'pytest-cov==3.0.0',
 
     # Python linter and formatter
-    'ruff==0.7.1',
+    'ruff==0.11.4',
 ]
 generate_api_docs_tool = [
     'docutils>=0.17',
@@ -205,8 +205,6 @@ ignore = [
     "ANN001", # ANN001: Missing type annotation for function argument
     "ANN002", # ANN002: Missing type annotation for `*args`
     "ANN003", # ANN003: Missing type annotation for `**kwargs`
-    # "ANN101", # ANN101: Missing type annotation for `self` in method
-    "ANN102", # ANN102: Missing type annotation for `cls` in classmethod
     "ANN201", # ANN201: Missing return type annotation for public function
     "ANN202", # ANN202: Missing return type annotation for private function
     "ANN204", # ANN204: Missing return type annotation for special method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,8 +322,8 @@ ignore = [
     "SIM910", # SIM910: Use {expected} instead of {actual}
     "SLF001", # SLF001: Private member accessed: {access}
     "SLOT001", # SLOT001: Subclasses of `tuple` should define `__slots__`
-    "TCH001", # TCH001: Move application import {} into a type-checking block
-    "TCH002", # TCH002: Move third-party import {} into a type-checking block
+    "TC001", # TC001: Move application import {} into a type-checking block
+    "TC002", # TC002: Move third-party import {} into a type-checking block
     "TD001", # TD001: Invalid TODO tag: `FIXME`
     "TD002", # TD002: Missing author in TODO; try: `# TODO(<author_name>): ...` or `# TODO @<author_name>: ...`
     "TD003", # TD003: Missing issue link on the line following this TODO

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -374,9 +374,9 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
             observation_shape[0] // 2, observation_shape[1] // 2
         ]
         if initial_pose:
-            assert (
-                depth_at_center > 0
-            ), "Object must be initialized such that the agent can visualize it by moving forward"  # noqa: E501
+            assert depth_at_center > 0, (
+                "Object must be initialized such that the agent can visualize it by moving forward"
+            )  # noqa: E501
             # TODO investigate - I think this may have always been passing in the
             # original surface-agent policy implementation because the surface
             # sensor clips at 1.0, so even if the object isn't strictly visible (or
@@ -843,6 +843,7 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
         y_mid, x_mid = image_shape[0] // 2, image_shape[1] // 2
         on_target_object = semantic[y_mid, x_mid] == target_semantic_id
         return on_target_object
+
 
 class NaiveScanPolicy(InformedPolicy):
     """Policy that just moves left and right along the object."""
@@ -1340,9 +1341,9 @@ class SurfacePolicy(InformedPolicy):
         x, y, z = rotated_point_normal
 
         if "horizontal" == orienting:
-            return -np.degrees(np.arctan(x / z)) if z != 0 else -np.sign(x)*90.0
+            return -np.degrees(np.arctan(x / z)) if z != 0 else -np.sign(x) * 90.0
         if "vertical" == orienting:
-            return -np.degrees(np.arctan(y / z)) if z != 0 else -np.sign(y)*90.0
+            return -np.degrees(np.arctan(y / z)) if z != 0 else -np.sign(y) * 90.0
 
 
 ###
@@ -1691,7 +1692,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
 
         # Before updating the representation and removing z-axis direction, check
         # for movements defined in the z-axis
-        if int(np.argmax(np.abs(rotated_form))) == int(2):
+        if int(np.argmax(np.abs(rotated_form))) == 2:
             # TODO decide if in cases where the PC is defined in the z-direction
             # relative to the agent, it might actually make sense to still follow it,
             # i.e. as it should representa a movement tangential to the surface, and
@@ -2204,9 +2205,9 @@ def projected_angle_from_vec(vector):
     for test_theta in test_thetas:
         test_vec = projected_vec_from_angle(test_theta)
         recovered = math.atan2(test_vec[0], test_vec[1])
-        assert (
-            abs(test_theta - recovered) < 0.01
-        ), f"Issue with angle recovery for : {test_theta} vs. {recovered}"
+        assert abs(test_theta - recovered) < 0.01, (
+            f"Issue with angle recovery for : {test_theta} vs. {recovered}"
+        )
 
     return math.atan2(vector[0], vector[1])
 

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -375,8 +375,9 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
         ]
         if initial_pose:
             assert depth_at_center > 0, (
-                "Object must be initialized such that the agent can visualize it by moving forward"
-            )  # noqa: E501
+                "Object must be initialized such that "
+                "agent can visualize it by moving forward"
+            )
             # TODO investigate - I think this may have always been passing in the
             # original surface-agent policy implementation because the surface
             # sensor clips at 1.0, so even if the object isn't strictly visible (or

--- a/src/tbp/monty/frameworks/utils/transform_utils.py
+++ b/src/tbp/monty/frameworks/utils/transform_utils.py
@@ -9,7 +9,7 @@
 # https://opensource.org/licenses/MIT.
 
 import numpy as np
-import quaternion  # noqa: F401; required by np.quaternion
+import quaternion  # noqa: F401 required by numpy-quaternion package
 
 
 def find_transform_instance(composed_transform, transform_type):

--- a/src/tbp/monty/frameworks/utils/transform_utils.py
+++ b/src/tbp/monty/frameworks/utils/transform_utils.py
@@ -9,7 +9,6 @@
 # https://opensource.org/licenses/MIT.
 
 import numpy as np
-import quaternion  # noqa: F401; required by np.quaternion
 
 
 def find_transform_instance(composed_transform, transform_type):

--- a/src/tbp/monty/frameworks/utils/transform_utils.py
+++ b/src/tbp/monty/frameworks/utils/transform_utils.py
@@ -9,6 +9,7 @@
 # https://opensource.org/licenses/MIT.
 
 import numpy as np
+import quaternion  # noqa: F401; required by np.quaternion
 
 
 def find_transform_instance(composed_transform, transform_type):

--- a/src/tbp/monty/simulators/tacto/__init__.py
+++ b/src/tbp/monty/simulators/tacto/__init__.py
@@ -8,6 +8,6 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-from .config import *  # noqa: I001; avoiding circular import
+from .config import *  # noqa: I001 avoiding circular import
 from .agents import *
 from .sensors import *

--- a/src/tbp/monty/simulators/tacto/__init__.py
+++ b/src/tbp/monty/simulators/tacto/__init__.py
@@ -8,6 +8,6 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-from .config import *  # noqa: I001
+from .config import *  # noqa: I001; avoiding circular import
 from .agents import *
 from .sensors import *

--- a/src/tbp/monty/simulators/tacto/__init__.py
+++ b/src/tbp/monty/simulators/tacto/__init__.py
@@ -8,6 +8,6 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-from .config import *  # noqa: I001; avoiding circular import
+from .config import *  # noqa: I001
 from .agents import *
 from .sensors import *


### PR DESCRIPTION
As of ruff 0.8.0, `ANN101` and `ANN102` have been removed (https://astral.sh/blog/ruff-v0.8.0), and depreciated since version 0.2.0. This PR updates the ruff version from 0.7.1 to 0.11.4, which is the latest version as of 2025/04/04. I have specified the version for reproducibility (removing the version pins will use the latest version of each tool). 