### PR TITLE
refactor: first movement logic in GraphLM

### DIFF
--- a/src/tbp/monty/frameworks/models/displacement_matching.py
+++ b/src/tbp/monty/frameworks/models/displacement_matching.py
@@ -187,21 +187,22 @@ class DisplacementGraphLM(GraphLM):
     # ======================= Private ==========================
 
     # ------------------- Main Algorithm -----------------------
-    def _compute_possible_matches(self, observation, not_moved=False):
+    def _compute_possible_matches(self, observation, first_movement_detected=True):
         """Use the current observation to narrown down the possible matches.
 
         This is framed as a prediction problem. We take the current observation
         as a query and try to predict whether after the displacement we will still be
         on the object. In a next step we could also predict the feature that we sense
-        next. The prediction is then compared with he actual obervation (currently
+        next. The prediction is then compared with he actual observation (currently
         just whether we sensed on_object or not). If there is a prediction error, then
         we remove the object from the possible matches.
 
         Args:
             observation: The current observation.
-            not_moved: Whether the agent has moved yet. True on the first step.
+            first_movement_detected: Whether the agent has moved yet. False on the first
+                step.
         """
-        if not_moved:
+        if not first_movement_detected:
             return
         if self.match_attribute == "displacement":
             query = self.buffer.get_current_displacement(input_channel="first")

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -994,7 +994,7 @@ class GraphLM(LearningModule):
 
         Args:
             observations: Observations to use for computing possible matches.
-            first_movement_detected: Whether the agent has moved since the reset
+            first_movement_detected: Whether the agent has moved since the buffer reset
                 signal.
         """
         if first_movement_detected:

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -21,10 +21,7 @@ from tbp.monty.frameworks.loggers.graph_matching_loggers import (
     DetailedGraphMatchingLogger,
     SelectiveEvidenceLogger,
 )
-from tbp.monty.frameworks.models.abstract_monty_classes import (
-    LearningModule,
-    LMMemory,
-)
+from tbp.monty.frameworks.models.abstract_monty_classes import LearningModule, LMMemory
 from tbp.monty.frameworks.models.buffer import FeatureAtLocationBuffer
 from tbp.monty.frameworks.models.goal_state_generation import GraphGoalStateGenerator
 from tbp.monty.frameworks.models.monty_base import MontyBase
@@ -645,18 +642,19 @@ class GraphLM(LearningModule):
 
     def matching_step(self, observations):
         """Update the possible matches given an observation."""
+        first_movement_detected = self._agent_moved_since_reset()
         buffer_data = self._add_displacements(observations)
         self.buffer.append(buffer_data)
         self.buffer.append_input_states(observations)
 
-        if len(self.buffer) > 1:
-            not_moved = False
+        if first_movement_detected:
             logging.debug("performing matching step.")
         else:
-            not_moved = True
             logging.debug("we have not moved yet.")
 
-        self._compute_possible_matches(observations, not_moved=not_moved)
+        self._compute_possible_matches(
+            observations, first_movement_detected=first_movement_detected
+        )
 
         if len(self.get_possible_matches()) == 0:
             self.set_individual_ts(terminal_state="no_match")
@@ -769,6 +767,9 @@ class GraphLM(LearningModule):
         else:
             logging.info(f"{self.learning_module_id} did not recognize an object yet.")
         return self.terminal_state
+
+    def _agent_moved_since_reset(self):
+        return len(self.buffer) > 0
 
     # ------------------ Getters & Setters ---------------------
 
@@ -988,22 +989,23 @@ class GraphLM(LearningModule):
     # ======================= Private ==========================
 
     # ------------------- Main Algorithm -----------------------
-    def _compute_possible_matches(self, observations, not_moved=False):
+    def _compute_possible_matches(self, observations, first_movement_detected=True):
         """Use graph memory to get the current possible matches.
 
         Args:
             observations: Observations to use for computing possible matches.
-            not_moved: Whether the observations are not moved.
+            first_movement_detected: Whether the agent has moved since the reset
+                signal.
         """
-        if not_moved:
+        if first_movement_detected:
             query = [
                 self._select_features_to_use(observations),
-                None,
+                self.buffer.get_current_displacement(input_channel="all"),
             ]
         else:
             query = [
                 self._select_features_to_use(observations),
-                self.buffer.get_current_displacement(input_channel="all"),
+                None,
             ]
 
         logging.debug(f"query: {query}")

--- a/tests/unit/evidence_sdr_lm_test.py
+++ b/tests/unit/evidence_sdr_lm_test.py
@@ -21,9 +21,7 @@ from tbp.monty.frameworks.models.evidence_sdr_matching import (
     EvidenceSDRGraphLM,
     EvidenceSDRTargetOverlaps,
 )
-from tbp.monty.frameworks.models.goal_state_generation import (
-    EvidenceGoalStateGenerator,
-)
+from tbp.monty.frameworks.models.goal_state_generation import EvidenceGoalStateGenerator
 from tbp.monty.frameworks.models.states import State
 from tests.unit.resources.unit_test_utils import BaseGraphTestCases
 
@@ -522,16 +520,14 @@ class EvidenceSDRIntegrationTest(BaseGraphTestCases.BaseGraphTest):
         Note: Observations are fed to the LM without the need to
         suggest new location in this toy example.
         """
+        first_movement_detected = lm._agent_moved_since_reset()
         buffer_data = lm._add_displacements(observations)
         lm.buffer.append(buffer_data)
         lm.buffer.append_input_states(observations)
 
-        if len(lm.buffer) > 1:
-            not_moved = False
-        else:
-            not_moved = True
-
-        lm._compute_possible_matches(observations, not_moved=not_moved)
+        lm._compute_possible_matches(
+            observations, first_movement_detected=first_movement_detected
+        )
 
         if len(lm.get_possible_matches()) == 0:
             lm.set_individual_ts(terminal_state="no_match")


### PR DESCRIPTION
This change refactors the logic of detecting the first movement since the reset signal from `GraphLM.matching_step` to `GraphLM._agent_moved_since_reset`. This will allow us to overwrite this logic in other PRs (e.g., [PR#221](https://github.com/thousandbrainsproject/tbp.monty/pull/221#discussion_r2021342279)) without modifying the `matching_step` function.

Additionally, `not_moved` has been renamed to `first_movement_detected` to avoid the slightly confusing double negatives in cases such as `not_moved = False`.

This change required other changes in `DisplacementGraphLM` and `EvidenceSDRIntegrationTest`.

I ran the benchmark experiments for `randrot_noise_10distinctobj_surf_agent` and `randrot_noise_10distinctobj_dist_agent` for a quick sanity check; they gave the same results as before the change.