### PR TITLE
refactor!: remove unused MotorSystem.update method

### DIFF
--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -49,11 +49,6 @@ class MotorSystem(abc.ABC, Callable):
         pass
 
     @abc.abstractmethod
-    def update(self, actions):
-        # TODO: nobody is using this. Is this still valid?
-        pass
-
-    @abc.abstractmethod
     def set_experiment_mode(self, mode):
         pass
 


### PR DESCRIPTION
While this is marked as a breaking change (removing a method from the API), there are no subclass implementations of this abstract method, meaning that if it were ever called, it would have thrown an error. Since we observe no such errors, there are no calls of this method in the code, and there's a `TODO` questioning needing the method, this method is now removed.