### PR TITLE
chore: clean up ruff's ignore list to remove rules that pass

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,6 @@ ignore = [
     # Original inherited flake8 ignores
     "C4", # C4XX: ignore all Flake8 comprehensions
     "D1", # D1XX: Missing Docstrings
-    "E203", # E203: whitespace before ':'
     "ERA001", # ERA001: Found commented out code
     "F541", # F541: f-string is missing placeholders
     "FIX001", # FIX001: Line contains FIXME, consider resolving the issue
@@ -199,7 +198,6 @@ ignore = [
     # TODO: flake8=6.1.0 upgrade introduced errors ignored below, resolve these
     "E721", # E721: do not compare types, use 'isinstance()'
     "B026", # B026: find argument unpacking after keyword argument
-    "B018", # B018: Found useless expression
     ###
     # TODO: ruff=0.11.4 upgrade introduced the errors ignored below, resolve these
     "LOG015", # LOG015: root-logger-call,
@@ -218,14 +216,10 @@ ignore = [
     "ANN401", # ANN401: Dynamically typed expressions (typing.Any) are disallowed in {name}
     # TODO: Address ARG002 right away
     "ARG002", # ARG002: Unused method argument
-    "BLE001", # BLE001: Do not catch blind exception: `Exception`
-    "C901", # C901: {name} is too complex ({complexity} > {max_complexity})
     "COM812", # COM812: Trailing comma missing
-    "COM819", # COM819: Trailing comma prohibited
     "DTZ005", # DTZ005: `datetime.datetime.now()` called without a `tz` argument
     "EM101", # EM101: Exception must not use a string literal, assign to variable first
     "EM102", # EM102: Exception must not use an f-string literal, assign to variable first
-    "EM103", # EM103: Exception must not use a `.format()` string directly, assign to variable first
     "F403", # F403: from {name} import * used; unable to detect undefined names
     "F841", # F841: Local variable {name} is assigned to but never used
     "FA100", # FA100: Add `from __future__ import annotations` to simplify
@@ -235,8 +229,6 @@ ignore = [
     "FLY002", # FLY002: Consider {expression} instead of string join
     "G003", # G003: Logging statement uses `+`
     "G004", # G004: Logging statement uses f-string
-    "G010", # G010: Logging statement uses `warn` instead of `warning`
-    "INP001", # INP001: File {filename} is part of an implicit namespace package. Add an __init__.py.
     "ISC001", # ISC001: Implicitly concatenated string literals on one line
     "ISC003", # ISC003: Explicitly concatenated string should be implicitly concatenated
     "N804", # N804: First argument of a class method should be named `cls`
@@ -244,15 +236,11 @@ ignore = [
     "NPY201", # NPY201: `np.infty` will be removed in NumPy 2.0. Use `numpy.inf` instead.
     "PD002", # PD002: `inplace=True` should be avoided; it has inconsistent behavior
     "PD901", # PD901: Avoid using the generic variable name `df` for DataFrames
-    "PERF102", # PERF102: When using only the values of a dict use the `values()` method
     "PERF203", # PERF203: `try`-`except` within a loop incurs performance overhead
     "PERF401", # PERF401: Use a list comprehension to create a transformed list
     "PERF402", # PERF402: Use `list` or `list.copy` to create a copy of a list
     "PIE790", # PIE790: Unnecessary pass statement
-    "PIE794", # PIE794: Class field {name} is defined multiple times
     "PIE807", # PIE807: Prefer `list` over useless lambda
-    "PIE808", # PIE808: Unnecessary `start` argument in `range`
-    "PIE810", # PIE810: Call `endswith` once with a `tuple`
     "PLE0302", # PLE0302: The special method `__getitem__` expects 2 parameters, 1 was given
     "PLR0402", # PLR0402: Use from {module} import {name} in lieu of alias
     "PLE0605", # PLE0605: Invalid format for `__all__`, must be `tuple` or `list`
@@ -261,7 +249,6 @@ ignore = [
     "PLR0913", # PLR0913: Too many arguments in function definition
     "PLR0915", # PLR0915: Too many statements
     "PLR1704", # PLR1704: Redefining argument with the local name
-    "PLR1711", # PLR1711: Useless `return` statement at end of function
     "PLR1714", # PLR1714: Consider merging multiple comparisons: {expression}. Use a set if the elements are hashable.
     "PLR1730", # PLR1730: Replace `if` statement with {replacement}
     "PLR2004", # PLR2004: Magic value used in comparison, consider replacing {value} with a constant variable
@@ -271,14 +258,11 @@ ignore = [
     "PT009", # PT009: Use a regular `assert` instead of unittest-style `assertEqual`
     "PT018", # PT018: Assertion should be broken down into multiple parts
     "PT027", # PT027: Use `pytest.raises` instead of unittest-style `assertRaises`
-    "PTH100", # PTH100: `os.path.abspath()` should be replaced by `Path.resolve()`
     "PTH103", # PTH103: `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
     "PTH104", # PTH104: `os.rename()` should be replaced by `Path.rename()`
     "PTH107", # PTH107: `os.remove()` should be replaced by `Path.unlink()`
     "PTH110", # PTH110: `os.path.exists()` should be replaced by `Path.exists()`
     "PTH111", # PTH111: `os.path.expanduser()` should be replaced by `Path.expanduser()`
-    "PTH112", # PTH112: `os.path.isdir()` should be replaced by `Path.is_dir()`
-    "PTH113", # PTH113: `os.path.isfile()` should be replaced by `Path.is_file()`
     "PTH118", # PTH118: `os.path.join()` should be replaced by `Path` with `/` operator
     "PTH119", # PTH119: `os.path.basename()` should be replaced by `Path.name`
     "PTH120", # PTH120: `os.path.dirname()` should be replaced by `Path.parent`
@@ -291,22 +275,17 @@ ignore = [
     "RET508", # RET508: Unnecessary `else` after `break` statement
     "RSE102", # RSE102: Unnecessary parentheses on raised exception
     "RUF005", # RUF005: Consider {expression} instead of concatenation
-    "RUF009", # RUF009: Do not perform function call `os.path.expanduser` in dataclass defaults
     "RUF010", # RUF010: Use explicit conversion flag
     "RUF012", # RUF012: Mutable class attributes should be annotated with `typing.ClassVar`
     "RUF013", # RUF013: PEP 484 prohibits implicit `Optional`
     "RUF015", # RUF015: Prefer next({iterable}) over single element slice
-    "RUF019", # RUF019: Unnecessary key check before dictionary access
     "S101", # S101: Use of `assert` detected
     "S104", # S104: Possible binding to all interfaces
-    "S113", # S113: Probable use of `requests` call without timeout
     "S301", # S301: `pickle` and modules that wrap it can be unsafe when used to deserialize untrusted data, possible security issue
     "S311", # S311: Standard pseudo-random generators are not suitable for cryptographic purposes
     "S605", # S605: Starting a process with a shell, possible injection detected
-    "SIM101", # SIM101: Multiple `isinstance` calls for `objects`, merge into a single call
     "SIM102", # SIM102: Use a single `if` statement instead of nested `if` statements
     "SIM103", # SIM103: Return the condition {condition} directly
-    "SIM105", # SIM105: Use `contextlib.suppress(SystemExit)` instead of `try`-`except`-`pass`
     "SIM108", # SIM108: Use ternary operator {contents} instead of if-else-block
     "SIM113", # SIM113: Use enumerate() for index variable {index} in for loop
     "SIM114", # SIM114: Combine `if` branches using logical `or` operator
@@ -314,7 +293,6 @@ ignore = [
     "SIM118", # SIM118: Use `key in dict` instead of `key in dict.keys()`
     "SIM201", # SIM201: Use {left} != {right} instead of not {left} == {right}
     "SIM300", # SIM300: Yoda condition detected
-    "SIM401", # SIM401: Use {contents} instead of an if block
     "SIM910", # SIM910: Use {expected} instead of {actual}
     "SLF001", # SLF001: Private member accessed: {access}
     "SLOT001", # SLOT001: Subclasses of `tuple` should define `__slots__`
@@ -328,15 +306,11 @@ ignore = [
     "TRY002", # TRY002: Create your own exception
     "TRY003", # TRY003: Avoid specifying long messages outside the exception class
     "TRY004", # TRY004: Prefer `TypeError` exception for invalid type
-    "TRY400", # TRY400: Use `logging.exception` instead of `logging.error`
     "UP005", # UP005: `assertEquals` is deprecated, use `assertEqual`
     "UP006", # UP006: Use `type` instead of `Type` for type annotation
     "UP008", # UP008: Use `super()` instead of `super(__class__, self)`
     "UP015", # UP015: Unnecessary open mode parameters
-    "UP018", # UP018: Unnecessary `int` call (rewrite as a literal)
-    "UP030", # UP030: Use implicit references for positional format fields
     "UP031", # UP031: Use format specifiers instead of percent format
-    "UP032", # UP032: Use f-string instead of `format` call
     "UP034", # UP034: Avoid extraneous parentheses
 ]
 


### PR DESCRIPTION
I wrote a short script to loop through the ignore list under [tool.ruff.lint] and remove those that pass. 

Core logic of script for reference:
```python
def extract_ignore_rules(pyproject_path: Path) -> List[str]:
    """Extract the ruff ignore rules from pyproject.toml."""

    with open(pyproject_path, "rb") as f:
        data = tomli.load(f)

    ignore_rules = data["tool"]["ruff"]["lint"]["ignore"]
    return ignore_rules


def check_rule(rule: str, src_dirs: List[str], tbp_monty_dir: Path) -> bool:
    """
    Check if a rule produces any errors when run with ruff check.
    Returns True if no errors are found (rule can be removed).
    """
    cmd = ["ruff", "check"] + src_dirs + ["--select", rule]

    try:
        # Run the command and capture output
        result = subprocess.run(
            cmd,
            cwd=tbp_monty_dir,
            stdout=subprocess.PIPE,
            stderr=subprocess.PIPE,
            text=True,
            check=False,
        )

        # If the exit code is 0, no issues were found
        return result.returncode == 0
    except Exception as e:
        print(f"Error checking rule {rule}: {e}", file=sys.stderr)
        return False
```