### PR TITLE
refactor!: motor policies are an attribute of MotorSystem

### DIFF
--- a/benchmarks/configs/pretraining_experiments.py
+++ b/benchmarks/configs/pretraining_experiments.py
@@ -46,6 +46,7 @@ from tbp.monty.frameworks.experiments import (
     MontySupervisedObjectPretrainingExperiment,
 )
 from tbp.monty.frameworks.models.displacement_matching import DisplacementGraphLM
+from tbp.monty.frameworks.models.motor_policies import NaiveScanPolicy
 from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     HabitatSurfacePatchSM,
@@ -120,7 +121,10 @@ supervised_pre_training_base = dict(
             )
         ),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=5)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=5),
+            )
         ),  # use spiral policy for more even object coverage during learning
     ),
     dataset_class=ED.EnvironmentDataset,
@@ -254,7 +258,10 @@ supervised_pre_training_5lms.update(
     monty_config=FiveLMMontyConfig(
         monty_args=MontyArgs(num_exploratory_steps=500),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=5)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=5),
+            )
         ),
     ),
     dataset_args=FiveLMMountHabitatDatasetArgs(),

--- a/benchmarks/make_detailed_follow_up_configs.py
+++ b/benchmarks/make_detailed_follow_up_configs.py
@@ -117,8 +117,8 @@ if __name__ == "__main__":
     # Check that config doesn't use goal state generator (actions.txt file doesn't
     # store those jumps)
     if follow_up_config["monty_config"]["motor_system_config"]["motor_system_args"][
-        "use_goal_state_driven_actions"
-    ]:
+        "policy_args"
+    ]["use_goal_state_driven_actions"]:
         print(
             "Warning: config uses goal state generator. This will not work for ",
             "exact replication because actions.txt file does not store those jumps.",

--- a/docs/how-to-use-monty/tutorials/multiple-learning-modules.md
+++ b/docs/how-to-use-monty/tutorials/multiple-learning-modules.md
@@ -76,7 +76,10 @@ dist_agent_5lm_2obj_train = dict(
     monty_config=FiveLMMontyConfig(
         monty_args=MontyArgs(num_exploratory_steps=500),
         motor_system_config=MotorSystemConfigNaiveScanSpiral(
-            motor_system_args=make_naive_scan_policy_config(step_size=5)
+            motor_system_args=dict(
+                policy_class=NaiveScanPolicy,
+                policy_args=make_naive_scan_policy_config(step_size=5),
+            )
         ),
     ),
     # Set up the environment and agent.

--- a/src/tbp/monty/frameworks/config_utils/config_args.py
+++ b/src/tbp/monty/frameworks/config_utils/config_args.py
@@ -13,7 +13,18 @@ import os
 from dataclasses import dataclass, field
 from itertools import product
 from numbers import Number
-from typing import Callable, Dict, Iterable, List, Mapping, Optional, Union
+from typing import (
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Protocol,
+    Union,
+)
 
 import numpy as np
 import wandb
@@ -54,11 +65,11 @@ from tbp.monty.frameworks.models.monty_base import (
 from tbp.monty.frameworks.models.motor_policies import (
     BasePolicy,
     InformedPolicy,
-    MotorSystem,
     NaiveScanPolicy,
     SurfacePolicy,
     SurfacePolicyCurvatureInformed,
 )
+from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     FeatureChangeSM,
@@ -74,6 +85,17 @@ from tbp.monty.frameworks.models.sensor_modules import (
 # -----------------------
 
 monty_logs_dir = os.getenv("MONTY_LOGS")
+
+
+class Dataclass(Protocol):
+    """A protocol for dataclasses to be used in type hints.
+
+    The reason this exists is because dataclass.dataclass is not a valid type.
+    """
+
+    __dataclass_fields__: ClassVar[Dict[str, Any]]
+    """Checking for presence of __dataclass_fields__ is a hack to check if a class is a
+    dataclass."""
 
 
 @dataclass
@@ -247,153 +269,189 @@ class PretrainLoggingConfig(LoggingConfig):
 
 @dataclass
 class MotorSystemConfig:
-    motor_system_class: MotorSystem = BasePolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_base_policy_config(
-            action_space_type="distant_agent",
-            action_sampler_class=UniformlyDistributedSampler,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=BasePolicy,
+            policy_args=make_base_policy_config(
+                action_space_type="distant_agent",
+                action_sampler_class=UniformlyDistributedSampler,
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigRelNoTrans:
-    motor_system_class: MotorSystem = BasePolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_base_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=UniformlyDistributedSampler,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=BasePolicy,
+            policy_args=make_base_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=UniformlyDistributedSampler,
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigInformedNoTrans:
-    motor_system_class: MotorSystem = InformedPolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            rotation_degrees=5.0,
-            use_goal_state_driven_actions=False,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                rotation_degrees=5.0,
+                use_goal_state_driven_actions=False,
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigInformedNoTransStepS3:
-    motor_system_class: MotorSystem = InformedPolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            rotation_degrees=3.0,
-            use_goal_state_driven_actions=False,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                rotation_degrees=3.0,
+                use_goal_state_driven_actions=False,
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigInformedNoTransStepS1:
-    motor_system_class: MotorSystem = InformedPolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            rotation_degrees=1.0,
-            use_goal_state_driven_actions=False,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                rotation_degrees=1.0,
+                use_goal_state_driven_actions=False,
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigInformedNoTransStepS6:
-    motor_system_class: MotorSystem = InformedPolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            rotation_degrees=6.0,
-            use_goal_state_driven_actions=False,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                rotation_degrees=6.0,
+                use_goal_state_driven_actions=False,
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigInformedNoTransStepS20:
-    motor_system_class: MotorSystem = InformedPolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            rotation_degrees=20.0,
-            use_goal_state_driven_actions=False,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                rotation_degrees=20.0,
+                use_goal_state_driven_actions=False,
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigInformedNoTransCloser:
-    motor_system_class: MotorSystem = InformedPolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            rotation_degrees=5.0,
-            good_view_percentage=0.7,
-            use_goal_state_driven_actions=False,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                rotation_degrees=5.0,
+                good_view_percentage=0.7,
+                use_goal_state_driven_actions=False,
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigInformedNoTransFurtherAway:
-    motor_system_class: MotorSystem = InformedPolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            rotation_degrees=5.0,
-            good_view_percentage=0.3,
-            use_goal_state_driven_actions=False,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                rotation_degrees=5.0,
+                good_view_percentage=0.3,
+                use_goal_state_driven_actions=False,
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigNaiveScanSpiral:
-    motor_system_class: MotorSystem = NaiveScanPolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_naive_scan_policy_config(step_size=5)
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=NaiveScanPolicy,
+            policy_args=make_naive_scan_policy_config(step_size=5),
+        )
     )
 
 
 @dataclass
 class MotorSystemConfigSurface:
-    motor_system_class: MotorSystem = SurfacePolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_surface_policy_config(
-            desired_object_distance=0.025,  # 2.5 cm desired distance
-            alpha=0.1,  # alpha 0.1 means we mostly maintain our heading
-            use_goal_state_driven_actions=False,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=SurfacePolicy,
+            policy_args=make_surface_policy_config(
+                desired_object_distance=0.025,  # 2.5 cm desired distance
+                alpha=0.1,  # alpha 0.1 means we mostly maintain our heading
+                use_goal_state_driven_actions=False,
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigCurvatureInformedSurface:
-    motor_system_class: MotorSystem = SurfacePolicyCurvatureInformed
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_curv_surface_policy_config(
-            desired_object_distance=0.025,
-            alpha=0.1,
-            pc_alpha=0.5,
-            # For a description of the below step parameters, see the class
-            # SurfacePolicyCurvatureInformed
-            max_pc_bias_steps=32,
-            min_general_steps=8,
-            min_heading_steps=12,
-            use_goal_state_driven_actions=False,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=SurfacePolicyCurvatureInformed,
+            policy_args=make_curv_surface_policy_config(
+                desired_object_distance=0.025,
+                alpha=0.1,
+                pc_alpha=0.5,
+                # For a description of the below step parameters, see the class
+                # SurfacePolicyCurvatureInformed
+                max_pc_bias_steps=32,
+                min_general_steps=8,
+                min_heading_steps=12,
+                use_goal_state_driven_actions=False,
+            ),
         )
     )
 
@@ -401,27 +459,33 @@ class MotorSystemConfigCurvatureInformedSurface:
 # Distant-agent ("eye") policy that also performs hypothesis-testing jumps
 @dataclass
 class MotorSystemConfigInformedGoalStateDriven:
-    motor_system_class: MotorSystem = InformedPolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            rotation_degrees=5.0,
-            use_goal_state_driven_actions=True,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                rotation_degrees=5.0,
+                use_goal_state_driven_actions=True,
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigInformedGoalStateDrivenFartherAway:
-    motor_system_class: MotorSystem = InformedPolicy
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            rotation_degrees=10.0,  # Relatively large step-size
-            good_view_percentage=0.5,  # Relatively far from the object
-            use_goal_state_driven_actions=True,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                rotation_degrees=10.0,  # Relatively large step-size
+                good_view_percentage=0.5,  # Relatively far from the object
+                use_goal_state_driven_actions=True,
+            ),
         )
     )
 
@@ -430,16 +494,19 @@ class MotorSystemConfigInformedGoalStateDrivenFartherAway:
 # hypothesis-testing jumps
 @dataclass
 class MotorSystemConfigCurInformedSurfaceGoalStateDriven:
-    motor_system_class: MotorSystem = SurfacePolicyCurvatureInformed
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_curv_surface_policy_config(
-            desired_object_distance=0.025,
-            alpha=0.1,
-            pc_alpha=0.5,
-            max_pc_bias_steps=32,
-            min_general_steps=8,
-            min_heading_steps=12,
-            use_goal_state_driven_actions=True,
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=SurfacePolicyCurvatureInformed,
+            policy_args=make_curv_surface_policy_config(
+                desired_object_distance=0.025,
+                alpha=0.1,
+                pc_alpha=0.5,
+                max_pc_bias_steps=32,
+                min_general_steps=8,
+                min_heading_steps=12,
+                use_goal_state_driven_actions=True,
+            ),
         )
     )
 

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -748,9 +748,10 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             "motor_only_step"
         ] = True
 
+        # TODO refactor so that the whole of the hypothesis driven jumps
+        # makes cleaner use of self.motor_system()
         # Call post_action (normally taken care of __call__ within
-        # self.motor_system._policy()) - TODO refactor so that the whole of the
-        # hypothesis driven jumps makes cleaner use of self.motor_system()
+        # self.motor_system._policy())
         self.motor_system._policy.post_action(self.motor_system._policy.action)
 
         return self._observation
@@ -776,13 +777,12 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 direction=[0, 0, 0],
             )
 
-            # Store logging information about jump success; when doing refactor
-            # of policy code, TODO cleanup where this is performed, and make
-            # variable names more general; TODO also only log this when
-            # we are doing detailed logging
+            # TODO cleanup where this is performed, and make variable names more general
+            # TODO also only log this when we are doing detailed logging
             # TODO M clean up these action details loggings; this may need to remain
             # local to a "motor-system buffer" given that these are model-free
             # actions that have nothing to do with the LMs
+            # Store logging information about jump success
             self.motor_system._policy.action_details["pc_heading"].append("jump")
             self.motor_system._policy.action_details["avoidance_heading"].append(False)
             self.motor_system._policy.action_details["z_defined_pc"].append(None)

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -134,7 +134,8 @@ class EnvironmentDataLoader:
 
     def __init__(self, dataset: EnvironmentDataset, motor_system: MotorSystem, rng):
         assert isinstance(dataset, EnvironmentDataset)
-        assert isinstance(motor_system, MotorSystem)
+        if not isinstance(motor_system, MotorSystem):
+            f"motor_system must be an instance of MotorSystem, got {motor_system}"
         self.dataset = dataset
         self.motor_system = motor_system
         self.rng = rng
@@ -859,9 +860,25 @@ class OmniglotDataLoader(EnvironmentDataLoaderPerObject):
         *args,
         **kwargs,
     ):
-        """Initialize dataloader."""
+        """Initialize dataloader.
+
+        Args:
+            alphabets (List[str]): List of alphabets.
+            characters (List[str]): List of characters.
+            versions: List of versions.
+            dataset (EnvironmentDataset): The environment dataset.
+            motor_system (MotorSystem): The motor system.
+            *args: Additional arguments
+            **kwargs: Additional keyword arguments
+
+        Raises:
+            ValueError: If `motor_system` is not an instance of `MotorSystem`.
+        """
         assert isinstance(dataset, EnvironmentDataset)
-        assert isinstance(motor_system, MotorSystem)
+        if not isinstance(motor_system, MotorSystem):
+            raise ValueError(
+                f"motor_system must be an instance of MotorSystem, got {motor_system}"
+            )
         self.dataset = dataset
         self.motor_system = motor_system
         self._observation, self.motor_system._policy.state = self.dataset.reset()
@@ -933,9 +950,24 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
         *args,
         **kwargs,
     ):
-        """Initialize dataloader."""
+        """Initialize dataloader.
+
+        Args:
+            scenes: List of scenes
+            versions: List of versions
+            dataset (EnvironmentDataset): The environment dataset.
+            motor_system (MotorSystem): The motor system.
+            *args: Additional arguments
+            **kwargs: Additional keyword arguments
+
+        Raises:
+            ValueError: If `motor_system` is not an instance of `MotorSystem`.
+        """
         assert isinstance(dataset, EnvironmentDataset)
-        assert isinstance(motor_system, MotorSystem)
+        if not isinstance(motor_system, MotorSystem):
+            raise ValueError(
+                f"motor_system must be an instance of MotorSystem, got {motor_system}"
+            )
         self.dataset = dataset
         self.motor_system = motor_system
         self._observation, self.motor_system._policy.state = self.dataset.reset()
@@ -1012,9 +1044,22 @@ class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):
         *args,
         **kwargs,
     ):
-        """Initialize dataloader."""
+        """Initialize dataloader.
+
+        Args:
+            dataset (EnvironmentDataset): The environment dataset.
+            motor_system (MotorSystem): The motor system.
+            *args: Additional arguments
+            **kwargs: Additional keyword arguments
+
+        Raises:
+            ValueError: If `motor_system` is not an instance of `MotorSystem`.
+        """
         assert isinstance(dataset, EnvironmentDataset)
-        assert isinstance(motor_system, MotorSystem)
+        if not isinstance(motor_system, MotorSystem):
+            raise ValueError(
+                f"motor_system must be an instance of MotorSystem, got {motor_system}"
+            )
         # TODO: call super init instead of duplication code & generally clean up more
         self.dataset = dataset
         self.motor_system = motor_system

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -27,6 +27,7 @@ from tbp.monty.frameworks.models.motor_policies import (
     SurfacePolicy,
     SurfacePolicyCurvatureInformed,
 )
+from tbp.monty.frameworks.models.motor_system import MotorSystem
 
 from .embodied_environment import EmbodiedEnvironment
 
@@ -120,7 +121,7 @@ class EnvironmentDataLoader:
 
     Attributes:
         dataset: :class:`EnvironmentDataset`
-        motor_system: Callable -> action
+        motor_system: :class:`MotorSystem`
 
     Note:
         If the amount variable returned by motor_system is None, the amount used by
@@ -131,20 +132,20 @@ class EnvironmentDataLoader:
         This one on its own won't work.
     """
 
-    def __init__(self, dataset, motor_system, rng):
+    def __init__(self, dataset: EnvironmentDataset, motor_system: MotorSystem, rng):
         assert isinstance(dataset, EnvironmentDataset)
-        assert callable(motor_system)
+        assert isinstance(motor_system, MotorSystem)
         self.dataset = dataset
         self.motor_system = motor_system
         self.rng = rng
-        self._observation, self.motor_system.state = self.dataset.reset()
+        self._observation, self.motor_system._policy.state = self.dataset.reset()
         self._action = None
         self._amount = None
         self._counter = 0
 
     def __iter__(self):
         # Reset the environment before iterating
-        self._observation, self.motor_system.state = self.dataset.reset()
+        self._observation, self.motor_system._policy.state = self.dataset.reset()
         self._action = None
         self._amount = None
         self._counter = 0
@@ -158,7 +159,7 @@ class EnvironmentDataLoader:
         else:
             action = self.motor_system()
             self._action = action
-            self._observation, self.motor_system.state = self.dataset[action]
+            self._observation, self.motor_system._policy.state = self.dataset[action]
             self._counter += 1
             return self._observation
 
@@ -274,9 +275,9 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
         In addition, create a dictionary mapping back and forth between these IDs and
         the corresponding name of the object
         """
-        assert set(self.object_names).issubset(
-            set(self.source_object_list)
-        ), "Semantic mapping requires primary targets sampled from source list"
+        assert set(self.object_names).issubset(set(self.source_object_list)), (
+            "Semantic mapping requires primary targets sampled from source list"
+        )
 
         starting_integer = 1  # Start at 1 so that we can distinguish on-object semantic
         # IDs (>0) from being off object (semantic_id == 0 in Habitat by default)
@@ -378,14 +379,16 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
 
     def reset_agent(self):
         logging.debug("resetting agent------")
-        self._observation, self.motor_system.state = self.dataset.reset()
+        self._observation, self.motor_system._policy.state = self.dataset.reset()
         self._counter = 0
 
         # Make sure to also reset action variables when resetting agent during
         # pre-episode
         self._action = None
         self._amount = None
-        self.motor_system.state[self.motor_system.agent_id]["motor_only_step"] = False
+        self.motor_system._policy.state[self.motor_system._policy.agent_id][
+            "motor_only_step"
+        ] = False
 
         return self._observation
 
@@ -433,8 +436,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         # Check if any LM's have output a goal-state (such as hypothesis-testing
         # goal-state)
         elif (
-            self.motor_system.use_goal_state_driven_actions
-            and self.motor_system.driving_goal_state is not None
+            self.motor_system._policy.use_goal_state_driven_actions
+            and self.motor_system._policy.driving_goal_state is not None
         ):
             return self.execute_jump_attempt()
 
@@ -446,29 +449,34 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             # TODO refactor so that this check is done in the motor-policy, and we
             # update the constraint separately/appropriately; i.e. the below
             # code should be as general as possible
-            if isinstance(self.motor_system, SurfacePolicy) and self._action is None:
-                self._action = self.motor_system.touch_object(
+            if (
+                isinstance(self.motor_system._policy, SurfacePolicy)
+                and self._action is None
+            ):
+                self._action = self.motor_system._policy.touch_object(
                     self._observation, view_sensor_id="view_finder"
                 )
 
-                self.motor_system.state[self.motor_system.agent_id][
+                self.motor_system._policy.state[self.motor_system._policy.agent_id][
                     "motor_only_step"
                 ] = True
 
-            self._observation, self.motor_system.state = self.dataset[self._action]
+            self._observation, self.motor_system._policy.state = self.dataset[
+                self._action
+            ]
 
             # Check whether sensory information is just for feeding back to motor policy
             # TODO refactor so that the motor policy itself is making this update
             # when appropriate, not embodied_data
             if (
-                (type(self.motor_system) == SurfacePolicy)
-                or (type(self.motor_system) == SurfacePolicyCurvatureInformed)
+                (type(self.motor_system._policy) == SurfacePolicy)
+                or (type(self.motor_system._policy) == SurfacePolicyCurvatureInformed)
             ) and self._action.name != "orient_vertical":
-                self.motor_system.state[self.motor_system.agent_id][
+                self.motor_system._policy.state[self.motor_system._policy.agent_id][
                     "motor_only_step"
                 ] = True
             else:
-                self.motor_system.state[self.motor_system.agent_id][
+                self.motor_system._policy.state[self.motor_system._policy.agent_id][
                     "motor_only_step"
                 ] = False
 
@@ -482,9 +490,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             on_target_object = self.get_good_view_with_patch_refinement()
             if self.num_distractors == 0:
                 # Only perform this check if we aren't doing multi-object experiments.
-                assert (
-                    on_target_object
-                ), "Primary target must be visible at the start of the episode"
+                assert on_target_object, (
+                    "Primary target must be visible at the start of the episode"
+                )
 
     def first_step(self):
         """Carry out particular motor-system state updates required on the first step.
@@ -504,9 +512,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         # For first step of surface-agent policy, always bypass LM processing
         # For distant-agent policy, we still process the first sensation if it is
         # on the object
-        self.motor_system.state[self.motor_system.agent_id]["motor_only_step"] = (
-            isinstance(self.motor_system, SurfacePolicy)
-        )
+        self.motor_system._policy.state[self.motor_system._policy.agent_id][
+            "motor_only_step"
+        ] = isinstance(self.motor_system._policy, SurfacePolicy)
 
         return self._observation
 
@@ -525,10 +533,10 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         policy.
 
         First, the agent moves towards object until it fills a minimum of percentage
-        (given by `motor_system.good_view_percentage`) of the sensor's field of view
-        or the closest point of the object is less than a given distance
-        (`motor_system.desired_object_distance`) from the sensor. This makes sure
-        that big and small objects all fill similar amount of space in the sensor's
+        (given by `motor_system._policy.good_view_percentage`) of the sensor's field of
+        view or the closest point of the object is less than a given distance
+        (`motor_system._policy.desired_object_distance`) from the sensor. This makes
+        sure that big and small objects all fill similar amount of space in the sensor's
         field of view. Otherwise small objects may be too small to perform saccades or
         the sensor ends up inside of big objects. This step is performed by default
         but can be skipped by setting `allow_translation=False`.
@@ -558,25 +566,27 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         # object before we start moving forward; only done for multi-object experiments
         multiple_objects_present = self.num_distractors > 0
         if multiple_objects_present:
-            on_target_object = self.motor_system.is_on_target_object(
+            on_target_object = self.motor_system._policy.is_on_target_object(
                 self._observation,
                 sensor_id,
                 target_semantic_id=self.primary_target["semantic_id"],
                 multiple_objects_present=multiple_objects_present,
             )
             if not on_target_object:
-                actions = self.motor_system.orient_to_object(
+                actions = self.motor_system._policy.orient_to_object(
                     self._observation,
                     sensor_id,
                     target_semantic_id=self.primary_target["semantic_id"],
                     multiple_objects_present=multiple_objects_present,
                 )
                 for action in actions:
-                    self._observation, self.motor_system.state = self.dataset[action]
+                    self._observation, self.motor_system._policy.state = self.dataset[
+                        action
+                    ]
 
         if allow_translation:
             # Move closer to the object, if not already close enough
-            action, close_enough = self.motor_system.move_close_enough(
+            action, close_enough = self.motor_system._policy.move_close_enough(
                 self._observation,
                 sensor_id,
                 target_semantic_id=self.primary_target["semantic_id"],
@@ -585,15 +595,17 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             # Continue moving to a close distance to the object
             while not close_enough:
                 logging.debug("moving closer!")
-                self._observation, self.motor_system.state = self.dataset[action]
-                action, close_enough = self.motor_system.move_close_enough(
+                self._observation, self.motor_system._policy.state = self.dataset[
+                    action
+                ]
+                action, close_enough = self.motor_system._policy.move_close_enough(
                     self._observation,
                     sensor_id,
                     target_semantic_id=self.primary_target["semantic_id"],
                     multiple_objects_present=multiple_objects_present,
                 )
 
-        on_target_object = self.motor_system.is_on_target_object(
+        on_target_object = self.motor_system._policy.is_on_target_object(
             self._observation,
             sensor_id,
             target_semantic_id=self.primary_target["semantic_id"],
@@ -601,15 +613,17 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         )
         num_attempts = 0
         while not on_target_object and num_attempts < max_orientation_attempts:
-            actions = self.motor_system.orient_to_object(
+            actions = self.motor_system._policy.orient_to_object(
                 self._observation,
                 sensor_id,
                 target_semantic_id=self.primary_target["semantic_id"],
                 multiple_objects_present=multiple_objects_present,
             )
             for action in actions:
-                self._observation, self.motor_system.state = self.dataset[action]
-            on_target_object = self.motor_system.is_on_target_object(
+                self._observation, self.motor_system._policy.state = self.dataset[
+                    action
+                ]
+            on_target_object = self.motor_system._policy.is_on_target_object(
                 self._observation,
                 sensor_id,
                 target_semantic_id=self.primary_target["semantic_id"],
@@ -647,7 +661,6 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 break
         return on_target_object
 
-
     def execute_jump_attempt(self):
         """Attempt a hypothesis-testing "jump" onto a location of the object.
 
@@ -663,7 +676,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         # Store the current location and orientation of the agent
         # If the hypothesis-guided jump is unsuccesful (e.g. to empty space,
         # or inside an object, we return here)
-        pre_jump_state = self.motor_system.state[self.motor_system.agent_id]
+        pre_jump_state = self.motor_system._policy.state[
+            self.motor_system._policy.agent_id
+        ]
 
         # Check that all sensors have identical rotations - this is because actions
         # currently update them all together; if this changes, the code needs
@@ -682,15 +697,19 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         # Could also consider making use of decide_location_for_movement (or
         # decide_location_for_movement_matching)
 
-        (target_loc, target_np_quat) = self.motor_system.derive_habitat_goal_state()
+        (target_loc, target_np_quat) = (
+            self.motor_system._policy.derive_habitat_goal_state()
+        )
 
         # Update observations and motor system-state based on new pose
         set_agent_pose = SetAgentPose(
-            agent_id=self.motor_system.agent_id,
+            agent_id=self.motor_system._policy.agent_id,
             location=target_loc,
             rotation_quat=target_np_quat,
         )
-        self._observation, self.motor_system.state = self.dataset[set_agent_pose]
+        self._observation, self.motor_system._policy.state = self.dataset[
+            set_agent_pose
+        ]
 
         # As above, but now also accounting for resetting the sensor pose; this
         # is necessary for the distant agent, which pivots the camera around
@@ -698,27 +717,20 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         # modify this from the the unit quaternion and [0, 0, 0] position
         # anyways; further note this is globally applied to all sensors
         set_sensor_rotation = SetSensorRotation(
-            agent_id=self.motor_system.agent_id,
+            agent_id=self.motor_system._policy.agent_id,
             rotation_quat=quaternion.one,
         )
-        self._observation, self.motor_system.state = self.dataset[set_sensor_rotation]
+        self._observation, self.motor_system._policy.state = self.dataset[
+            set_sensor_rotation
+        ]
 
         # Check depth-at-center to see if the object is in front of us
         # As for methods such as touch_object, we use the view-finder
-        depth_at_center = self.motor_system.get_depth_at_center(
+        depth_at_center = self.motor_system._policy.get_depth_at_center(
             self._observation,
             view_sensor_id="view_finder",
             initial_pose=False,
         )
-
-        # Save the potential post-jump state for later visualization (i.e. of
-        # failed jumps)
-        # TODO M when updating code to visualize graph-mismatch, can also ensure we
-        # log this information as necessary
-        # temp_motor_state_copy = self.motor_system.convert_motor_state()
-        # self.motor_system.action_details["post_jump_pose"].append(
-        #     temp_motor_state_copy
-        # )
 
         # If depth_at_center < 1.0, there is a visible element within 1 meter of the
         # view-finder's central pixel)
@@ -732,12 +744,14 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         # and we provide the observation to the next step of the motor policy
         self._counter += 1
 
-        self.motor_system.state[self.motor_system.agent_id]["motor_only_step"] = True
+        self.motor_system._policy.state[self.motor_system._policy.agent_id][
+            "motor_only_step"
+        ] = True
 
         # Call post_action (normally taken care of __call__ within
-        # self.motor_system()) - TODO refactor so that the whole of the hypothesis
-        # driven jumps makes cleaner use of self.motor_system()
-        self.motor_system.post_action(self.motor_system.action)
+        # self.motor_system._policy()) - TODO refactor so that the whole of the
+        # hypothesis driven jumps makes cleaner use of self.motor_system()
+        self.motor_system._policy.post_action(self.motor_system._policy.action)
 
         return self._observation
 
@@ -750,14 +764,16 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             "Object visible, maintaining new pose for hypothesis-testing action"
         )
 
-        if isinstance(self.motor_system, SurfacePolicy):
+        if isinstance(self.motor_system._policy, SurfacePolicy):
             # For the surface-agent policy, update last action as if we have
             # just moved tangentially
             # Results in us seemlessly transitioning into the typical
             # corrective movements (forward or orientation) of the surface-agent
             # policy
-            self.motor_system.action = MoveTangentially(
-                agent_id=self.motor_system.agent_id, distance=0.0, direction=[0, 0, 0]
+            self.motor_system._policy.action = MoveTangentially(
+                agent_id=self.motor_system._policy.agent_id,
+                distance=0.0,
+                direction=[0, 0, 0],
             )
 
             # Store logging information about jump success; when doing refactor
@@ -767,9 +783,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             # TODO M clean up these action details loggings; this may need to remain
             # local to a "motor-system buffer" given that these are model-free
             # actions that have nothing to do with the LMs
-            self.motor_system.action_details["pc_heading"].append("jump")
-            self.motor_system.action_details["avoidance_heading"].append(False)
-            self.motor_system.action_details["z_defined_pc"].append(None)
+            self.motor_system._policy.action_details["pc_heading"].append("jump")
+            self.motor_system._policy.action_details["avoidance_heading"].append(False)
+            self.motor_system._policy.action_details["z_defined_pc"].append(None)
 
         else:
             self.get_good_view_with_patch_refinement()
@@ -783,36 +799,44 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         logging.debug("Returning to previous position")
 
         set_agent_pose = SetAgentPose(
-            agent_id=self.motor_system.agent_id,
+            agent_id=self.motor_system._policy.agent_id,
             location=pre_jump_state["position"],
             rotation_quat=pre_jump_state["rotation"],
         )
-        self._observation, self.motor_system.state = self.dataset[set_agent_pose]
+        self._observation, self.motor_system._policy.state = self.dataset[
+            set_agent_pose
+        ]
 
         # All sensors are updated globally by actions, and are therefore
         # identical
         set_sensor_rotation = SetSensorRotation(
-            agent_id=self.motor_system.agent_id,
+            agent_id=self.motor_system._policy.agent_id,
             rotation_quat=pre_jump_state["sensors"][first_sensor]["rotation"],
         )
-        self._observation, self.motor_system.state = self.dataset[set_sensor_rotation]
+        self._observation, self.motor_system._policy.state = self.dataset[
+            set_sensor_rotation
+        ]
 
         assert np.all(
-            self.motor_system.state[self.motor_system.agent_id]["position"]
+            self.motor_system._policy.state[self.motor_system._policy.agent_id][
+                "position"
+            ]
             == pre_jump_state["position"]
         ), "Failed to return agent to location"
         assert np.all(
-            self.motor_system.state[self.motor_system.agent_id]["rotation"]
+            self.motor_system._policy.state[self.motor_system._policy.agent_id][
+                "rotation"
+            ]
             == pre_jump_state["rotation"]
         ), "Failed to return agent to orientation"
 
-        for current_sensor in self.motor_system.state[self.motor_system.agent_id][
-            "sensors"
-        ].keys():
+        for current_sensor in self.motor_system._policy.state[
+            self.motor_system._policy.agent_id
+        ]["sensors"].keys():
             assert np.all(
-                self.motor_system.state[self.motor_system.agent_id]["sensors"][
-                    current_sensor
-                ]["rotation"]
+                self.motor_system._policy.state[self.motor_system._policy.agent_id][
+                    "sensors"
+                ][current_sensor]["rotation"]
                 == pre_jump_state["sensors"][current_sensor]["rotation"]
             ), "Failed to return sensor to orientation"
 
@@ -831,16 +855,16 @@ class OmniglotDataLoader(EnvironmentDataLoaderPerObject):
         characters,
         versions,
         dataset,
-        motor_system,
+        motor_system: MotorSystem,
         *args,
         **kwargs,
     ):
         """Initialize dataloader."""
         assert isinstance(dataset, EnvironmentDataset)
-        assert callable(motor_system)
+        assert isinstance(motor_system, MotorSystem)
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, self.motor_system.state = self.dataset.reset()
+        self._observation, self.motor_system._policy.state = self.dataset.reset()
         self._action = None
         self._amount = None
         self._counter = 0
@@ -904,17 +928,17 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
         self,
         scenes,
         versions,
-        dataset,
-        motor_system,
+        dataset: EnvironmentDataset,
+        motor_system: MotorSystem,
         *args,
         **kwargs,
     ):
         """Initialize dataloader."""
         assert isinstance(dataset, EnvironmentDataset)
-        assert callable(motor_system)
+        assert isinstance(motor_system, MotorSystem)
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, self.motor_system.state = self.dataset.reset()
+        self._observation, self.motor_system._policy.state = self.dataset.reset()
         self._action = None
         self._amount = None
         self._counter = 0
@@ -983,18 +1007,18 @@ class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):
 
     def __init__(
         self,
-        dataset,
-        motor_system,
+        dataset: EnvironmentDataset,
+        motor_system: MotorSystem,
         *args,
         **kwargs,
     ):
         """Initialize dataloader."""
         assert isinstance(dataset, EnvironmentDataset)
-        assert callable(motor_system)
+        assert isinstance(motor_system, MotorSystem)
         # TODO: call super init instead of duplication code & generally clean up more
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, self.motor_system.state = self.dataset.reset()
+        self._observation, self.motor_system._policy.state = self.dataset.reset()
         self._action = None
         self._amount = None
         self._counter = 0

--- a/src/tbp/monty/frameworks/experiments/data_collection_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/data_collection_experiments.py
@@ -44,7 +44,7 @@ class DataCollectionExperiment(MontyObjectRecognitionExperiment):
 
     def pass_features_to_motor_system(self, observation, step):
         self.model.aggregate_sensory_inputs(observation)
-        self.model.motor_system.processed_observations = (
+        self.model.motor_system._policy.processed_observations = (
             self.model.sensor_module_outputs[0]
         )
         # Add the object and action to the observation dict
@@ -53,16 +53,16 @@ class DataCollectionExperiment(MontyObjectRecognitionExperiment):
         )
         self.model.sensor_modules[0].processed_obs[-1]["action"] = (
             None
-            if self.model.motor_system.action is None
+            if self.model.motor_system._policy.action is None
             else (
-                f"{self.model.motor_system.action.agent_id}."
-                f"{self.model.motor_system.action.name}"
+                f"{self.model.motor_system._policy.action.agent_id}."
+                f"{self.model.motor_system._policy.action.name}"
             )
         )
         # Only include observations coming right before a move_tangentially action
         if step > 0 and (
-            self.model.motor_system.action is None
-            or self.model.motor_system.action.name != "move_tangentially"
+            self.model.motor_system._policy.action is None
+            or self.model.motor_system._policy.action.name != "move_tangentially"
         ):
             del self.model.sensor_modules[0].processed_obs[-2]
 

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -35,7 +35,8 @@ from tbp.monty.frameworks.models.abstract_monty_classes import (
     SensorModule,
 )
 from tbp.monty.frameworks.models.monty_base import MontyBase
-from tbp.monty.frameworks.models.motor_policies import MotorSystem
+from tbp.monty.frameworks.models.motor_policies import MotorPolicy
+from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.frameworks.utils.dataclass_utils import (
     config_to_dict,
     get_subset_of_args,
@@ -134,7 +135,11 @@ class MontyExperiment:
         motor_system_class = motor_system_config["motor_system_class"]
         motor_system_args = motor_system_config["motor_system_args"]
         assert issubclass(motor_system_class, MotorSystem)
-        motor_system = motor_system_class(rng=self.rng, **motor_system_args)
+        policy_class = motor_system_args["policy_class"]
+        policy_args = motor_system_args["policy_args"]
+        assert issubclass(policy_class, MotorPolicy)
+        policy = policy_class(rng=self.rng, **policy_args)
+        motor_system = motor_system_class(policy=policy)
 
         # Get mapping between sensor modules, learning modules and agents
         lm_len = len(learning_modules)

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -106,6 +106,10 @@ class MontyExperiment:
 
         Returns:
             Monty class instance
+
+        Raises:
+            ValueError: If `motor_system_class` is not a subclass of `MotorSystem` or
+                `policy_class` is not a subclass of `MotorPolicy`.
         """
         monty_config = copy.deepcopy(monty_config)
 
@@ -134,10 +138,17 @@ class MontyExperiment:
         motor_system_config = monty_config.pop("motor_system_config")
         motor_system_class = motor_system_config["motor_system_class"]
         motor_system_args = motor_system_config["motor_system_args"]
-        assert issubclass(motor_system_class, MotorSystem)
+        if not issubclass(motor_system_class, MotorSystem):
+            raise ValueError(
+                "motor_system_class must be a subclass of MotorSystem, got "
+                f"{motor_system_class}"
+            )
         policy_class = motor_system_args["policy_class"]
         policy_args = motor_system_args["policy_args"]
-        assert issubclass(policy_class, MotorPolicy)
+        if not issubclass(policy_class, MotorPolicy):
+            raise ValueError(
+                f"policy_class must be a subclass of MotorPolicy, got {policy_class}"
+            )
         policy = policy_class(rng=self.rng, **policy_args)
         motor_system = motor_system_class(policy=policy)
 

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -190,7 +190,7 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
         mlh_id = mlh["graph_id"].split("_")
         for word in mlh_id:
             new_text += r"$\bf{" + word + "}$ "
-        new_text += f"with evidence {np.round(mlh['evidence'], 2)}\n\n"
+        new_text += f"with evidence {np.round(mlh['evidence'],2)}\n\n"
         pms = self.model.learning_modules[0].get_possible_matches()
         graph_ids, evidences = self.model.learning_modules[
             0
@@ -203,12 +203,12 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
             new_text += "2nd MLH: "
             for word in second_id:
                 new_text += r"$\bf{" + word + "}$ "
-            new_text += f"with evidence {np.round(evidences[top_indices[1]], 2)}\n\n"
+            new_text += f"with evidence {np.round(evidences[top_indices[1]],2)}\n\n"
 
         new_text += r"$\bf{Possible}$ $\bf{matches:}$"
         for gid, ev in zip(graph_ids, evidences):
             if gid in pms:
-                new_text += f"\n{gid}: {np.round(ev, 1)}"
+                new_text += f"\n{gid}: {np.round(ev,1)}"
 
         self.text = self.ax[0].text(0, pos + 30, new_text, va="top")
 

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -136,13 +136,13 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
         if self.camera_image:
             self.camera_image.remove()
 
-        view_finder_image = observation[self.model.motor_system.agent_id][sensor_id][
-            "rgba"
-        ]
+        view_finder_image = observation[self.model.motor_system._policy.agent_id][
+            sensor_id
+        ]["rgba"]
         if isinstance(self.dataloader, SaccadeOnImageDataLoader):
             center_pixel_id = np.array([200, 200])
             patch_size = np.array(
-                observation[self.model.motor_system.agent_id]["patch"]["depth"]
+                observation[self.model.motor_system._policy.agent_id]["patch"]["depth"]
             ).shape[0]
             raw_obs = self.model.sensor_modules[0].raw_observations
             if len(raw_obs) > 0:
@@ -158,9 +158,9 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
             )
             # Show a square in the middle as a rough estimate of where the patch is
             if step == 0:
-                image_shape = observation[self.model.motor_system.agent_id][sensor_id][
-                    "rgba"
-                ].shape
+                image_shape = observation[self.model.motor_system._policy.agent_id][
+                    sensor_id
+                ]["rgba"].shape
                 square = plt.Rectangle(
                     (image_shape[1] * 4.5 // 10, image_shape[0] * 4.5 // 10),
                     image_shape[1] / 10,
@@ -178,7 +178,7 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
         if self.depth_image:
             self.depth_image.remove()
         self.depth_image = self.ax[1].imshow(
-            observation[self.model.motor_system.agent_id][sensor_id]["depth"],
+            observation[self.model.motor_system._policy.agent_id][sensor_id]["depth"],
             cmap="viridis_r",
         )
         # self.colorbar.update_normal(self.depth_image)
@@ -190,7 +190,7 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
         mlh_id = mlh["graph_id"].split("_")
         for word in mlh_id:
             new_text += r"$\bf{" + word + "}$ "
-        new_text += f"with evidence {np.round(mlh['evidence'],2)}\n\n"
+        new_text += f"with evidence {np.round(mlh['evidence'], 2)}\n\n"
         pms = self.model.learning_modules[0].get_possible_matches()
         graph_ids, evidences = self.model.learning_modules[
             0
@@ -203,12 +203,12 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
             new_text += "2nd MLH: "
             for word in second_id:
                 new_text += r"$\bf{" + word + "}$ "
-            new_text += f"with evidence {np.round(evidences[top_indices[1]],2)}\n\n"
+            new_text += f"with evidence {np.round(evidences[top_indices[1]], 2)}\n\n"
 
         new_text += r"$\bf{Possible}$ $\bf{matches:}$"
         for gid, ev in zip(graph_ids, evidences):
             if gid in pms:
-                new_text += f"\n{gid}: {np.round(ev,1)}"
+                new_text += f"\n{gid}: {np.round(ev, 1)}"
 
         self.text = self.ax[0].text(0, pos + 30, new_text, va="top")
 

--- a/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
+++ b/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
@@ -212,7 +212,7 @@ class BasicGraphMatchingLogger(BaseMontyLogger):
 
         mode = model.experiment_mode
         episode = logger_args[f"{mode}_episodes"]
-        actions = model.motor_system.action_sequence
+        actions = model.motor_system._policy.action_sequence
         logger_time = {k: v for k, v in logger_args.items() if k != "target"}
         self.data["BASIC"][f"{mode}_stats"][episode] = performance_dict
 
@@ -500,14 +500,14 @@ class DetailedGraphMatchingLogger(BasicGraphMatchingLogger):
         # TODO ensure will work with multiple, independent sensor agents
         buffer_data["motor_system"] = dict()
         buffer_data["motor_system"]["action_sequence"] = (
-            model.motor_system.action_sequence
+            model.motor_system._policy.action_sequence
         )
 
         # Some motor systems store additional data specific to their policy, e.g. when
         # principal curvature has informed movements
-        if hasattr(model.motor_system, "action_details"):
+        if hasattr(model.motor_system._policy, "action_details"):
             buffer_data["motor_system"]["action_details"] = (
-                model.motor_system.action_details
+                model.motor_system._policy.action_details
             )
 
         self.data["DETAILED"][episodes] = buffer_data

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -65,7 +65,7 @@ class MontyForEvidenceGraphMatching(MontyForGraphMatching):
         super()._pass_infos_to_motor_system()
 
         # Check the motor-system can receive goal-states
-        if self.motor_system.use_goal_state_driven_actions:
+        if self.motor_system._policy.use_goal_state_driven_actions:
             best_goal_state = None
             best_goal_confidence = -np.inf
             for current_goal_state in self.gsg_outputs:
@@ -76,7 +76,7 @@ class MontyForEvidenceGraphMatching(MontyForGraphMatching):
                     best_goal_state = current_goal_state
                     best_goal_confidence = current_goal_state.confidence
 
-            self.motor_system.set_driving_goal_state(best_goal_state)
+            self.motor_system._policy.set_driving_goal_state(best_goal_state)
 
     def _combine_votes(self, votes_per_lm):
         """Combine evidence from different lms.
@@ -1079,8 +1079,8 @@ class EvidenceGraphLM(GraphLM):
         assert not np.isnan(np.max(self.evidence[graph_id])), "evidence contains NaN."
         logging.debug(
             f"evidence update for {graph_id} took "
-            f"{np.round(end_time - start_time,2)} seconds."
-            f" New max evidence: {np.round(np.max(self.evidence[graph_id]),3)}"
+            f"{np.round(end_time - start_time, 2)} seconds."
+            f" New max evidence: {np.round(np.max(self.evidence[graph_id]), 3)}"
         )
 
     def _update_evidence_with_vote(self, state_votes, graph_id):
@@ -1169,7 +1169,7 @@ class EvidenceGraphLM(GraphLM):
             The location evidence.
         """
         logging.debug(
-            f"Calculating evidence for {graph_id} using input from " f"{input_channel}"
+            f"Calculating evidence for {graph_id} using input from {input_channel}"
         )
 
         pose_transformed_features = rotate_pose_dependent_features(
@@ -1597,7 +1597,7 @@ class EvidenceGraphLM(GraphLM):
         all_possible_locations = np.zeros((1, 3))
         all_possible_rotations = np.zeros((1, 3, 3))
 
-        logging.debug("Determining possible poses using input from " f"{input_channel}")
+        logging.debug(f"Determining possible poses using input from {input_channel}")
         node_directions = self.graph_memory.get_rotation_features_at_all_nodes(
             graph_id, input_channel
         )
@@ -1739,7 +1739,7 @@ class EvidenceGraphLM(GraphLM):
                 mlh["graph_id"] = "new_object0"
             logging.info(
                 f"current most likely hypothesis: {mlh['graph_id']} "
-                f"with evidence {np.round(mlh['evidence'],2)}"
+                f"with evidence {np.round(mlh['evidence'], 2)}"
             )
         return mlh
 
@@ -1764,9 +1764,9 @@ class EvidenceGraphLM(GraphLM):
         ) and self.evidence_update_threshold.endswith("%"):
             percentage_str = self.evidence_update_threshold.strip("%")
             percentage = float(percentage_str)
-            assert (
-                percentage >= 0 and percentage <= 100
-            ), "Percentage must be between 0 and 100"
+            assert percentage >= 0 and percentage <= 100, (
+                "Percentage must be between 0 and 100"
+            )
             max_global_evidence = self.current_mlh["evidence"]
             x_percent_of_max = max_global_evidence * (percentage / 100)
             return max_global_evidence - x_percent_of_max

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -1079,8 +1079,8 @@ class EvidenceGraphLM(GraphLM):
         assert not np.isnan(np.max(self.evidence[graph_id])), "evidence contains NaN."
         logging.debug(
             f"evidence update for {graph_id} took "
-            f"{np.round(end_time - start_time, 2)} seconds."
-            f" New max evidence: {np.round(np.max(self.evidence[graph_id]), 3)}"
+            f"{np.round(end_time - start_time,2)} seconds."
+            f" New max evidence: {np.round(np.max(self.evidence[graph_id]),3)}"
         )
 
     def _update_evidence_with_vote(self, state_votes, graph_id):
@@ -1169,7 +1169,7 @@ class EvidenceGraphLM(GraphLM):
             The location evidence.
         """
         logging.debug(
-            f"Calculating evidence for {graph_id} using input from {input_channel}"
+            f"Calculating evidence for {graph_id} using input from " f"{input_channel}"
         )
 
         pose_transformed_features = rotate_pose_dependent_features(
@@ -1597,7 +1597,7 @@ class EvidenceGraphLM(GraphLM):
         all_possible_locations = np.zeros((1, 3))
         all_possible_rotations = np.zeros((1, 3, 3))
 
-        logging.debug(f"Determining possible poses using input from {input_channel}")
+        logging.debug("Determining possible poses using input from " f"{input_channel}")
         node_directions = self.graph_memory.get_rotation_features_at_all_nodes(
             graph_id, input_channel
         )
@@ -1739,7 +1739,7 @@ class EvidenceGraphLM(GraphLM):
                 mlh["graph_id"] = "new_object0"
             logging.info(
                 f"current most likely hypothesis: {mlh['graph_id']} "
-                f"with evidence {np.round(mlh['evidence'], 2)}"
+                f"with evidence {np.round(mlh['evidence'],2)}"
             )
         return mlh
 
@@ -1764,9 +1764,9 @@ class EvidenceGraphLM(GraphLM):
         ) and self.evidence_update_threshold.endswith("%"):
             percentage_str = self.evidence_update_threshold.strip("%")
             percentage = float(percentage_str)
-            assert percentage >= 0 and percentage <= 100, (
-                "Percentage must be between 0 and 100"
-            )
+            assert (
+                percentage >= 0 and percentage <= 100
+            ), "Percentage must be between 0 and 100"
             max_global_evidence = self.current_mlh["evidence"]
             x_percent_of_max = max_global_evidence * (percentage / 100)
             return max_global_evidence - x_percent_of_max

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -158,7 +158,7 @@ class MontyForGraphMatching(MontyBase):
         for lm in self.learning_modules:
             lm.update_terminal_condition()
             logging.debug(
-                f"{lm.learning_module_id} has terminal state: {lm.terminal_state}"
+                f"{lm.learning_module_id} has terminal state: " f"{lm.terminal_state}"
             )
             # If any LM is not done yet, we are not done yet
             if lm.terminal_state == "match":
@@ -921,15 +921,16 @@ class GraphLM(LearningModule):
 
     def set_individual_ts(self, terminal_state):
         logging.info(
-            f"Setting terminal state of {self.learning_module_id} to {terminal_state}"
+            f"Setting terminal state of {self.learning_module_id} "
+            f"to {terminal_state}"
         )
         self.set_detected_object(terminal_state)
         if terminal_state == "match":
             logging.info(
                 f"{self.learning_module_id}: "
                 f"Detected {self.detected_object} "
-                f"at location {np.round(self.detected_pose[:3], 3)},"
-                f" rotation {np.round(self.detected_pose[3:6], 3)},"
+                f"at location {np.round(self.detected_pose[:3],3)},"
+                f" rotation {np.round(self.detected_pose[3:6],3)},"
                 f" and scale {self.detected_pose[6]}"
             )
             self.buffer.set_individual_ts(self.detected_object, self.detected_pose)

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -158,7 +158,7 @@ class MontyForGraphMatching(MontyBase):
         for lm in self.learning_modules:
             lm.update_terminal_condition()
             logging.debug(
-                f"{lm.learning_module_id} has terminal state: " f"{lm.terminal_state}"
+                f"{lm.learning_module_id} has terminal state: {lm.terminal_state}"
             )
             # If any LM is not done yet, we are not done yet
             if lm.terminal_state == "match":
@@ -498,11 +498,11 @@ class MontyForGraphMatching(MontyBase):
         provides locations associated with tangential movements; this can help ensure we
         e.g. avoid revisiting old locations.
         """
-        self.motor_system.processed_observations = infos
+        self.motor_system._policy.processed_observations = infos
 
         # TODO M clean up the below when refactoring the surface-agent policy
-        if hasattr(self.motor_system, "tangent_locs"):
-            last_action = self.motor_system.last_action()
+        if hasattr(self.motor_system._policy, "tangent_locs"):
+            last_action = self.motor_system._policy.last_action
 
             if last_action is not None:
                 if "orient_vertical" == last_action.name:
@@ -510,10 +510,10 @@ class MontyForGraphMatching(MontyBase):
                     # action, rather than some form of corrective movement; these
                     # movements are performed immediately after "orient_vertical"
                     # TODO generalize to multiple sensor modules
-                    self.motor_system.tangent_locs.append(
+                    self.motor_system._policy.tangent_locs.append(
                         self.sensor_modules[0].visited_locs[-1]
                     )
-                    self.motor_system.tangent_norms.append(
+                    self.motor_system._policy.tangent_norms.append(
                         self.sensor_modules[0].visited_normals[-1]
                     )
 
@@ -921,16 +921,15 @@ class GraphLM(LearningModule):
 
     def set_individual_ts(self, terminal_state):
         logging.info(
-            f"Setting terminal state of {self.learning_module_id} "
-            f"to {terminal_state}"
+            f"Setting terminal state of {self.learning_module_id} to {terminal_state}"
         )
         self.set_detected_object(terminal_state)
         if terminal_state == "match":
             logging.info(
                 f"{self.learning_module_id}: "
                 f"Detected {self.detected_object} "
-                f"at location {np.round(self.detected_pose[:3],3)},"
-                f" rotation {np.round(self.detected_pose[3:6],3)},"
+                f"at location {np.round(self.detected_pose[:3], 3)},"
+                f" rotation {np.round(self.detected_pose[3:6], 3)},"
                 f" and scale {self.detected_pose[6]}"
             )
             self.buffer.set_individual_ts(self.detected_object, self.detected_pose)

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -18,6 +18,7 @@ from tbp.monty.frameworks.models.abstract_monty_classes import (
     Monty,
     SensorModule,
 )
+from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.frameworks.models.states import State
 from tbp.monty.frameworks.utils.communication_utils import get_first_sensory_state
 
@@ -29,7 +30,7 @@ class MontyBase(Monty):
         self,
         sensor_modules,
         learning_modules,
-        motor_system,
+        motor_system: MotorSystem,
         sm_to_agent_dict,
         sm_to_lm_matrix,
         lm_to_lm_matrix,
@@ -374,7 +375,7 @@ class MontyBase(Monty):
         sm_dict = {
             i: module.state_dict() for i, module in enumerate(self.sensor_modules)
         }
-        motor_system_dict = self.motor_system.state_dict()
+        motor_system_dict = self.motor_system._policy.state_dict()
 
         return dict(
             lm_dict=lm_dict,
@@ -436,11 +437,11 @@ class MontyBase(Monty):
         Returns:
             State of the agent.
         """
-        return self.motor_system.get_agent_state()
+        return self.motor_system._policy.get_agent_state()
 
     @property
     def is_motor_only_step(self):
-        return self.motor_system.is_motor_only_step
+        return self.motor_system._policy.is_motor_only_step
 
     @property
     def is_done(self):

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -50,7 +50,11 @@ class MotorPolicy(abc.ABC):
 
     @abc.abstractmethod
     def dynamic_call(self) -> Action:
-        """Use this method when actions are not predefined."""
+        """Use this method when actions are not predefined.
+
+        Returns:
+            (Action): The action to take.
+        """
         pass
 
     @property
@@ -80,7 +84,11 @@ class MotorPolicy(abc.ABC):
 
     @abc.abstractmethod
     def predefined_call(self) -> Action:
-        """Use this method when actions are not predefined."""
+        """Use this method when actions are not predefined.
+
+        Returns:
+            (Action): The action to take.
+        """
         pass
 
     @abc.abstractmethod

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -60,7 +60,7 @@ class MotorPolicy(abc.ABC):
     @property
     @abc.abstractmethod
     def last_action(self) -> Action:
-        """Retrieves the last action taken by the motor policy."""
+        """Returns the last action taken by the motor policy."""
         pass
 
     @abc.abstractmethod
@@ -84,7 +84,7 @@ class MotorPolicy(abc.ABC):
 
     @abc.abstractmethod
     def predefined_call(self) -> Action:
-        """Use this method when actions are not predefined.
+        """Use this method when actions are predefined.
 
         Returns:
             (Action): The action to take.

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -14,7 +14,7 @@ import json
 import logging
 import math
 import os
-from typing import Any, Callable, Dict, List, Mapping, Tuple, Type, Union, cast
+from typing import Dict, List, Literal, Mapping, Tuple, Type, Union, cast
 
 import numpy as np
 import quaternion as qt
@@ -42,38 +42,53 @@ from tbp.monty.frameworks.utils.spatial_arithmetics import get_angle_beefed_up
 from tbp.monty.frameworks.utils.transform_utils import scipy_to_numpy_quat
 
 
-class MotorSystem(abc.ABC, Callable):
-    @property
-    @abc.abstractmethod
-    def last_action(self) -> Action:
-        pass
+class MotorPolicy(abc.ABC):
+    """The abstract scaffold for motor policies."""
 
-    @abc.abstractmethod
-    def set_experiment_mode(self, mode):
-        pass
+    def __init__(self) -> None:
+        self.is_predefined = False
 
     @abc.abstractmethod
     def dynamic_call(self) -> Action:
         """Use this method when actions are not predefined."""
         pass
 
+    @property
     @abc.abstractmethod
-    def predefined_call(self) -> Tuple[Union[str, None], Any]:
-        """Use this method when actions are not predefined."""
+    def last_action(self) -> Action:
+        """Retrieves the last action taken by the motor policy."""
         pass
 
     @abc.abstractmethod
     def post_action(self, action: Action) -> None:
-        """This method will automatically be called at the end of __call__."""
+        """This post action hook will automatically be called at the end of __call__."""
+        pass
+
+    @abc.abstractmethod
+    def post_episode(self) -> None:
+        """Post episode hook."""
+        pass
+
+    @abc.abstractmethod
+    def pre_episode(self) -> None:
+        """Pre episode hook."""
+        pass
+
+    @abc.abstractmethod
+    def predefined_call(self) -> Action:
+        """Use this method when actions are not predefined."""
+        pass
+
+    @abc.abstractmethod
+    def set_experiment_mode(self, mode: Literal["train", "eval"]) -> None:
+        """Sets the experiment mode."""
         pass
 
     def __call__(self) -> Action:
-        """Defines the structure for __call__.
-
-        Selects dynamic or predfined call, and then calls post_action.
+        """Select either dynamic or predefined call.
 
         Returns:
-            Action to take.
+            (Action): The action to take.
         """
         if self.is_predefined:
             action = self.predefined_call()
@@ -83,7 +98,7 @@ class MotorSystem(abc.ABC, Callable):
         return action
 
 
-class BasePolicy(MotorSystem):
+class BasePolicy(MotorPolicy):
     def __init__(
         self,
         rng,
@@ -106,6 +121,7 @@ class BasePolicy(MotorSystem):
             file_name: Path to file with predefined actions. Defaults to None.
             file_names_per_episode: ?. Defaults to None.
         """
+        super().__init__()
         ###
         # Define instance attributes
         ###
@@ -209,11 +225,9 @@ class BasePolicy(MotorSystem):
         else:
             return False
 
+    @property
     def last_action(self) -> Action:
         return self.action
-
-    def update(self, *args):
-        pass
 
     def state_dict(self):
         return {"timestep": self.timestep, "episode_step": self.episode_step}
@@ -222,7 +236,7 @@ class BasePolicy(MotorSystem):
         self.timestep = state_dict["timestep"]
         self.episode_step = state_dict["episode_step"]
 
-    def set_experiment_mode(self, mode):
+    def set_experiment_mode(self, mode: Literal["train", "eval"]) -> None:
         pass
 
 
@@ -430,7 +444,7 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
         An Action.undo of some sort would be a better solution, however it is not
         yet clear to me what to do for actions that do not support undo.
         """
-        last_action = self.last_action()
+        last_action = self.last_action
 
         if isinstance(last_action, LookDown):
             return LookDown(
@@ -1201,7 +1215,7 @@ class SurfacePolicy(InformedPolicy):
         if not hasattr(self, "processed_observations"):
             return None
 
-        last_action = self.last_action()
+        last_action = self.last_action
 
         if isinstance(last_action, MoveForward):
             return self._orient_horizontal()

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -61,7 +61,11 @@ class MotorPolicy(abc.ABC):
 
     @abc.abstractmethod
     def post_action(self, action: Action) -> None:
-        """This post action hook will automatically be called at the end of __call__."""
+        """This post action hook will automatically be called at the end of __call__.
+
+        Args:
+            action (Action): The action to process the hook for.
+        """
         pass
 
     @abc.abstractmethod
@@ -81,7 +85,11 @@ class MotorPolicy(abc.ABC):
 
     @abc.abstractmethod
     def set_experiment_mode(self, mode: Literal["train", "eval"]) -> None:
-        """Sets the experiment mode."""
+        """Sets the experiment mode.
+
+        Args:
+            mode (Literal["train", "eval"]): The experiment mode to set.
+        """
         pass
 
     def __call__(self) -> Action:

--- a/src/tbp/monty/frameworks/models/motor_system.py
+++ b/src/tbp/monty/frameworks/models/motor_system.py
@@ -27,7 +27,7 @@ class MotorSystem:
 
     @property
     def last_action(self) -> Action:
-        """Retrieves the last action taken by the motor system."""
+        """Returns the last action taken by the motor system."""
         return self._policy.last_action
 
     def post_episode(self) -> None:

--- a/src/tbp/monty/frameworks/models/motor_system.py
+++ b/src/tbp/monty/frameworks/models/motor_system.py
@@ -1,0 +1,58 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+
+from typing import Literal
+
+from tbp.monty.frameworks.actions.actions import Action
+from tbp.monty.frameworks.models.motor_policies import MotorPolicy
+
+
+class MotorSystem:
+    """The basic motor system implementation."""
+
+    def __init__(self, policy: MotorPolicy) -> None:
+        """Initialize the motor system with a motor policy.
+
+        Args:
+            policy (MotorPolicy): The motor policy to use.
+        """
+        self._policy = policy
+
+    @property
+    def last_action(self) -> Action:
+        """Retrieves the last action taken by the motor system."""
+        return self._policy.last_action
+
+    def post_episode(self) -> None:
+        """Post episode hook."""
+        self._policy.post_episode()
+
+    def pre_episode(self) -> None:
+        """Pre episode hook."""
+        self._policy.pre_episode()
+
+    def set_experiment_mode(self, mode: Literal["train", "eval"]) -> None:
+        """Sets the experiment mode.
+
+        Args:
+            mode (Literal["train", "eval"]): The experiment mode.
+        """
+        self._policy.set_experiment_mode(mode)
+
+    def __call__(self) -> Action:
+        """Defines the structure for __call__.
+
+        Delegates to the motor policy.
+
+        Returns:
+            (Action): The action to take.
+        """
+        action = self._policy()
+        return action

--- a/src/tbp/monty/frameworks/utils/follow_up_configs.py
+++ b/src/tbp/monty/frameworks/utils/follow_up_configs.py
@@ -98,8 +98,8 @@ def create_eval_episode_config(
         output_dir, "reproduce_episode_data", f"eval_episode_{episode}_actions.jsonl"
     )
     new_config["monty_config"]["motor_system_config"]["motor_system_args"][
-        "file_name"
-    ] = motor_file
+        "policy_args"
+    ]["file_name"] = motor_file
 
     # 2) Load object params from this episode into dataloader config
     object_params_file = os.path.join(
@@ -233,7 +233,7 @@ def create_eval_config_multiple_episodes(
         )
     )
     new_config["monty_config"]["motor_system_config"]["motor_system_args"][
-        "file_names_per_episode"
-    ] = file_names_per_episode
+        "policy_args"
+    ]["file_names_per_episode"] = file_names_per_episode
 
     return new_config

--- a/tests/unit/embodied_data_test.py
+++ b/tests/unit/embodied_data_test.py
@@ -34,6 +34,7 @@ from tbp.monty.frameworks.environments.two_d_data import (
     SaccadeOnImageFromStreamEnvironment,
 )
 from tbp.monty.frameworks.models.motor_policies import BasePolicy
+from tbp.monty.frameworks.models.motor_system import MotorSystem
 
 AGENT_ID = "agent_id_0"
 SENSOR_ID = "sensor_id_0"
@@ -152,12 +153,14 @@ class EmbodiedDataTest(unittest.TestCase):
         self.assertSequenceEqual(action_space_dist, EXPECTED_ACTIONS_DIST)
         self.assertIn(action_space_dist.sample(), EXPECTED_ACTIONS_DIST)
 
-        motor_system_config_dist = make_base_policy_config(
+        base_policy_config_dist = make_base_policy_config(
             action_space_type="distant_agent",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
-        motor_system_dist = BasePolicy(rng=rng, **motor_system_config_dist.__dict__)
+        motor_system_dist = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_dist.__dict__)
+        )
 
         for i in range(1, DATASET_LEN):
             obs_dist, _ = dataset_dist[motor_system_dist()]
@@ -195,12 +198,14 @@ class EmbodiedDataTest(unittest.TestCase):
         self.assertSequenceEqual(action_space_abs, EXPECTED_ACTIONS_ABS)
         self.assertIn(action_space_abs.sample(), EXPECTED_ACTIONS_ABS)
 
-        motor_system_config_abs = make_base_policy_config(
+        base_policy_config_abs = make_base_policy_config(
             action_space_type="absolute_only",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
-        motor_system_abs = BasePolicy(rng=rng, **motor_system_config_abs.__dict__)
+        motor_system_abs = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_abs.__dict__)
+        )
 
         for i in range(1, DATASET_LEN):
             obs_abs, _ = dataset_abs[motor_system_abs()]
@@ -233,12 +238,14 @@ class EmbodiedDataTest(unittest.TestCase):
             rng=rng,
         )
 
-        motor_system_config_dist = make_base_policy_config(
+        base_policy_config_dist = make_base_policy_config(
             action_space_type="distant_agent",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
-        motor_system_dist = BasePolicy(rng=rng, **motor_system_config_dist.__dict__)
+        motor_system_dist = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_dist.__dict__)
+        )
 
         dataloader_dist = EnvironmentDataLoader(
             dataset_dist, motor_system_dist, rng=rng
@@ -263,12 +270,14 @@ class EmbodiedDataTest(unittest.TestCase):
             env_init_func=FakeEnvironmentAbs, env_init_args={}, rng=rng
         )
 
-        motor_system_config_abs = make_base_policy_config(
+        base_policy_config_abs = make_base_policy_config(
             action_space_type="absolute_only",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
-        motor_system_abs = BasePolicy(rng=rng, **motor_system_config_abs.__dict__)
+        motor_system_abs = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_abs.__dict__)
+        )
 
         dataloader_abs = EnvironmentDataLoader(dataset_abs, motor_system_abs, rng)
         initial_state = next(dataloader_abs)
@@ -336,13 +345,15 @@ class EmbodiedDataTest(unittest.TestCase):
             rng=rng,
         )
 
-        motor_system_config_rel = make_base_policy_config(
+        base_policy_config_rel = make_base_policy_config(
             action_space_type="distant_agent",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
 
-        motor_system_rel = BasePolicy(rng=rng, **motor_system_config_rel.__dict__)
+        motor_system_rel = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_rel.__dict__)
+        )
 
         dataloader_rel = SaccadeOnImageDataLoader(
             scenes=[0, 0],
@@ -413,13 +424,15 @@ class EmbodiedDataTest(unittest.TestCase):
             rng=rng,
         )
 
-        motor_system_config_rel = make_base_policy_config(
+        base_policy_config_rel = make_base_policy_config(
             action_space_type="distant_agent",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
 
-        motor_system_rel = BasePolicy(rng=rng, **motor_system_config_rel.__dict__)
+        motor_system_rel = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_rel.__dict__)
+        )
 
         dataloader_rel = SaccadeOnImageFromStreamDataLoader(
             dataset=dataset_rel,

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -25,6 +25,7 @@ import pandas as pd
 
 from tbp.monty.frameworks.actions.action_samplers import ConstantSampler
 from tbp.monty.frameworks.config_utils.config_args import (
+    Dataclass,
     FiveLMMontyConfig,
     InformedPolicy,
     LoggingConfig,
@@ -52,6 +53,7 @@ from tbp.monty.frameworks.models.goal_state_generation import (
     EvidenceGoalStateGenerator,
     GraphGoalStateGenerator,
 )
+from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     HabitatDistantPatchSM,
@@ -71,26 +73,32 @@ from tests.unit.resources.unit_test_utils import BaseGraphTestCases
 
 @dataclass
 class MotorSystemConfigFixed:
-    motor_system_class: Callable = field(default=InformedPolicy)
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            rotation_degrees=5.0,
-            file_name=Path(__file__).parent / "resources/fixed_test_actions.jsonl",
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                rotation_degrees=5.0,
+                file_name=Path(__file__).parent / "resources/fixed_test_actions.jsonl",
+            ),
         )
     )
 
 
 @dataclass
 class MotorSystemConfigOffObject:
-    motor_system_class: Callable = field(default=InformedPolicy)
-    motor_system_args: Union[Dict, dataclass] = field(
-        default_factory=lambda: make_informed_policy_config(
-            action_space_type="distant_agent_no_translation",
-            action_sampler_class=ConstantSampler,
-            file_name=Path(__file__).parent
-            / "resources/fixed_test_actions_off_object.jsonl",
+    motor_system_class: MotorSystem = MotorSystem
+    motor_system_args: Union[Dict, Dataclass] = field(
+        default_factory=lambda: dict(
+            policy_class=InformedPolicy,
+            policy_args=make_informed_policy_config(
+                action_space_type="distant_agent_no_translation",
+                action_sampler_class=ConstantSampler,
+                file_name=Path(__file__).parent
+                / "resources/fixed_test_actions_off_object.jsonl",
+            ),
         )
     )
 
@@ -821,9 +829,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
@@ -930,12 +936,11 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         self.assertEqual(
             num_matching_steps,
             sum(
-                exp.model.learning_modules[0].buffer.features["patch"][
-                    "on_object"
-                ][:num_matching_steps]
+                exp.model.learning_modules[0].buffer.features["patch"]["on_object"][
+                    :num_matching_steps
+                ]
             ),
-            "Number of match steps does not match with stored observations"
-            " on object",
+            "Number of match steps does not match with stored observations on object",
         )
         # Since min_train_steps==12 we should have taken 13 steps.
         self.assertEqual(
@@ -953,12 +958,8 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         )
 
         self.assertGreater(
-            exp.model.learning_modules[0].buffer.stats["current_mlh"][-1][
-                "evidence"
-            ],
-            exp.model.learning_modules[0].buffer.stats["current_mlh"][6][
-                "evidence"
-            ],
+            exp.model.learning_modules[0].buffer.stats["current_mlh"][-1]["evidence"],
+            exp.model.learning_modules[0].buffer.stats["current_mlh"][6]["evidence"],
             "evidence should have increased after moving back on the object.",
         )
 
@@ -969,9 +970,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
             pprint("...check time out logging...")
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.assertEqual(
                 train_stats["individual_ts_performance"][0],
                 "no_match",
@@ -982,7 +981,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 self.assertEqual(
                     train_stats["individual_ts_performance"][i + 1],
                     "time_out",
-                    f"time out not recognized/logged correctly in episode {i+1}",
+                    f"time out not recognized/logged correctly in episode {i + 1}",
                 )
             self.assertEqual(
                 train_stats["primary_performance"][2],
@@ -1086,9 +1085,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             print(train_stats)
             self.check_train_results(train_stats)
 
@@ -1109,9 +1106,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             print(train_stats)
             self.check_train_results(train_stats)
 
@@ -1413,9 +1408,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         first_input_channel = graph_lm.get_input_channels_in_graph(target_object)[0]
         target_loc = target_graph[first_input_channel].pos[target_loc_id]
 
-        assert np.all(
-            np.isclose(target_loc, self.fake_obs_house[4].location)
-        ), "Should propose testing 5th (indexed from 0) location on object"
+        assert np.all(np.isclose(target_loc, self.fake_obs_house[4].location)), (
+            "Should propose testing 5th (indexed from 0) location on object"
+        )
 
     def test_hypothesis_testing_proposal_for_id(self):
         """Test that the LM correctly predicts a location on a graph to test.
@@ -1689,9 +1684,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
@@ -1710,9 +1703,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             print(train_stats)
             self.check_train_results(train_stats, num_lms=5)
 
@@ -1723,9 +1714,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 exp.run_epoch()
             exp.logger_handler.post_eval(exp.logger_args)
             pprint("...loading and checking eval statistics...")
-            eval_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "eval_stats.csv")
-            )
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
             self.check_eval_results(eval_stats, num_lms=5)
 
             pprint("checking that evaluation also works with larger mmd.")
@@ -1747,9 +1736,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
             # Same as in previous test we make it a bit more difficult during eval
             for lm in exp.model.learning_modules:
@@ -1776,9 +1763,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
 
             exp.train()
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             # Just checking that objects are still recognized correctly when moving off
             # the object.
             self.check_train_results(train_stats, num_lms=5)
@@ -1821,8 +1806,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             self.assertEqual(
                 eval_stats["monty_matching_steps"][row],
                 13,
-                "All eval episodes should have recognized the object "
-                "after 13 steps.",
+                "All eval episodes should have recognized the object after 13 steps.",
             )
         for lm_id in [0, 2, 3, 4]:
             self.assertLess(
@@ -1876,13 +1860,10 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 self.assertNotIn(
                     key,
                     exp.model.learning_modules[0].buffer.stats.keys(),
-                    f"{key} should not be stored in buffer when using "
-                    f"BASIC logging.",
+                    f"{key} should not be stored in buffer when using BASIC logging.",
                 )
             self.assertEqual(
-                len(
-                    exp.model.learning_modules[0].buffer.stats["possible_matches"]
-                ),
+                len(exp.model.learning_modules[0].buffer.stats["possible_matches"]),
                 1,
                 "When using basic logging we don't append stats for every step.",
             )
@@ -1899,9 +1880,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
@@ -1924,9 +1903,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
@@ -1946,9 +1923,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
@@ -1975,9 +1950,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             # NOTE: This might fail if the model becomes more noise robust or
             # better able to deal with few incomplete objects in memory.
             for i in range(6):
@@ -2017,9 +1990,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             # NOTE: This might fail if the model becomes more noise robust or
             # better able to deal with few incomplete objects in memory.
             for i in range(6):
@@ -2085,9 +2056,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
             exp.train()
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_hierarchical_lm_train_results(train_stats)
 
             models = load_models_from_dir(exp.output_dir)
@@ -2095,9 +2064,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
 
             pprint("...evaluating...")
             exp.evaluate()
-            eval_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "eval_stats.csv")
-            )
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
             self.check_hierarchical_lm_eval_results(eval_stats)
 
 

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -829,7 +829,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
@@ -936,11 +938,12 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         self.assertEqual(
             num_matching_steps,
             sum(
-                exp.model.learning_modules[0].buffer.features["patch"]["on_object"][
-                    :num_matching_steps
-                ]
+                exp.model.learning_modules[0].buffer.features["patch"][
+                    "on_object"
+                ][:num_matching_steps]
             ),
-            "Number of match steps does not match with stored observations on object",
+            "Number of match steps does not match with stored observations"
+            " on object",
         )
         # Since min_train_steps==12 we should have taken 13 steps.
         self.assertEqual(
@@ -958,8 +961,12 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         )
 
         self.assertGreater(
-            exp.model.learning_modules[0].buffer.stats["current_mlh"][-1]["evidence"],
-            exp.model.learning_modules[0].buffer.stats["current_mlh"][6]["evidence"],
+            exp.model.learning_modules[0].buffer.stats["current_mlh"][-1][
+                "evidence"
+            ],
+            exp.model.learning_modules[0].buffer.stats["current_mlh"][6][
+                "evidence"
+            ],
             "evidence should have increased after moving back on the object.",
         )
 
@@ -970,7 +977,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
             pprint("...check time out logging...")
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             self.assertEqual(
                 train_stats["individual_ts_performance"][0],
                 "no_match",
@@ -981,7 +990,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 self.assertEqual(
                     train_stats["individual_ts_performance"][i + 1],
                     "time_out",
-                    f"time out not recognized/logged correctly in episode {i + 1}",
+                    f"time out not recognized/logged correctly in episode {i+1}",
                 )
             self.assertEqual(
                 train_stats["primary_performance"][2],
@@ -1085,7 +1094,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             print(train_stats)
             self.check_train_results(train_stats)
 
@@ -1106,7 +1117,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             print(train_stats)
             self.check_train_results(train_stats)
 
@@ -1408,9 +1421,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         first_input_channel = graph_lm.get_input_channels_in_graph(target_object)[0]
         target_loc = target_graph[first_input_channel].pos[target_loc_id]
 
-        assert np.all(np.isclose(target_loc, self.fake_obs_house[4].location)), (
-            "Should propose testing 5th (indexed from 0) location on object"
-        )
+        assert np.all(
+            np.isclose(target_loc, self.fake_obs_house[4].location)
+        ), "Should propose testing 5th (indexed from 0) location on object"
 
     def test_hypothesis_testing_proposal_for_id(self):
         """Test that the LM correctly predicts a location on a graph to test.
@@ -1684,7 +1697,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
@@ -1703,7 +1718,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             print(train_stats)
             self.check_train_results(train_stats, num_lms=5)
 
@@ -1714,7 +1731,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 exp.run_epoch()
             exp.logger_handler.post_eval(exp.logger_args)
             pprint("...loading and checking eval statistics...")
-            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+            eval_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "eval_stats.csv")
+            )
             self.check_eval_results(eval_stats, num_lms=5)
 
             pprint("checking that evaluation also works with larger mmd.")
@@ -1736,7 +1755,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
             # Same as in previous test we make it a bit more difficult during eval
             for lm in exp.model.learning_modules:
@@ -1763,7 +1784,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
 
             exp.train()
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             # Just checking that objects are still recognized correctly when moving off
             # the object.
             self.check_train_results(train_stats, num_lms=5)
@@ -1806,7 +1829,8 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             self.assertEqual(
                 eval_stats["monty_matching_steps"][row],
                 13,
-                "All eval episodes should have recognized the object after 13 steps.",
+                "All eval episodes should have recognized the object "
+                "after 13 steps.",
             )
         for lm_id in [0, 2, 3, 4]:
             self.assertLess(
@@ -1860,10 +1884,13 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 self.assertNotIn(
                     key,
                     exp.model.learning_modules[0].buffer.stats.keys(),
-                    f"{key} should not be stored in buffer when using BASIC logging.",
+                    f"{key} should not be stored in buffer when using "
+                    f"BASIC logging.",
                 )
             self.assertEqual(
-                len(exp.model.learning_modules[0].buffer.stats["possible_matches"]),
+                len(
+                    exp.model.learning_modules[0].buffer.stats["possible_matches"]
+                ),
                 1,
                 "When using basic logging we don't append stats for every step.",
             )
@@ -1880,7 +1907,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
@@ -1903,7 +1932,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
@@ -1923,7 +1954,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
@@ -1950,7 +1983,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             # NOTE: This might fail if the model becomes more noise robust or
             # better able to deal with few incomplete objects in memory.
             for i in range(6):
@@ -1990,7 +2025,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             # NOTE: This might fail if the model becomes more noise robust or
             # better able to deal with few incomplete objects in memory.
             for i in range(6):
@@ -2056,7 +2093,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
             exp.train()
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             self.check_hierarchical_lm_train_results(train_stats)
 
             models = load_models_from_dir(exp.output_dir)
@@ -2064,7 +2103,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
 
             pprint("...evaluating...")
             exp.evaluate()
-            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+            eval_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "eval_stats.csv")
+            )
             self.check_hierarchical_lm_eval_results(eval_stats)
 
 

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -18,7 +18,7 @@ import unittest
 from dataclasses import dataclass, field
 from pathlib import Path
 from pprint import pprint
-from typing import Callable, Dict, Union
+from typing import Dict, Union
 
 import numpy as np
 import pandas as pd

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -16,7 +16,7 @@ import unittest
 from dataclasses import dataclass, field
 from pathlib import Path
 from pprint import pprint
-from typing import Callable, Dict, Union
+from typing import Dict, Union
 
 import numpy as np
 import pandas as pd

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -594,9 +594,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
                 if step == 0:
                     self.assertListEqual(
                         list(
-                            exp.model.learning_modules[0].buffer.get_nth_displacement(
-                                0, input_channel="first"
-                            )
+                            exp.model.learning_modules[
+                                0
+                            ].buffer.get_nth_displacement(0, input_channel="first")
                         ),
                         list([0, 0, 0]),
                         "displacement at step 0 should be 0.",
@@ -604,9 +604,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
                 self.assertEqual(
                     step + 1,
                     len(
-                        exp.model.learning_modules[0].buffer.displacements["patch"][
-                            "displacement"
-                        ]
+                        exp.model.learning_modules[0].buffer.displacements[
+                            "patch"
+                        ]["displacement"]
                     ),
                     "buffer does not contain the right amount of displacements.",
                 )
@@ -686,7 +686,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
             pprint("...loading and checking train statistics...")
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
@@ -705,7 +707,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
             pprint("...loading and checking train statistics...")
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
 
             self.check_train_results(train_stats)
 
@@ -726,7 +730,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
 
             self.check_train_results(train_stats)
 
@@ -791,7 +797,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
         # Check that basic csv stats are the same
         ###
-        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
+        original_eval_stats_file = os.path.join(
+            eval_exp_1.output_dir, "eval_stats.csv"
+        )
         new_eval_stats_file = os.path.join(
             eval_exp_1.output_dir, "eval_episode_0_rerun", "eval_stats.csv"
         )
@@ -896,7 +904,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
         # Check that basic csv stats are the same
         ###
-        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
+        original_eval_stats_file = os.path.join(
+            eval_exp_1.output_dir, "eval_stats.csv"
+        )
         new_eval_stats_file = os.path.join(
             eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
         )
@@ -985,7 +995,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
         # Check that basic csv stats are the same
         ###
-        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
+        original_eval_stats_file = os.path.join(
+            eval_exp_1.output_dir, "eval_stats.csv"
+        )
         new_eval_stats_file = os.path.join(
             eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
         )
@@ -1199,27 +1211,27 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             self.assertEqual(
                 len(
-                    exp.model.learning_modules[0].buffer.get_all_locations_on_object(
-                        input_channel="patch"
-                    )
+                    exp.model.learning_modules[
+                        0
+                    ].buffer.get_all_locations_on_object(input_channel="patch")
                 ),
                 len(
-                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
-                        "patch"
-                    ]["pose_vectors"]
+                    exp.model.learning_modules[
+                        0
+                    ].buffer.get_all_features_on_object()["patch"]["pose_vectors"]
                 ),
                 "Did not retrieve same amount of feature and locations on object.",
             )
             self.assertEqual(
                 sum(
-                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
-                        "patch"
-                    ]["on_object"]
+                    exp.model.learning_modules[
+                        0
+                    ].buffer.get_all_features_on_object()["patch"]["on_object"]
                 ),
                 len(
-                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
-                        "patch"
-                    ]["on_object"]
+                    exp.model.learning_modules[
+                        0
+                    ].buffer.get_all_features_on_object()["patch"]["on_object"]
                 ),
                 "not all retrieved features were collected on the object.",
             )
@@ -1232,9 +1244,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             self.assertEqual(
                 num_matching_steps,
                 sum(
-                    exp.model.learning_modules[0].buffer.features["patch"]["on_object"][
-                        :num_matching_steps
-                    ]
+                    exp.model.learning_modules[0].buffer.features["patch"][
+                        "on_object"
+                    ][:num_matching_steps]
                 ),
                 "Number of match steps does not match with stored observations "
                 "on object",
@@ -1285,7 +1297,8 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         self.assertEqual(
             len(detailed_stats["1"]["LM_0"]["possible_matches"]),
             train_stats.loc[1]["monty_matching_steps"],
-            "matching steps in detailed stats don't match with those in train stats.",
+            "matching steps in detailed stats don't match with those in "
+            "train stats.",
         )
         self.assertEqual(
             sum(np.array(detailed_stats["1"]["LM_0"]["patch"]["on_object"])),
@@ -1304,7 +1317,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
@@ -1626,7 +1641,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
 
             pprint("...evaluating...")
@@ -1646,7 +1663,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            train_stats = pd.read_csv(
+                os.path.join(exp.output_dir, "train_stats.csv")
+            )
             # The following check is brittle and depends on sensor arrangement. Leaving
             # the rest of the test intact to detect run failures, but disabling checking
             # of particular results.

--- a/tests/unit/habitat_data_test.py
+++ b/tests/unit/habitat_data_test.py
@@ -24,6 +24,7 @@ from tbp.monty.frameworks.environments.embodied_data import (
 )
 from tbp.monty.frameworks.environments.embodied_environment import ActionSpace
 from tbp.monty.frameworks.models.motor_policies import BasePolicy
+from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.simulators.habitat import SingleSensorAgent
 from tbp.monty.simulators.habitat.environment import AgentConfig, HabitatEnvironment
 
@@ -126,12 +127,14 @@ class HabitatDataTest(unittest.TestCase):
         self.assertIn(action_space_dist.sample(), EXPECTED_ACTIONS_DIST)
 
         # Create distant-agent motor systems / policies
-        motor_system_config_dist = make_base_policy_config(
+        base_policy_config_dist = make_base_policy_config(
             action_space_type="distant_agent",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
-        motor_system_dist = BasePolicy(rng=rng, **motor_system_config_dist.__dict__)
+        motor_system_dist = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_dist.__dict__)
+        )
 
         # Check if datasets are getting observations from simulator
         mock_sim_dist.get_sensor_observations.side_effect = self.mock_observations
@@ -191,12 +194,14 @@ class HabitatDataTest(unittest.TestCase):
         self.assertCountEqual(action_space_abs, EXPECTED_ACTIONS_ABS)
         self.assertIn(action_space_abs.sample(), EXPECTED_ACTIONS_ABS)
 
-        motor_system_config_abs = make_base_policy_config(
+        base_policy_config_abs = make_base_policy_config(
             action_space_type="absolute_only",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
-        motor_system_abs = BasePolicy(rng=rng, **motor_system_config_abs.__dict__)
+        motor_system_abs = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_abs.__dict__)
+        )
 
         # Check if datasets are getting observations from simulator
         mock_sim_abs.get_sensor_observations.side_effect = self.mock_observations
@@ -258,12 +263,14 @@ class HabitatDataTest(unittest.TestCase):
 
         # Note we just test random actions (i.e. base policy) with the surface-agent
         # action space
-        motor_system_config_surf = make_base_policy_config(
+        base_policy_config_surf = make_base_policy_config(
             action_space_type="surface_agent",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
-        motor_system_surf = BasePolicy(rng=rng, **motor_system_config_surf.__dict__)
+        motor_system_surf = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_surf.__dict__)
+        )
 
         # Check if datasets are getting observations from simulator
         mock_sim_surf.get_sensor_observations.side_effect = self.mock_observations
@@ -316,12 +323,14 @@ class HabitatDataTest(unittest.TestCase):
             rng=rng,
         )
 
-        motor_system_config_dist = make_base_policy_config(
+        base_policy_config_dist = make_base_policy_config(
             action_space_type="distant_agent",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
-        motor_system_dist = BasePolicy(rng=rng, **motor_system_config_dist.__dict__)
+        motor_system_dist = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_dist.__dict__)
+        )
 
         dataloader_dist = EnvironmentDataLoader(dataset_dist, motor_system_dist, rng)
         initial_obs_dist = next(dataloader_dist)
@@ -359,12 +368,14 @@ class HabitatDataTest(unittest.TestCase):
             rng=rng,
         )
 
-        motor_system_config_abs = make_base_policy_config(
+        base_policy_config_abs = make_base_policy_config(
             action_space_type="absolute_only",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
-        motor_system_abs = BasePolicy(rng=rng, **motor_system_config_abs.__dict__)
+        motor_system_abs = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_abs.__dict__)
+        )
 
         dataloader_abs = EnvironmentDataLoader(dataset_abs, motor_system_abs, rng)
         initial_obs_abs = next(dataloader_abs)
@@ -404,12 +415,14 @@ class HabitatDataTest(unittest.TestCase):
 
         # Note we just test random actions (i.e. base policy) with the surface-agent
         # action space
-        motor_system_config_surf = make_base_policy_config(
+        base_policy_config_surf = make_base_policy_config(
             action_space_type="surface_agent",
             action_sampler_class=UniformlyDistributedSampler,
             agent_id=AGENT_ID,
         )
-        motor_system_surf = BasePolicy(rng=rng, **motor_system_config_surf.__dict__)
+        motor_system_surf = MotorSystem(
+            policy=BasePolicy(rng=rng, **base_policy_config_surf.__dict__)
+        )
 
         dataloader_surf = EnvironmentDataLoader(dataset_surf, motor_system_surf, rng)
         initial_obs_surf = next(dataloader_surf)

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -65,7 +65,12 @@ from tbp.monty.frameworks.models.evidence_matching import (
 from tbp.monty.frameworks.models.goal_state_generation import (
     EvidenceGoalStateGenerator,
 )
-from tbp.monty.frameworks.models.motor_policies import get_perc_on_obj_semantic
+from tbp.monty.frameworks.models.motor_policies import (
+    InformedPolicy,
+    SurfacePolicy,
+    SurfacePolicyCurvatureInformed,
+    get_perc_on_obj_semantic,
+)
 from tbp.monty.frameworks.models.states import State
 from tbp.monty.frameworks.utils.dataclass_utils import config_to_dict
 from tbp.monty.frameworks.utils.transform_utils import numpy_to_scipy_quat
@@ -235,14 +240,17 @@ class PolicyTest(unittest.TestCase):
             monty_config=PatchAndViewMontyConfig(
                 monty_args=MontyArgs(num_exploratory_steps=5),
                 motor_system_config=MotorSystemConfigInformedNoTransStepS20(
-                    motor_system_args=make_informed_policy_config(
-                        action_space_type="distant_agent_no_translation",
-                        action_sampler_class=ConstantSampler,
-                        # Take large steps for a quick experiment
-                        rotation_degrees=20.0,
-                        use_goal_state_driven_actions=False,
-                        switch_frequency=0,  # Overwrite default of 1.0
-                    )
+                    motor_system_args=dict(
+                        policy_class=InformedPolicy,
+                        policy_args=make_informed_policy_config(
+                            action_space_type="distant_agent_no_translation",
+                            action_sampler_class=ConstantSampler,
+                            # Take large steps for a quick experiment
+                            rotation_degrees=20.0,
+                            use_goal_state_driven_actions=False,
+                            switch_frequency=0,  # Overwrite default of 1.0
+                        ),
+                    ),
                 ),
             ),
         )
@@ -253,12 +261,15 @@ class PolicyTest(unittest.TestCase):
             monty_config=SurfaceAndViewMontyConfig(
                 monty_args=MontyArgs(num_exploratory_steps=20),
                 motor_system_config=MotorSystemConfigSurface(
-                    motor_system_args=make_surface_policy_config(
-                        desired_object_distance=0.025,
-                        alpha=0.0,  # Overwrite default of 0.1
-                        use_goal_state_driven_actions=False,
-                        translation_distance=0.05,
-                    )
+                    motor_system_args=dict(
+                        policy_class=SurfacePolicy,
+                        policy_args=make_surface_policy_config(
+                            desired_object_distance=0.025,
+                            alpha=0.0,  # Overwrite default of 0.1
+                            use_goal_state_driven_actions=False,
+                            translation_distance=0.05,
+                        ),
+                    ),
                 ),
             ),
             dataset_args=SurfaceViewFinderMountHabitatDatasetArgs(
@@ -279,15 +290,18 @@ class PolicyTest(unittest.TestCase):
             monty_config=PatchAndViewMontyConfig(
                 monty_args=MontyArgs(num_exploratory_steps=20),
                 motor_system_config=MotorSystemConfigInformedNoTransStepS20(
-                    motor_system_args=make_informed_policy_config(
-                        action_space_type="distant_agent_no_translation",
-                        action_sampler_class=ConstantSampler,
-                        rotation_degrees=5.0,
-                        use_goal_state_driven_actions=False,
-                        switch_frequency=1.0,
-                        good_view_percentage=0.5,  # Make sure we define the required
-                        # good view percentage
-                    )
+                    motor_system_args=dict(
+                        policy_class=InformedPolicy,
+                        policy_args=make_informed_policy_config(
+                            action_space_type="distant_agent_no_translation",
+                            action_sampler_class=ConstantSampler,
+                            rotation_degrees=5.0,
+                            use_goal_state_driven_actions=False,
+                            switch_frequency=1.0,
+                            good_view_percentage=0.5,  # Make sure we define the required
+                            # good view percentage
+                        ),
+                    ),
                 ),
             ),
         )
@@ -299,12 +313,15 @@ class PolicyTest(unittest.TestCase):
             monty_config=SurfaceAndViewMontyConfig(
                 monty_args=MontyArgs(num_exploratory_steps=20),
                 motor_system_config=MotorSystemConfigSurface(
-                    motor_system_args=make_surface_policy_config(
-                        desired_object_distance=0.025,
-                        alpha=0.0,
-                        use_goal_state_driven_actions=False,
-                        translation_distance=0.05,
-                    )
+                    motor_system_args=dict(
+                        policy_class=SurfacePolicy,
+                        policy_args=make_surface_policy_config(
+                            desired_object_distance=0.025,
+                            alpha=0.0,
+                            use_goal_state_driven_actions=False,
+                            translation_distance=0.05,
+                        ),
+                    ),
                 ),
             ),
             dataset_args=SurfaceViewFinderMountHabitatDatasetArgs(
@@ -337,15 +354,18 @@ class PolicyTest(unittest.TestCase):
             monty_config=PatchAndViewMontyConfig(
                 monty_args=MontyArgs(num_exploratory_steps=20),
                 motor_system_config=MotorSystemConfigInformedNoTransStepS20(
-                    motor_system_args=make_informed_policy_config(
-                        action_space_type="distant_agent_no_translation",
-                        action_sampler_class=ConstantSampler,
-                        rotation_degrees=5.0,
-                        use_goal_state_driven_actions=False,
-                        switch_frequency=1.0,
-                        good_view_percentage=0.5,  # Make sure we define the required
-                        # good view percentage
-                    )
+                    motor_system_args=dict(
+                        policy_class=InformedPolicy,
+                        policy_args=make_informed_policy_config(
+                            action_space_type="distant_agent_no_translation",
+                            action_sampler_class=ConstantSampler,
+                            rotation_degrees=5.0,
+                            use_goal_state_driven_actions=False,
+                            switch_frequency=1.0,
+                            good_view_percentage=0.5,  # Make sure we define the required
+                            # good view percentage
+                        ),
+                    ),
                 ),
             ),
         )
@@ -364,12 +384,15 @@ class PolicyTest(unittest.TestCase):
             monty_config=SurfaceAndViewMontyConfig(
                 monty_args=MontyArgs(num_exploratory_steps=20),
                 motor_system_config=MotorSystemConfigSurface(
-                    motor_system_args=make_surface_policy_config(
-                        desired_object_distance=0.025,
-                        alpha=0.0,
-                        use_goal_state_driven_actions=False,
-                        translation_distance=0.05,
-                    )
+                    motor_system_args=dict(
+                        policy_class=SurfacePolicy,
+                        policy_args=make_surface_policy_config(
+                            desired_object_distance=0.025,
+                            alpha=0.0,
+                            use_goal_state_driven_actions=False,
+                            translation_distance=0.05,
+                        ),
+                    ),
                 ),
             ),
             dataset_args=SurfaceViewFinderMountHabitatDatasetArgs(
@@ -530,10 +553,10 @@ class PolicyTest(unittest.TestCase):
         motor_system_config = config_to_dict(config_object)
         motor_system_class = motor_system_config["motor_system_class"]
         motor_system_args = motor_system_config["motor_system_args"]
-
-        motor_system = motor_system_class(
-            rng=np.random.RandomState(123), **motor_system_args
-        )
+        policy_class = motor_system_args["policy_class"]
+        policy_args = motor_system_args["policy_args"]
+        policy = policy_class(rng=np.random.RandomState(123), **policy_args)
+        motor_system = motor_system_class(policy=policy)
         motor_system.pre_episode()
 
         return motor_system, motor_system_args
@@ -592,7 +615,7 @@ class PolicyTest(unittest.TestCase):
             # Check the initial view
             observation = next(exp.dataloader)
             # TODO M remove the following train-wreck during refactor
-            view = observation[exp.model.motor_system.agent_id]["view_finder"]
+            view = observation[exp.model.motor_system._policy.agent_id]["view_finder"]
             semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
             perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
 
@@ -600,25 +623,25 @@ class PolicyTest(unittest.TestCase):
 
             target_perc_on_target_obj = dict_config["monty_config"][
                 "motor_system_config"
-            ]["motor_system_args"]["good_view_percentage"]
+            ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
-            assert (
-                perc_on_target_obj >= target_perc_on_target_obj
-            ), f"Initial view is not good enough, {perc_on_target_obj}\
+            assert perc_on_target_obj >= target_perc_on_target_obj, (
+                f"Initial view is not good enough, {perc_on_target_obj}\
                 vs target of {target_perc_on_target_obj}"
+            )
 
             points_on_target_obj = semantic == 1
             closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
             target_closest_point = dict_config["monty_config"]["motor_system_config"][
                 "motor_system_args"
-            ]["desired_object_distance"]
+            ]["policy_args"]["desired_object_distance"]
 
             # Utility policy should not have moved too close to the object
-            assert (
-                closest_point_on_target_obj > target_closest_point
-            ), f"Initial view is too close, {closest_point_on_target_obj}\
+            assert closest_point_on_target_obj > target_closest_point, (
+                f"Initial view is too close, {closest_point_on_target_obj}\
                 vs target of {target_closest_point}"
+            )
 
     def test_touch_object_basic_surf_agent(self):
         """Test ability to move a surface agent to touch an object.
@@ -646,7 +669,7 @@ class PolicyTest(unittest.TestCase):
             observation_post_touch = next(exp.dataloader)
 
             # TODO M remove the following train-wreck during refactor
-            view = observation_post_touch[exp.model.motor_system.agent_id][
+            view = observation_post_touch[exp.model.motor_system._policy.agent_id][
                 "view_finder"
             ]
             dict_config = config_to_dict(config)
@@ -656,20 +679,20 @@ class PolicyTest(unittest.TestCase):
             )
             closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
-            assert (
-                closest_point_on_target_obj < 1.0
-            ), f"Should be within a meter of the object,\
+            assert closest_point_on_target_obj < 1.0, (
+                f"Should be within a meter of the object,\
                 closest point at {closest_point_on_target_obj}"
+            )
 
             target_closest_point = dict_config["monty_config"]["motor_system_config"][
                 "motor_system_args"
-            ]["desired_object_distance"]
+            ]["policy_args"]["desired_object_distance"]
 
             # Utility policy should not have moved too close to the object
-            assert (
-                closest_point_on_target_obj > target_closest_point
-            ), f"Initial position is too close, {closest_point_on_target_obj}\
+            assert closest_point_on_target_obj > target_closest_point, (
+                f"Initial position is too close, {closest_point_on_target_obj}\
                 vs target of {target_closest_point}"
+            )
 
     def test_get_good_view_multi_object(self):
         """Test ability to move a distant agent to a good view of an object.
@@ -699,42 +722,42 @@ class PolicyTest(unittest.TestCase):
             # Check the initial view
             observation = next(exp.dataloader)
             # TODO M remove the following train-wreck during refactor
-            view = observation[exp.model.motor_system.agent_id]["view_finder"]
+            view = observation[exp.model.motor_system._policy.agent_id]["view_finder"]
             semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
             perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
 
             dict_config = config_to_dict(config)
             target_perc_on_target_obj = dict_config["monty_config"][
                 "motor_system_config"
-            ]["motor_system_args"]["good_view_percentage"]
+            ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
-            assert (
-                perc_on_target_obj >= target_perc_on_target_obj
-            ), f"Initial view is not good enough, {perc_on_target_obj}\
+            assert perc_on_target_obj >= target_perc_on_target_obj, (
+                f"Initial view is not good enough, {perc_on_target_obj}\
                 vs target of {target_perc_on_target_obj}"
+            )
 
             points_on_target_obj = semantic == 1
             closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
             target_closest_point = dict_config["monty_config"]["motor_system_config"][
                 "motor_system_args"
-            ]["desired_object_distance"]
+            ]["policy_args"]["desired_object_distance"]
 
             # Utility policy should not have moved too close to the object
-            assert (
-                closest_point_on_target_obj > target_closest_point
-            ), f"Initial view is too close to target, {closest_point_on_target_obj}\
+            assert closest_point_on_target_obj > target_closest_point, (
+                f"Initial view is too close to target, {closest_point_on_target_obj}\
                 vs target of {target_closest_point}"
+            )
 
             # Also calculate closest point on *any* object so that we don't get
             # too close and clip into objects; NB that any object will have a
             # semantic ID > 0
             points_on_any_obj = view["semantic"] > 0
             closest_point_on_any_obj = np.min(view["depth"][points_on_any_obj])
-            assert (
-                closest_point_on_any_obj > target_closest_point / 6
-            ), f"Initial view too cloase to other objects, {closest_point_on_any_obj}\
+            assert closest_point_on_any_obj > target_closest_point / 6, (
+                f"Initial view too cloase to other objects, {closest_point_on_any_obj}\
                 vs target of {target_closest_point / 6}"
+            )
 
     def test_distant_policy_moves_back_to_object(self):
         """Test ability of distant agent to move back to an object.
@@ -760,7 +783,7 @@ class PolicyTest(unittest.TestCase):
             for loader_step, observation in enumerate(exp.dataloader):
                 exp.model.step(observation)
 
-                last_action = exp.model.motor_system.last_action()
+                last_action = exp.model.motor_system.last_action
 
                 if loader_step == 3:
                     stored_action = last_action
@@ -917,7 +940,7 @@ class PolicyTest(unittest.TestCase):
             # current orientation
             agent_direction = np.array(
                 hab_utils.quat_rotate_vector(
-                    exp.model.motor_system.state["agent_id_0"]["rotation"],
+                    exp.model.motor_system._policy.state["agent_id_0"]["rotation"],
                     [
                         0,
                         0,
@@ -948,21 +971,24 @@ class PolicyTest(unittest.TestCase):
         """
         motor_system, motor_system_args = self.initialize_motor_system(
             MotorSystemConfigCurvatureInformedSurface(
-                motor_system_args=make_curv_surface_policy_config(
-                    desired_object_distance=0.025,
-                    alpha=0.1,
-                    pc_alpha=0.5,
-                    max_pc_bias_steps=2,  # Overwrite default value
-                    min_general_steps=8,
-                    min_heading_steps=12,
-                    use_goal_state_driven_actions=False,
-                )
+                motor_system_args=dict(
+                    policy_class=SurfacePolicyCurvatureInformed,
+                    policy_args=make_curv_surface_policy_config(
+                        desired_object_distance=0.025,
+                        alpha=0.1,
+                        pc_alpha=0.5,
+                        max_pc_bias_steps=2,  # Overwrite default value
+                        min_general_steps=8,
+                        min_heading_steps=12,
+                        use_goal_state_driven_actions=False,
+                    ),
+                ),
             )
         )
 
         # Initialize motor-system state
-        motor_system.state = dict(agent_id_0=dict())
-        motor_system.state["agent_id_0"]["rotation"] = qt.quaternion(1, 0, 0, 0)
+        motor_system._policy.state = dict(agent_id_0=dict())
+        motor_system._policy.state["agent_id_0"]["rotation"] = qt.quaternion(1, 0, 0, 0)
 
         # Step 1
         # fake_obs_pc contains observations including the point-normal and principal
@@ -971,77 +997,79 @@ class PolicyTest(unittest.TestCase):
         # also in environmental coordinates, so we compare these
         # Note that the movement is a unit vector because it is a direction, the amount
         # (i.e. size) of the translation is represented separately.
-        motor_system.processed_observations = self.fake_obs_pc[0]
-        direction = motor_system.tangential_direction()
-        assert np.all(
-            np.isclose(direction, [1, 0, 0])
-        ), "Not following correct PC direction"
-        assert (
-            motor_system.following_pc_counter == 1
-        ), "Should have followed PC and incremented counter"
-        assert (
-            motor_system.continuous_pc_steps == 1
-        ), "Should have incremented continuous counter"
+        motor_system._policy.processed_observations = self.fake_obs_pc[0]
+        direction = motor_system._policy.tangential_direction()
+        assert np.all(np.isclose(direction, [1, 0, 0])), (
+            "Not following correct PC direction"
+        )
+        assert motor_system._policy.following_pc_counter == 1, (
+            "Should have followed PC and incremented counter"
+        )
+        assert motor_system._policy.continuous_pc_steps == 1, (
+            "Should have incremented continuous counter"
+        )
 
         # Step 2
-        motor_system.processed_observations = self.fake_obs_pc[1]
-        direction = motor_system.tangential_direction()
-        assert np.all(
-            np.isclose(direction, [1, 0, 0])
-        ), "Not following correct PC direction"
-        assert (
-            motor_system.following_pc_counter == 2
-        ), "Should have followed PC and incremented counter"
-        assert (
-            motor_system.continuous_pc_steps == 2
-        ), "Should have incremented continuous counter"
+        motor_system._policy.processed_observations = self.fake_obs_pc[1]
+        direction = motor_system._policy.tangential_direction()
+        assert np.all(np.isclose(direction, [1, 0, 0])), (
+            "Not following correct PC direction"
+        )
+        assert motor_system._policy.following_pc_counter == 2, (
+            "Should have followed PC and incremented counter"
+        )
+        assert motor_system._policy.continuous_pc_steps == 2, (
+            "Should have incremented continuous counter"
+        )
 
         # Step 3: Our bias should change from following minimal to maximal
         # PC
-        motor_system.processed_observations = self.fake_obs_pc[2]
-        direction = motor_system.tangential_direction()
-        assert np.all(
-            np.isclose(direction, [0, 1, 0])
-        ), "Not following correct PC direction"
-        assert (
-            motor_system.following_pc_counter == 1
-        ), "Should have reset following PC counter due to bias change, and incremented"
-        assert (
-            motor_system.continuous_pc_steps == 1
-        ), "Should have reset continous counter due to bias change, and incremented"
+        motor_system._policy.processed_observations = self.fake_obs_pc[2]
+        direction = motor_system._policy.tangential_direction()
+        assert np.all(np.isclose(direction, [0, 1, 0])), (
+            "Not following correct PC direction"
+        )
+        assert motor_system._policy.following_pc_counter == 1, (
+            "Should have reset following PC counter due to bias change, and incremented"
+        )
+        assert motor_system._policy.continuous_pc_steps == 1, (
+            "Should have reset continous counter due to bias change, and incremented"
+        )
 
         # Step 4
-        motor_system.processed_observations = self.fake_obs_pc[3]
-        direction = motor_system.tangential_direction()
-        assert np.all(
-            np.isclose(direction, [0, 1, 0])
-        ), "Not following correct PC direction"
-        assert (
-            motor_system.following_pc_counter == 2
-        ), "Should have followed PC and incremented counter"
-        assert (
-            motor_system.continuous_pc_steps == 2
-        ), "Should have incremented continuous counter"
+        motor_system._policy.processed_observations = self.fake_obs_pc[3]
+        direction = motor_system._policy.tangential_direction()
+        assert np.all(np.isclose(direction, [0, 1, 0])), (
+            "Not following correct PC direction"
+        )
+        assert motor_system._policy.following_pc_counter == 2, (
+            "Should have followed PC and incremented counter"
+        )
+        assert motor_system._policy.continuous_pc_steps == 2, (
+            "Should have incremented continuous counter"
+        )
 
         # Step 5: Pass observation *without* a well defined PC direction
-        motor_system.processed_observations = self.fake_obs_pc[4]
-        direction = motor_system.tangential_direction()
+        motor_system._policy.processed_observations = self.fake_obs_pc[4]
+        direction = motor_system._policy.tangential_direction()
         # Note the following movement is a random direction deterministcally set by the
         # random seed
-        assert np.all(
-            np.isclose(direction, [-0.13745981, 0.99050735, 0])
-        ), "Not following correct non-PC direction"
-        assert (
-            motor_system.ignoring_pc_counter == 1
-        ), "Should have reset ignoring_pc_counter, and then incremented"
-        assert (
-            motor_system.continuous_pc_steps == 0
-        ), "Should have reset continuous counter"
-        assert (
-            motor_system.following_pc_counter == 2
-        ), "Should have not changed following_pc_counter"
-        assert motor_system.using_pc_guide is False, "Should not be using PC guide"
-        assert motor_system.prev_angle is None, "Should have reset prev_angle"
+        assert np.all(np.isclose(direction, [-0.13745981, 0.99050735, 0])), (
+            "Not following correct non-PC direction"
+        )
+        assert motor_system._policy.ignoring_pc_counter == 1, (
+            "Should have reset ignoring_pc_counter, and then incremented"
+        )
+        assert motor_system._policy.continuous_pc_steps == 0, (
+            "Should have reset continuous counter"
+        )
+        assert motor_system._policy.following_pc_counter == 2, (
+            "Should have not changed following_pc_counter"
+        )
+        assert motor_system._policy.using_pc_guide is False, (
+            "Should not be using PC guide"
+        )
+        assert motor_system._policy.prev_angle is None, "Should have reset prev_angle"
 
         # Step 6 : Follow principal curvature, but the agent is rotated, so the policy
         # needs to ensure PC is still handled correctly (PC and the returned movement
@@ -1049,14 +1077,16 @@ class PolicyTest(unittest.TestCase):
         # the same); note the agent is still orthogonal to the PC directions.
 
         # Update relevant motor-system variables
-        motor_system.ignoring_pc_counter = motor_system_args["min_general_steps"]
-        motor_system.state["agent_id_0"]["rotation"] = qt.quaternion(0, 0, 1, 0)
+        motor_system._policy.ignoring_pc_counter = motor_system_args["policy_args"][
+            "min_general_steps"
+        ]
+        motor_system._policy.state["agent_id_0"]["rotation"] = qt.quaternion(0, 0, 1, 0)
 
-        motor_system.processed_observations = self.fake_obs_pc[5]
-        direction = motor_system.tangential_direction()
-        assert np.all(
-            np.isclose(direction, [1.0, 0.0, 0])
-        ), "Not following correct PC direction"
+        motor_system._policy.processed_observations = self.fake_obs_pc[5]
+        direction = motor_system._policy.tangential_direction()
+        assert np.all(np.isclose(direction, [1.0, 0.0, 0])), (
+            "Not following correct PC direction"
+        )
 
     def test_advanced_following_principal_curvature(self):
         """Test more edge-case elements of the following-PC policy.
@@ -1067,122 +1097,134 @@ class PolicyTest(unittest.TestCase):
         """
         motor_system, motor_system_args = self.initialize_motor_system(
             MotorSystemConfigCurvatureInformedSurface(
-                motor_system_args=make_curv_surface_policy_config(
-                    desired_object_distance=0.025,
-                    alpha=0.1,
-                    pc_alpha=0.5,
-                    max_pc_bias_steps=32,
-                    min_general_steps=1,  # Overwrite default value so that we more
-                    # quickly transition into taking PC steps when testing this
-                    min_heading_steps=12,
-                    use_goal_state_driven_actions=False,
-                )
+                motor_system_args=dict(
+                    policy_class=SurfacePolicyCurvatureInformed,
+                    policy_args=make_curv_surface_policy_config(
+                        desired_object_distance=0.025,
+                        alpha=0.1,
+                        pc_alpha=0.5,
+                        max_pc_bias_steps=32,
+                        min_general_steps=1,  # Overwrite default value so that we more
+                        # quickly transition into taking PC steps when testing this
+                        min_heading_steps=12,
+                        use_goal_state_driven_actions=False,
+                    ),
+                ),
             )
         )
 
         # Initialize motor system state
-        motor_system.state = dict(agent_id_0=dict())
-        motor_system.state["agent_id_0"]["rotation"] = qt.quaternion(1, 0, 0, 0)
+        motor_system._policy.state = dict(agent_id_0=dict())
+        motor_system._policy.state["agent_id_0"]["rotation"] = qt.quaternion(1, 0, 0, 0)
 
         # Step 1 : PC-guided information, but we haven't taken the minimum number of
         # non-PC steps, so take random step
-        motor_system.ignoring_pc_counter = 0  # Set to 0 so we skip PC
-        motor_system.processed_observations = self.fake_obs_advanced_pc[0]
+        motor_system._policy.ignoring_pc_counter = 0  # Set to 0 so we skip PC
+        motor_system._policy.processed_observations = self.fake_obs_advanced_pc[0]
         # TODO M clean up how we set this when doing the refactor; currently this is
         # done in graph_matching.py normally
-        motor_system.tangent_locs.append(self.fake_obs_pc[0].location)
-        motor_system.tangent_norms.append([0, 0, 1])
-        direction = motor_system.tangential_direction()
+        motor_system._policy.tangent_locs.append(self.fake_obs_pc[0].location)
+        motor_system._policy.tangent_norms.append([0, 0, 1])
+        direction = motor_system._policy.tangential_direction()
         # Note the following movement is a random direction deterministcally set by the
         # random seed
-        assert np.all(
-            np.isclose(direction, [0.98165657, 0.19065773, 0])
-        ), "Not following correct non-PC direction"
-        assert (
-            motor_system.following_pc_counter == 0
-        ), "Should not have followed PC and incremented counter"
-        assert (
-            motor_system.continuous_pc_steps == 0
-        ), "Should not have incremented continuous counter"
+        assert np.all(np.isclose(direction, [0.98165657, 0.19065773, 0])), (
+            "Not following correct non-PC direction"
+        )
+        assert motor_system._policy.following_pc_counter == 0, (
+            "Should not have followed PC and incremented counter"
+        )
+        assert motor_system._policy.continuous_pc_steps == 0, (
+            "Should not have incremented continuous counter"
+        )
 
         # Step 2 : Given the same observation, but now have taken sufficient non-PC
         # steps, so should follow PC direction
-        motor_system.processed_observations = self.fake_obs_advanced_pc[0]
+        motor_system._policy.processed_observations = self.fake_obs_advanced_pc[0]
         # TODO M clean up how we set this when doing the refactor; currently this is
         # done in graph_matching.py normally
-        motor_system.tangent_locs.append(self.fake_obs_pc[0].location)
-        motor_system.tangent_norms.append([0, 0, 1])
-        direction = motor_system.tangential_direction()
-        assert np.all(
-            np.isclose(direction, [1, 0, 0])
-        ), "Not following correct PC direction"
-        assert (
-            motor_system.following_pc_counter == 1
-        ), "Should have followed PC and incremented counter"
-        assert (
-            motor_system.continuous_pc_steps == 1
-        ), "Should have incremented continuous counter"
+        motor_system._policy.tangent_locs.append(self.fake_obs_pc[0].location)
+        motor_system._policy.tangent_norms.append([0, 0, 1])
+        direction = motor_system._policy.tangential_direction()
+        assert np.all(np.isclose(direction, [1, 0, 0])), (
+            "Not following correct PC direction"
+        )
+        assert motor_system._policy.following_pc_counter == 1, (
+            "Should have followed PC and incremented counter"
+        )
+        assert motor_system._policy.continuous_pc_steps == 1, (
+            "Should have incremented continuous counter"
+        )
 
         # Step 3 : Following PC direction would cause us to double back on ourself;
         # PC has been aribtrarily flipped vs. previous step, so can just flip it back
-        motor_system.processed_observations = self.fake_obs_advanced_pc[1]
-        motor_system.tangent_locs.append(self.fake_obs_advanced_pc[1].location)
-        motor_system.tangent_norms.append([0, 0, 1])
-        direction = motor_system.tangential_direction()
-        assert np.all(
-            np.isclose(direction, [1, 0, 0])
-        ), "Not following correct PC direction"
-        assert (
-            motor_system.following_pc_counter == 2
-        ), "Should have followed PC and incremented counter"
-        assert (
-            motor_system.continuous_pc_steps == 2
-        ), "Should have incremented continuous counter"
+        motor_system._policy.processed_observations = self.fake_obs_advanced_pc[1]
+        motor_system._policy.tangent_locs.append(self.fake_obs_advanced_pc[1].location)
+        motor_system._policy.tangent_norms.append([0, 0, 1])
+        direction = motor_system._policy.tangential_direction()
+        assert np.all(np.isclose(direction, [1, 0, 0])), (
+            "Not following correct PC direction"
+        )
+        assert motor_system._policy.following_pc_counter == 2, (
+            "Should have followed PC and incremented counter"
+        )
+        assert motor_system._policy.continuous_pc_steps == 2, (
+            "Should have incremented continuous counter"
+        )
 
         # Step 4 : PC is defined in z-direction, so policy should take a random step
-        motor_system.processed_observations = self.fake_obs_advanced_pc[2]
-        motor_system.tangent_locs.append(self.fake_obs_pc[2].location)
-        motor_system.tangent_norms.append([0, 0, 1])
-        direction = motor_system.tangential_direction()
+        motor_system._policy.processed_observations = self.fake_obs_advanced_pc[2]
+        motor_system._policy.tangent_locs.append(self.fake_obs_pc[2].location)
+        motor_system._policy.tangent_norms.append([0, 0, 1])
+        direction = motor_system._policy.tangential_direction()
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(
             np.isclose(direction, [0.9789808522232504, -0.20395217816987962, 0])
         ), "Not following correct non-PC direction"
         assert (
-            motor_system.ignoring_pc_counter == motor_system_args["min_general_steps"]
-        ), "Shoulnd't increment ignoring_pc_counter"
-        assert (
-            motor_system.following_pc_counter == 2
-        ), "Should have not changed following_pc_counter"
-        assert motor_system.pc_is_z_defined is True, "Should have detected z-defined PC"
+            motor_system._policy.ignoring_pc_counter
+            == motor_system_args["policy_args"]["min_general_steps"]
+        ), "Shouldn't increment ignoring_pc_counter"
+        assert motor_system._policy.following_pc_counter == 2, (
+            "Should have not changed following_pc_counter"
+        )
+        assert motor_system._policy.pc_is_z_defined is True, (
+            "Should have detected z-defined PC"
+        )
 
         # Step 5 : Following PC direction would cause us to double back on ourself; PC
         # has not been arbitrarily flipped, so policy selects a new heading
-        motor_system.processed_observations = self.fake_obs_advanced_pc[0]
-        motor_system.tangent_locs.append(self.fake_obs_pc[0].location)  # Synthetically
+        motor_system._policy.processed_observations = self.fake_obs_advanced_pc[0]
+        motor_system._policy.tangent_locs.append(
+            self.fake_obs_pc[0].location
+        )  # Synthetically
         # "teleport" the agent back to the first observation and location, such that
         # following PC would cause it to visit the observation 1 again (which it is
         # designed to avoid)
-        motor_system.tangent_norms.append([0, 0, 1])
-        direction = motor_system.tangential_direction()
+        motor_system._policy.tangent_norms.append([0, 0, 1])
+        direction = motor_system._policy.tangential_direction()
         # Note the following movement is a random direction deterministcally set by the
         # random seed
-        assert np.all(
-            np.isclose(direction, [0.60958557, 0.79272027, 0])
-        ), "Not following correct non-PC direction"
-        assert (
-            motor_system.ignoring_pc_counter == 0
-        ), "Should have reset ignoring_pc_counter, and not incremented"
-        assert (
-            motor_system.continuous_pc_steps == 0
-        ), "Should have reset continuous counter"
-        assert (
-            motor_system.following_pc_counter == 2
-        ), "Should have not changed following_pc_counter"
-        assert motor_system.using_pc_guide is False, "Should not be using PC guide"
-        assert motor_system.prev_angle is None, "Should have reset prev_angle"
-        assert motor_system.pc_is_z_defined is False, "Should have reset z-defind flag"
+        assert np.all(np.isclose(direction, [0.60958557, 0.79272027, 0])), (
+            "Not following correct non-PC direction"
+        )
+        assert motor_system._policy.ignoring_pc_counter == 0, (
+            "Should have reset ignoring_pc_counter, and not incremented"
+        )
+        assert motor_system._policy.continuous_pc_steps == 0, (
+            "Should have reset continuous counter"
+        )
+        assert motor_system._policy.following_pc_counter == 2, (
+            "Should have not changed following_pc_counter"
+        )
+        assert motor_system._policy.using_pc_guide is False, (
+            "Should not be using PC guide"
+        )
+        assert motor_system._policy.prev_angle is None, "Should have reset prev_angle"
+        assert motor_system._policy.pc_is_z_defined is False, (
+            "Should have reset z-defind flag"
+        )
 
     def core_evaluate_compute_goal_state_for_target_loc(
         self, lm, motor_system, object_orientation, target_location_on_object
@@ -1256,9 +1298,9 @@ class PolicyTest(unittest.TestCase):
 
         # --- Determine Habitat-coordinates from goal-state ---
 
-        motor_system.set_driving_goal_state(motor_goal_state)
+        motor_system._policy.set_driving_goal_state(motor_goal_state)
 
-        target_loc_hab, target_quat = motor_system.derive_habitat_goal_state()
+        target_loc_hab, target_quat = motor_system._policy.derive_habitat_goal_state()
 
         resulting_rot = Rotation.from_quat(
             numpy_to_scipy_quat(np.array([target_quat.real] + list(target_quat.imag)))
@@ -1308,18 +1350,18 @@ class PolicyTest(unittest.TestCase):
         ), "Goal-state location is not as expected"
 
         # Pointing down
-        assert np.all(
-            np.isclose(motor_goal_direction, [0, -1.0, 0])
-        ), "Goal-state pose is not as expected"
+        assert np.all(np.isclose(motor_goal_direction, [0, -1.0, 0])), (
+            "Goal-state pose is not as expected"
+        )
 
         assert np.all(
             np.isclose(target_loc_hab, [0.1, 1.6 + surface_displacement, 0.2])
         ), "Habitat target location is not as expected"
 
         # Pointing down
-        assert np.all(
-            np.isclose(agent_direction_hab, [0, -1.0, 0])
-        ), "Habitat pose is not as expected"
+        assert np.all(np.isclose(agent_direction_hab, [0, -1.0, 0])), (
+            "Habitat pose is not as expected"
+        )
 
         # === Second, harder example ===
 
@@ -1342,9 +1384,9 @@ class PolicyTest(unittest.TestCase):
         ), "Goal-state location is not as expected"
 
         # Pointing up, because object is flipped in y-axis
-        assert np.all(
-            np.isclose(motor_goal_direction_2, [0, 1.0, 0])
-        ), "Goal-state pose is not as expected"
+        assert np.all(np.isclose(motor_goal_direction_2, [0, 1.0, 0])), (
+            "Goal-state pose is not as expected"
+        )
 
         # Surface displacement is negative, because object is flipped in x-axis
         assert np.all(
@@ -1352,9 +1394,9 @@ class PolicyTest(unittest.TestCase):
         ), "Habitat target location is not as expected"
 
         # Pointing up, because object is flipped in y-axis
-        assert np.all(
-            np.isclose(agent_direction_hab_2, [0, 1.0, 0])
-        ), "Habitat pose is not as expected"
+        assert np.all(np.isclose(agent_direction_hab_2, [0, 1.0, 0])), (
+            "Habitat pose is not as expected"
+        )
 
         # === Third, hardest example ===
 

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -298,8 +298,7 @@ class PolicyTest(unittest.TestCase):
                             rotation_degrees=5.0,
                             use_goal_state_driven_actions=False,
                             switch_frequency=1.0,
-                            good_view_percentage=0.5,  # Make sure we define the required
-                            # good view percentage
+                            good_view_percentage=0.5,
                         ),
                     ),
                 ),
@@ -362,8 +361,7 @@ class PolicyTest(unittest.TestCase):
                             rotation_degrees=5.0,
                             use_goal_state_driven_actions=False,
                             switch_frequency=1.0,
-                            good_view_percentage=0.5,  # Make sure we define the required
-                            # good view percentage
+                            good_view_percentage=0.5,
                         ),
                     ),
                 ),

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -623,10 +623,10 @@ class PolicyTest(unittest.TestCase):
                 "motor_system_config"
             ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
-            assert perc_on_target_obj >= target_perc_on_target_obj, (
-                f"Initial view is not good enough, {perc_on_target_obj}\
+            assert (
+                perc_on_target_obj >= target_perc_on_target_obj
+            ), f"Initial view is not good enough, {perc_on_target_obj}\
                 vs target of {target_perc_on_target_obj}"
-            )
 
             points_on_target_obj = semantic == 1
             closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
@@ -636,10 +636,10 @@ class PolicyTest(unittest.TestCase):
             ]["policy_args"]["desired_object_distance"]
 
             # Utility policy should not have moved too close to the object
-            assert closest_point_on_target_obj > target_closest_point, (
-                f"Initial view is too close, {closest_point_on_target_obj}\
+            assert (
+                closest_point_on_target_obj > target_closest_point
+            ), f"Initial view is too close, {closest_point_on_target_obj}\
                 vs target of {target_closest_point}"
-            )
 
     def test_touch_object_basic_surf_agent(self):
         """Test ability to move a surface agent to touch an object.
@@ -677,20 +677,20 @@ class PolicyTest(unittest.TestCase):
             )
             closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
-            assert closest_point_on_target_obj < 1.0, (
-                f"Should be within a meter of the object,\
+            assert (
+                closest_point_on_target_obj < 1.0
+            ), f"Should be within a meter of the object,\
                 closest point at {closest_point_on_target_obj}"
-            )
 
             target_closest_point = dict_config["monty_config"]["motor_system_config"][
                 "motor_system_args"
             ]["policy_args"]["desired_object_distance"]
 
             # Utility policy should not have moved too close to the object
-            assert closest_point_on_target_obj > target_closest_point, (
-                f"Initial position is too close, {closest_point_on_target_obj}\
+            assert (
+                closest_point_on_target_obj > target_closest_point
+            ), f"Initial position is too close, {closest_point_on_target_obj}\
                 vs target of {target_closest_point}"
-            )
 
     def test_get_good_view_multi_object(self):
         """Test ability to move a distant agent to a good view of an object.
@@ -729,10 +729,10 @@ class PolicyTest(unittest.TestCase):
                 "motor_system_config"
             ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
-            assert perc_on_target_obj >= target_perc_on_target_obj, (
-                f"Initial view is not good enough, {perc_on_target_obj}\
+            assert (
+                perc_on_target_obj >= target_perc_on_target_obj
+            ), f"Initial view is not good enough, {perc_on_target_obj}\
                 vs target of {target_perc_on_target_obj}"
-            )
 
             points_on_target_obj = semantic == 1
             closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
@@ -742,20 +742,20 @@ class PolicyTest(unittest.TestCase):
             ]["policy_args"]["desired_object_distance"]
 
             # Utility policy should not have moved too close to the object
-            assert closest_point_on_target_obj > target_closest_point, (
-                f"Initial view is too close to target, {closest_point_on_target_obj}\
+            assert (
+                closest_point_on_target_obj > target_closest_point
+            ), f"Initial view is too close to target, {closest_point_on_target_obj}\
                 vs target of {target_closest_point}"
-            )
 
             # Also calculate closest point on *any* object so that we don't get
             # too close and clip into objects; NB that any object will have a
             # semantic ID > 0
             points_on_any_obj = view["semantic"] > 0
             closest_point_on_any_obj = np.min(view["depth"][points_on_any_obj])
-            assert closest_point_on_any_obj > target_closest_point / 6, (
-                f"Initial view too cloase to other objects, {closest_point_on_any_obj}\
+            assert (
+                closest_point_on_any_obj > target_closest_point / 6
+            ), f"Initial view too cloase to other objects, {closest_point_on_any_obj}\
                 vs target of {target_closest_point / 6}"
-            )
 
     def test_distant_policy_moves_back_to_object(self):
         """Test ability of distant agent to move back to an object.
@@ -997,9 +997,9 @@ class PolicyTest(unittest.TestCase):
         # (i.e. size) of the translation is represented separately.
         motor_system._policy.processed_observations = self.fake_obs_pc[0]
         direction = motor_system._policy.tangential_direction()
-        assert np.all(np.isclose(direction, [1, 0, 0])), (
-            "Not following correct PC direction"
-        )
+        assert np.all(
+            np.isclose(direction, [1, 0, 0])
+        ), "Not following correct PC direction"
         assert motor_system._policy.following_pc_counter == 1, (
             "Should have followed PC and incremented counter"
         )
@@ -1010,9 +1010,9 @@ class PolicyTest(unittest.TestCase):
         # Step 2
         motor_system._policy.processed_observations = self.fake_obs_pc[1]
         direction = motor_system._policy.tangential_direction()
-        assert np.all(np.isclose(direction, [1, 0, 0])), (
-            "Not following correct PC direction"
-        )
+        assert np.all(
+            np.isclose(direction, [1, 0, 0])
+        ), "Not following correct PC direction"
         assert motor_system._policy.following_pc_counter == 2, (
             "Should have followed PC and incremented counter"
         )
@@ -1024,9 +1024,9 @@ class PolicyTest(unittest.TestCase):
         # PC
         motor_system._policy.processed_observations = self.fake_obs_pc[2]
         direction = motor_system._policy.tangential_direction()
-        assert np.all(np.isclose(direction, [0, 1, 0])), (
-            "Not following correct PC direction"
-        )
+        assert np.all(
+            np.isclose(direction, [0, 1, 0])
+        ), "Not following correct PC direction"
         assert motor_system._policy.following_pc_counter == 1, (
             "Should have reset following PC counter due to bias change, and incremented"
         )
@@ -1037,9 +1037,9 @@ class PolicyTest(unittest.TestCase):
         # Step 4
         motor_system._policy.processed_observations = self.fake_obs_pc[3]
         direction = motor_system._policy.tangential_direction()
-        assert np.all(np.isclose(direction, [0, 1, 0])), (
-            "Not following correct PC direction"
-        )
+        assert np.all(
+            np.isclose(direction, [0, 1, 0])
+        ), "Not following correct PC direction"
         assert motor_system._policy.following_pc_counter == 2, (
             "Should have followed PC and incremented counter"
         )
@@ -1052,9 +1052,9 @@ class PolicyTest(unittest.TestCase):
         direction = motor_system._policy.tangential_direction()
         # Note the following movement is a random direction deterministcally set by the
         # random seed
-        assert np.all(np.isclose(direction, [-0.13745981, 0.99050735, 0])), (
-            "Not following correct non-PC direction"
-        )
+        assert np.all(
+            np.isclose(direction, [-0.13745981, 0.99050735, 0])
+        ), "Not following correct non-PC direction"
         assert motor_system._policy.ignoring_pc_counter == 1, (
             "Should have reset ignoring_pc_counter, and then incremented"
         )
@@ -1082,9 +1082,9 @@ class PolicyTest(unittest.TestCase):
 
         motor_system._policy.processed_observations = self.fake_obs_pc[5]
         direction = motor_system._policy.tangential_direction()
-        assert np.all(np.isclose(direction, [1.0, 0.0, 0])), (
-            "Not following correct PC direction"
-        )
+        assert np.all(
+            np.isclose(direction, [1.0, 0.0, 0])
+        ), "Not following correct PC direction"
 
     def test_advanced_following_principal_curvature(self):
         """Test more edge-case elements of the following-PC policy.
@@ -1126,9 +1126,9 @@ class PolicyTest(unittest.TestCase):
         direction = motor_system._policy.tangential_direction()
         # Note the following movement is a random direction deterministcally set by the
         # random seed
-        assert np.all(np.isclose(direction, [0.98165657, 0.19065773, 0])), (
-            "Not following correct non-PC direction"
-        )
+        assert np.all(
+            np.isclose(direction, [0.98165657, 0.19065773, 0])
+        ), "Not following correct non-PC direction"
         assert motor_system._policy.following_pc_counter == 0, (
             "Should not have followed PC and incremented counter"
         )
@@ -1144,9 +1144,9 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[0].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
         direction = motor_system._policy.tangential_direction()
-        assert np.all(np.isclose(direction, [1, 0, 0])), (
-            "Not following correct PC direction"
-        )
+        assert np.all(
+            np.isclose(direction, [1, 0, 0])
+        ), "Not following correct PC direction"
         assert motor_system._policy.following_pc_counter == 1, (
             "Should have followed PC and incremented counter"
         )
@@ -1160,9 +1160,9 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.tangent_locs.append(self.fake_obs_advanced_pc[1].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
         direction = motor_system._policy.tangential_direction()
-        assert np.all(np.isclose(direction, [1, 0, 0])), (
-            "Not following correct PC direction"
-        )
+        assert np.all(
+            np.isclose(direction, [1, 0, 0])
+        ), "Not following correct PC direction"
         assert motor_system._policy.following_pc_counter == 2, (
             "Should have followed PC and incremented counter"
         )
@@ -1183,7 +1183,7 @@ class PolicyTest(unittest.TestCase):
         assert (
             motor_system._policy.ignoring_pc_counter
             == motor_system_args["policy_args"]["min_general_steps"]
-        ), "Shouldn't increment ignoring_pc_counter"
+        ), "Shoulnd't increment ignoring_pc_counter"
         assert motor_system._policy.following_pc_counter == 2, (
             "Should have not changed following_pc_counter"
         )
@@ -1204,9 +1204,9 @@ class PolicyTest(unittest.TestCase):
         direction = motor_system._policy.tangential_direction()
         # Note the following movement is a random direction deterministcally set by the
         # random seed
-        assert np.all(np.isclose(direction, [0.60958557, 0.79272027, 0])), (
-            "Not following correct non-PC direction"
-        )
+        assert np.all(
+            np.isclose(direction, [0.60958557, 0.79272027, 0])
+        ), "Not following correct non-PC direction"
         assert motor_system._policy.ignoring_pc_counter == 0, (
             "Should have reset ignoring_pc_counter, and not incremented"
         )
@@ -1348,18 +1348,18 @@ class PolicyTest(unittest.TestCase):
         ), "Goal-state location is not as expected"
 
         # Pointing down
-        assert np.all(np.isclose(motor_goal_direction, [0, -1.0, 0])), (
-            "Goal-state pose is not as expected"
-        )
+        assert np.all(
+            np.isclose(motor_goal_direction, [0, -1.0, 0])
+        ), "Goal-state pose is not as expected"
 
         assert np.all(
             np.isclose(target_loc_hab, [0.1, 1.6 + surface_displacement, 0.2])
         ), "Habitat target location is not as expected"
 
         # Pointing down
-        assert np.all(np.isclose(agent_direction_hab, [0, -1.0, 0])), (
-            "Habitat pose is not as expected"
-        )
+        assert np.all(
+            np.isclose(agent_direction_hab, [0, -1.0, 0])
+        ), "Habitat pose is not as expected"
 
         # === Second, harder example ===
 
@@ -1382,9 +1382,9 @@ class PolicyTest(unittest.TestCase):
         ), "Goal-state location is not as expected"
 
         # Pointing up, because object is flipped in y-axis
-        assert np.all(np.isclose(motor_goal_direction_2, [0, 1.0, 0])), (
-            "Goal-state pose is not as expected"
-        )
+        assert np.all(
+            np.isclose(motor_goal_direction_2, [0, 1.0, 0])
+        ), "Goal-state pose is not as expected"
 
         # Surface displacement is negative, because object is flipped in x-axis
         assert np.all(
@@ -1392,9 +1392,9 @@ class PolicyTest(unittest.TestCase):
         ), "Habitat target location is not as expected"
 
         # Pointing up, because object is flipped in y-axis
-        assert np.all(np.isclose(agent_direction_hab_2, [0, 1.0, 0])), (
-            "Habitat pose is not as expected"
-        )
+        assert np.all(
+            np.isclose(agent_direction_hab_2, [0, 1.0, 0])
+        ), "Habitat pose is not as expected"
 
         # === Third, hardest example ===
 


### PR DESCRIPTION
This pull request removes motor policies from the `MotorSystem` inheritance hierarchy. 

This is a breaking change (`refactor!:`) due to configuration changes. The functionality, once configuration is updated, works the same.

A new inheritance hierarchy is introduced with `MotorPolicy` replacing `MotorSystem` at the top. The rest of the policy hierarchy remains intact.

Going forward, motor policies are an attribute of `MotorSystem` instances, specifically: `motor_system._policy`.

`MotorSystem` configuration changes as follows:
- `motor_system_class` is always now an instance of `MotorSystem`
- `motor_system_args` is now a dictionary `{"policy_class":..., "policy_args":...}` where `policy_args` contain what used to be in `motor_system_args`, i.e., the policy configuration.

For example:
```python
@dataclass
class MotorSystemConfig:
    motor_system_class: MotorSystem = MotorSystem
    motor_system_args: Union[Dict, Dataclass] = field(
        default_factory=lambda: dict(
            policy_class=BasePolicy,
            policy_args=make_base_policy_config(
                action_space_type="distant_agent",
                action_sampler_class=UniformlyDistributedSampler,
            ),
        )
    )
```

`MotorSystem` initialization changes as follows, new portions highlighted with comments:
```python
        # Create motor system
        motor_system_config = monty_config.pop("motor_system_config")
        motor_system_class = motor_system_config["motor_system_class"]
        motor_system_args = motor_system_config["motor_system_args"]
        assert issubclass(motor_system_class, MotorSystem)  # expecting MotorSystem class
        policy_class = motor_system_args["policy_class"]  # extract "policy_class" from motor_system_args
        policy_args = motor_system_args["policy_args"]  # extract "policy_args" from motor_system_args
        assert issubclass(policy_class, MotorPolicy)  # policy now inherits from MotorPolicy
        policy = policy_class(rng=self.rng, **policy_args)  # policy class gets rng during initialization
        motor_system = motor_system_class(policy=policy)  # motor system only gets policy on initialization
```

All direct `motor_system` accesses are now `motor_system._policy` accesses, highlighting that we are reaching into intended-to-be-private internals of motor system implementation. Follow on pull requests will address this.