### PR TITLE
refactor!: remove setting unused MotorSystem.step_type attribute

### DIFF
--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -488,13 +488,11 @@ class MontyBase(Monty):
     def switch_to_matching_step(self):
         self.step_type = "matching_step"
         self.is_seeking_match = True
-        self.motor_system.step_type = "exploratory_step"
         logging.debug(f"Going into matching mode after {self.episode_steps} steps")
 
     def switch_to_exploratory_step(self):
         self.step_type = "exploratory_step"
         self.is_seeking_match = False
-        self.motor_system.step_type = "exploratory_step"
         logging.info(
             "Going into exploratory mode after" f" {self.matching_steps} steps"
         )


### PR DESCRIPTION
The `MotorSystem` `step_type` attribute is unused but is set as part of `MontyBase` methods (and incorrectly). This pull request removes setting the unused attribute.