### PR TITLE
chore: address B026 (arg unpacking after keyword argument)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,7 +197,6 @@ ignore = [
     ###
     # TODO: flake8=6.1.0 upgrade introduced errors ignored below, resolve these
     "E721", # E721: do not compare types, use 'isinstance()'
-    "B026", # B026: find argument unpacking after keyword argument
     ###
     # TODO: ruff=0.11.4 upgrade introduced the errors ignored below, resolve these
     "LOG015", # LOG015: root-logger-call,

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -284,9 +284,8 @@ class EvidenceGraphLM(GraphLM):
         *args,
         **kwargs,
     ):
-        super(EvidenceGraphLM, self).__init__(
-            initialize_base_modules=False, *args, **kwargs
-        )
+        kwargs["initialize_base_modules"] = False
+        super(EvidenceGraphLM, self).__init__(*args, **kwargs)
         # --- LM components ---
         self.graph_memory = EvidenceGraphMemory(
             graph_delta_thresholds=graph_delta_thresholds,


### PR DESCRIPTION
Addresses B026: find argument unpacking after keyword argument. This can cause silent bugs or errors. 

I considered 3 options:

## Option 1
```python
super(EvidenceGraphLM, self).__init__(
            *args, initialize_base_modules=False, **kwargs
        )
```

## Option 2
```python
kwargs["initialize_base_modules"] = False
super(EvidenceGraphLM, self).__init__(*args, **kwargs)
```

## Option 3
```python
super(EvidenceGraphLM, self).__init__(initialize_base_modules=False) # The `GraphLM` class only takes this argument
```

I chose **Option 2** over Option 1 because I thought it was more understandable and cleaner. I chose Option 2 over Option 3 in case `GraphLM` class gets updated. My preference is Option 2 = Option 3 > Option 1. 

