### PR TITLE
chore: run tools workflows when pyproject.toml changes

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -35,6 +35,7 @@ jobs:
           do
             echo $changed_file
             if [[ $changed_file == tools/* ]] ||
+               [[ $changed_file == pyproject.toml ]] ||
                [[ $changed_file == .github/workflows/tools.yml ]]; then
               echo "run_test_tools=true" >> $GITHUB_OUTPUT
               exit 0
@@ -50,6 +51,7 @@ jobs:
           do
             echo $changed_file
             if [[ $changed_file == tools/* ]] ||
+               [[ $changed_file == pyproject.toml ]] ||
                [[ $changed_file == .github/workflows/tools.yml ]]; then
               echo "run_test_tools=true" >> $GITHUB_OUTPUT
               exit 0

--- a/tools/generate_api_docs/__init__.py
+++ b/tools/generate_api_docs/__init__.py
@@ -1,5 +1,4 @@
 # Copyright 2025 Thousand Brains Project
-# Copyright 2024 Numenta Inc.
 #
 # Copyright may exist in Contributors' modifications
 # and/or contributions to the work.
@@ -7,14 +6,3 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
-
-import os
-from pathlib import Path
-
-
-def get_folders(file_path: str) -> list:
-    return [
-        name
-        for name in os.listdir(file_path)
-        if Path(os.path.join(file_path, name)).is_dir()
-    ]

--- a/tools/generate_api_docs/source/__init__.py
+++ b/tools/generate_api_docs/source/__init__.py
@@ -1,5 +1,4 @@
 # Copyright 2025 Thousand Brains Project
-# Copyright 2024 Numenta Inc.
 #
 # Copyright may exist in Contributors' modifications
 # and/or contributions to the work.
@@ -7,14 +6,3 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
-
-import os
-from pathlib import Path
-
-
-def get_folders(file_path: str) -> list:
-    return [
-        name
-        for name in os.listdir(file_path)
-        if Path(os.path.join(file_path, name)).is_dir()
-    ]

--- a/tools/generate_api_docs/source/conf.py
+++ b/tools/generate_api_docs/source/conf.py
@@ -25,7 +25,7 @@ import datetime
 import sys
 from pathlib import Path
 
-source_path = Path.resolve("../../../src")
+source_path = Path("../../../src").resolve()
 sys.path.insert(0, source_path)
 
 # -- Project information -----------------------------------------------------

--- a/tools/generate_api_docs/source/conf.py
+++ b/tools/generate_api_docs/source/conf.py
@@ -22,10 +22,10 @@ import datetime
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-import os
 import sys
+from pathlib import Path
 
-source_path = os.path.abspath("../../../src")
+source_path = Path.resolve("../../../src")
 sys.path.insert(0, source_path)
 
 # -- Project information -----------------------------------------------------

--- a/tools/github_readme_sync/cli.py
+++ b/tools/github_readme_sync/cli.py
@@ -12,11 +12,12 @@ import argparse
 import logging
 import os
 import sys
-from os.path import abspath, dirname
+from os.path import dirname
+from pathlib import Path
 
 from dotenv import load_dotenv
 
-monty_root = dirname(dirname(dirname(abspath(__file__))))
+monty_root = dirname(dirname(dirname(Path.resolve(__file__))))
 sys.path.append(monty_root)
 
 from tools.github_readme_sync.colors import RED, RESET  # noqa: E402

--- a/tools/github_readme_sync/cli.py
+++ b/tools/github_readme_sync/cli.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-monty_root = dirname(dirname(dirname(Path.resolve(__file__))))
+monty_root = dirname(dirname(dirname(Path(__file__).resolve())))
 sys.path.append(monty_root)
 
 from tools.github_readme_sync.colors import RED, RESET  # noqa: E402

--- a/tools/github_readme_sync/file.py
+++ b/tools/github_readme_sync/file.py
@@ -16,5 +16,5 @@ def get_folders(file_path: str) -> list:
     return [
         name
         for name in os.listdir(file_path)
-        if Path(os.path.join(file_path, name)).is_dir()
+        if Path(file_path).joinpath(name).is_dir()
     ]

--- a/tools/github_readme_sync/hierarchy.py
+++ b/tools/github_readme_sync/hierarchy.py
@@ -227,8 +227,8 @@ def check_external(folder, ignore_dirs, rdme):
                 total_links_checked += links_checked
                 if file_errors:
                     errors[file_path] = file_errors
-            except Exception as exc:
-                logging.error(f"{RED}Error processing {file_path}: {exc}{RESET}")
+            except Exception:
+                logging.exception(f"{RED}Error processing {file_path}: {RESET}")
 
     report_errors(errors, total_links_checked)
 
@@ -303,7 +303,7 @@ def check_readme_link(url, rdme):
         logging.info(log_msg)
         if not response:
             return [f"  broken link: {url} (Not found)"]
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         return [f"  {url}: {str(e)}"]
 
     return []

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -259,7 +259,7 @@ class ReadMe:
                         },
                     )
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 return f"[Failed to load table from {csv_path} - {e}]"
 
         return REGEX_CSV_TABLE.sub(replace_match, body)
@@ -506,7 +506,7 @@ class ReadMe:
                     unsafe_content = f.read()
                     return self.sanitize_html(unsafe_content)
 
-            except Exception as e:
+            except Exception:  # noqa: BLE001
                 return f"[File not found or could not be read: {snippet_path}]"
 
         return regex_markdown_snippet.sub(replace_match, body)

--- a/tools/github_readme_sync/req.py
+++ b/tools/github_readme_sync/req.py
@@ -13,11 +13,12 @@ import os
 
 import requests
 
+REQUEST_TIMEOUT_SECONDS = 60
 
 def get(url: str, headers=None):
     headers = headers or {}
     headers["Authorization"] = f"Basic {os.getenv('README_API_KEY')}"
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
     logging.debug("get %s %s", url, response.status_code)
     if response.status_code == 404:
         return None
@@ -30,7 +31,9 @@ def get(url: str, headers=None):
 def post(url: str, data: dict, headers=None):
     headers = headers or {}
     headers["Authorization"] = f"Basic {os.getenv('README_API_KEY')}"
-    response = requests.post(url, json=data, headers=headers)
+    response = requests.post(
+        url, json=data, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
+    )
     logging.debug("post %s %s", url, response.status_code)
     if response.status_code < 200 or response.status_code >= 300:
         logging.error(f"Failed to post {url} {response.text}")
@@ -41,7 +44,9 @@ def post(url: str, data: dict, headers=None):
 def put(url: str, data: dict, headers=None):
     headers = headers or {}
     headers["Authorization"] = f"Basic {os.getenv('README_API_KEY')}"
-    response = requests.put(url, json=data, headers=headers)
+    response = requests.put(
+        url, json=data, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
+    )
     logging.debug("put %s %s", url, response.status_code)
     if response.status_code < 200 or response.status_code >= 300:
         logging.error(f"Failed to put {url} {response.text}")
@@ -52,7 +57,7 @@ def put(url: str, data: dict, headers=None):
 def delete(url: str, headers=None):
     headers = headers or {}
     headers["Authorization"] = f"Basic {os.getenv('README_API_KEY')}"
-    response = requests.delete(url, headers=headers)
+    response = requests.delete(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
     logging.debug("delete %s %s", url, response.status_code)
     if response.status_code < 200 or response.status_code >= 300:
         return False

--- a/tools/github_readme_sync/tests/export_test.py
+++ b/tools/github_readme_sync/tests/export_test.py
@@ -11,6 +11,7 @@
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from tools.github_readme_sync.export import export
@@ -68,15 +69,15 @@ class TestExport(unittest.TestCase):
         self.assertEqual(hierarchy, expected_hierarchy)
 
         # Assert that the directory structure is created as expected
-        self.assertTrue(os.path.isdir(os.path.join(self.test_output_dir, "category-1")))
-        self.assertTrue(os.path.isdir(os.path.join(self.test_output_dir, "category-2")))
+        self.assertTrue(Path(os.path.join(self.test_output_dir, "category-1")).is_dir())
+        self.assertTrue(Path(os.path.join(self.test_output_dir, "category-2")).is_dir())
 
         # Assert that the document files are created as expected
         self.assertTrue(
-            os.path.isfile(os.path.join(self.test_output_dir, "category-1", "doc-1.md"))
+            Path(os.path.join(self.test_output_dir, "category-1", "doc-1.md")).is_file()
         )
         self.assertTrue(
-            os.path.isfile(os.path.join(self.test_output_dir, "category-2", "doc-2.md"))
+            Path(os.path.join(self.test_output_dir, "category-2", "doc-2.md")).is_file()
         )
 
         # Assert the content of the files is correct

--- a/tools/github_readme_sync/tests/file_test.py
+++ b/tools/github_readme_sync/tests/file_test.py
@@ -22,9 +22,7 @@ class TestGetFolders(unittest.TestCase):
         mock_listdir.return_value = ["folder1", "folder2", "file1.txt", "file2.txt"]
 
         # Mocking os.path.isdir to return True for folders and False for files
-        mock_isdir.side_effect = lambda x: x.endswith("folder1") or x.endswith(
-            "folder2"
-        )
+        mock_isdir.side_effect = lambda x: x.endswith(("folder1", "folder2"))
 
         # The expected output should only include the folders
         expected_folders = ["folder1", "folder2"]

--- a/tools/github_readme_sync/tests/file_test.py
+++ b/tools/github_readme_sync/tests/file_test.py
@@ -8,40 +8,35 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+import os
+import shutil
+import tempfile
 import unittest
-from unittest.mock import patch
+from pathlib import Path
 
 from tools.github_readme_sync.file import get_folders
 
 
 class TestGetFolders(unittest.TestCase):
-    @patch("os.listdir")
-    @patch("os.path.isdir")
-    def test_get_folders(self, mock_isdir, mock_listdir):
-        # Mocking os.listdir to return a specific list of files/folders
-        mock_listdir.return_value = ["folder1", "folder2", "file1.txt", "file2.txt"]
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
 
-        # Mocking os.path.isdir to return True for folders and False for files
-        mock_isdir.side_effect = lambda x: x.endswith(("folder1", "folder2"))
+        os.makedirs(Path(self.temp_dir).joinpath("folder1"))
+        os.makedirs(Path(self.temp_dir).joinpath("folder2"))
+        open(Path(self.temp_dir).joinpath("file1.txt"), "w").close()
+        open(Path(self.temp_dir).joinpath("file2.txt"), "w").close()
 
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_get_folders(self):
         # The expected output should only include the folders
         expected_folders = ["folder1", "folder2"]
 
-        # Call the function with a dummy path
-        result = get_folders("/dummy/path")
+        result = get_folders(self.temp_dir)
 
         # Assert that the result matches the expected folders
-        self.assertEqual(result, expected_folders)
-
-        # Ensure os.listdir was called with the correct path
-        mock_listdir.assert_called_once_with("/dummy/path")
-
-        # Ensure os.path.isdir was called correctly for each item
-        mock_isdir.assert_any_call("/dummy/path/folder1")
-        mock_isdir.assert_any_call("/dummy/path/folder2")
-        mock_isdir.assert_any_call("/dummy/path/file1.txt")
-        mock_isdir.assert_any_call("/dummy/path/file2.txt")
-
+        self.assertEqual(sorted(result), sorted(expected_folders))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/github_readme_sync/tests/hierarchy_test.py
+++ b/tools/github_readme_sync/tests/hierarchy_test.py
@@ -8,6 +8,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+import contextlib
 import http.server
 import os
 import socketserver
@@ -178,10 +179,8 @@ class TestHierarchyFile(unittest.TestCase):
             f.write(f"[Fragment]({self.server_url}/valid#fragment)\n")
 
         with self.assertLogs(level="ERROR") as log:
-            try:
+            with contextlib.suppress(SystemExit):
                 check_external(self.test_dir, [], ReadMe("0.0"))
-            except SystemExit:
-                pass
 
         self.assertTrue(
             any(

--- a/tools/github_readme_sync/tests/req_test.py
+++ b/tools/github_readme_sync/tests/req_test.py
@@ -13,7 +13,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from tools.github_readme_sync.readme import ReadMe
-from tools.github_readme_sync.req import delete, get, post, put
+from tools.github_readme_sync.req import REQUEST_TIMEOUT_SECONDS, delete, get, post, put
 
 
 @patch.dict(os.environ, {"README_API_KEY": "test_api_key"})
@@ -30,7 +30,9 @@ class TestReq(unittest.TestCase):
 
         self.assertEqual(result, {"key": "value"})
         mock_get.assert_called_once_with(
-            url, headers={"Authorization": "Basic test_api_key"}
+            url,
+            headers={"Authorization": "Basic test_api_key"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
     @patch("requests.get")
@@ -44,7 +46,9 @@ class TestReq(unittest.TestCase):
 
         self.assertIsNone(result)
         mock_get.assert_called_once_with(
-            url, headers={"Authorization": "Basic test_api_key"}
+            url,
+            headers={"Authorization": "Basic test_api_key"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
     @patch("requests.get")
@@ -61,7 +65,9 @@ class TestReq(unittest.TestCase):
         self.assertIsNone(result)
         self.assertIn("Failed to get https://api.example.com/data", log.output[0])
         mock_get.assert_called_once_with(
-            url, headers={"Authorization": "Basic test_api_key"}
+            url,
+            headers={"Authorization": "Basic test_api_key"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
     @patch("requests.post")
@@ -80,6 +86,7 @@ class TestReq(unittest.TestCase):
             url,
             json=data,
             headers={"Authorization": "Basic test_api_key", "version": "1.0"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
     @patch("requests.post")
@@ -97,7 +104,10 @@ class TestReq(unittest.TestCase):
         self.assertIsNone(result)
         self.assertIn("Failed to post https://api.example.com/data", log.output[0])
         mock_post.assert_called_once_with(
-            url, json=data, headers={"Authorization": "Basic test_api_key"}
+            url,
+            json=data,
+            headers={"Authorization": "Basic test_api_key"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
     @patch("requests.put")
@@ -112,7 +122,10 @@ class TestReq(unittest.TestCase):
 
         self.assertTrue(result)
         mock_put.assert_called_once_with(
-            url, json=data, headers={"Authorization": "Basic test_api_key"}
+            url,
+            json=data,
+            headers={"Authorization": "Basic test_api_key"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
     @patch("requests.put")
@@ -130,7 +143,10 @@ class TestReq(unittest.TestCase):
         self.assertFalse(result)
         self.assertIn("Failed to put https://api.example.com/data", log.output[0])
         mock_put.assert_called_once_with(
-            url, json=data, headers={"Authorization": "Basic test_api_key"}
+            url,
+            json=data,
+            headers={"Authorization": "Basic test_api_key"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
     @patch("requests.delete")
@@ -144,7 +160,9 @@ class TestReq(unittest.TestCase):
 
         self.assertTrue(result)
         mock_delete.assert_called_once_with(
-            url, headers={"Authorization": "Basic test_api_key"}
+            url,
+            headers={"Authorization": "Basic test_api_key"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
     @patch("requests.delete")
@@ -158,7 +176,9 @@ class TestReq(unittest.TestCase):
 
         self.assertFalse(result)
         mock_delete.assert_called_once_with(
-            url, headers={"Authorization": "Basic test_api_key"}
+            url,
+            headers={"Authorization": "Basic test_api_key"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
     @patch("requests.delete")
@@ -175,7 +195,9 @@ class TestReq(unittest.TestCase):
 
         self.assertIn("Successfully deleted version 1.0.0", log.output[0])
         mock_delete.assert_called_once_with(
-            url, headers={"Authorization": "Basic test_api_key"}
+            url,
+            headers={"Authorization": "Basic test_api_key"},
+            timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
 

--- a/tools/github_readme_sync/upload.py
+++ b/tools/github_readme_sync/upload.py
@@ -77,7 +77,7 @@ def process_children(
         set_do_not_delete(to_be_deleted, child["slug"])
 
         # If this child has children, call the function recursively
-        if "children" in child and child["children"]:
+        if child.get("children"):
             process_children(
                 parent=child,
                 cat_id=cat_id,


### PR DESCRIPTION
Tools workflow does not run when `pyproject.toml` changes, so if linting or other tooling configuration changes (for example: https://github.com/thousandbrainsproject/tbp.monty/pull/233), it won't be noticed until something alters the tools.

This pull request ensures tools checks run when `pyproject.toml` changes.

The newly effective linter rules are addressed for checks to pass in `tools`.