### PR TITLE
refactor: simplify collect_stats_to_save override in EvidenceGraphLM

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -788,7 +788,12 @@ class EvidenceGraphLM(GraphLM):
             if "possible_rotations" not in self.buffer.stats.keys():
                 get_rotations = True
 
-            stats = self._add_detailed_stats(stats, get_rotations)
+            stats["possible_locations"] = self.possible_locations
+            if get_rotations:
+                stats["possible_rotations"] = self.get_possible_poses(as_euler=False)
+            stats["evidences"] = self.evidence
+            stats["symmetry_evidence"] = self.symmetry_evidence
+
         return stats
 
     # ======================= Private ==========================
@@ -1798,14 +1803,6 @@ class EvidenceGraphLM(GraphLM):
         # Do we want to store this? will probably just clutter.
         # self.buffer.update_stats(vote_data, update_time=False)
         pass
-
-    def _add_detailed_stats(self, stats, get_rotations):
-        stats["possible_locations"] = self.possible_locations
-        if get_rotations:
-            stats["possible_rotations"] = self.get_possible_poses(as_euler=False)
-        stats["evidences"] = self.evidence
-        stats["symmetry_evidence"] = self.symmetry_evidence
-        return stats
 
 
 class EvidenceGraphMemory(GraphMemory):


### PR DESCRIPTION
The current `EvidenceGraphLM` override structure for detailed stats logging became a problem in https://github.com/thousandbrainsproject/tbp.monty/pull/227#discussion_r2036072556.

This pull request overrides `collect_stats_to_save` with all details and no longer overrides `_add_detailed_stats`. This enables `NoResetEvidenceGraphLM` in https://github.com/thousandbrainsproject/tbp.monty/pull/227 to override `collect_stats_to_save` directly without propagating extra parameters in `add_detailed_stats`.