### PR TITLE
chore: only strings should be added to sys.path

### DIFF
--- a/tools/generate_api_docs/source/conf.py
+++ b/tools/generate_api_docs/source/conf.py
@@ -26,7 +26,7 @@ import sys
 from pathlib import Path
 
 source_path = Path("../../../src").resolve()
-sys.path.insert(0, source_path)
+sys.path.insert(0, str(source_path))
 
 # -- Project information -----------------------------------------------------
 

--- a/tools/github_readme_sync/cli.py
+++ b/tools/github_readme_sync/cli.py
@@ -12,13 +12,12 @@ import argparse
 import logging
 import os
 import sys
-from os.path import dirname
 from pathlib import Path
 
 from dotenv import load_dotenv
 
-monty_root = dirname(dirname(dirname(Path(__file__).resolve())))
-sys.path.append(monty_root)
+monty_root = Path(__file__).resolve().parent.parent.parent
+sys.path.append(str(monty_root))
 
 from tools.github_readme_sync.colors import RED, RESET  # noqa: E402
 from tools.github_readme_sync.export import export  # noqa: E402


### PR DESCRIPTION
Follow on to #237, where I incorrectly add `Path` objects to `sys.path` instead of strings.

> A program is free to modify this list for its own purposes. **Only strings and bytes** should be added to [sys.path](https://docs.python.org/3.8/library/sys.html#sys.path); all other data types are ignored during import.
> -- https://docs.python.org/3.8/library/sys.html#sys.path