### PR TITLE
chore: initial implementation of plot tool

### DIFF
--- a/tools/plot/README.md
+++ b/tools/plot/README.md
@@ -1,0 +1,38 @@
+# Plot a figure
+
+A tool that plots a figure from experiment log output.
+
+## Setup
+
+Ensure you setup Monty. See [Getting Started - 2. Set up Your Environment](https://thousandbrainsproject.readme.io/docs/getting-started#2-set-up-your-environment).
+
+No additional dependencies are required.
+
+## Usage
+
+```
+$ python -m tools.plot.cli -h
+
+usage: cli.py [-h]
+
+usage: cli.py [-h] [--debug] {objects_evidence_over_time,pose_error_over_time} ...
+
+Plot a figure
+
+positional arguments:
+  {objects_evidence_over_time,pose_error_over_time}
+    objects_evidence_over_time
+                        Plot evidence scores for each object over time.
+    pose_error_over_time
+                        Plot MLH pose error and theoretical limits over time.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --debug               Enable debug logging
+```
+
+## Tests
+
+```
+pytest
+```

--- a/tools/plot/README.md
+++ b/tools/plot/README.md
@@ -31,6 +31,20 @@ optional arguments:
   --debug               Enable debug logging
 ```
 
+### Examples
+
+The tool can be invoked in multiple ways for convenience:
+
+```
+tbp.monty$ python -m tools.plot.cli pose_error_over_time ~/your_experiment_log_directory
+
+tbp.monty$ python tools/plot/cli.py pose_error_over_time ~/your_experiment_log_directory
+
+tbp.monty/tools$ python plot/cli.py pose_error_over_time ~/your_experiment_log_directory
+
+tbp.monty/tools/plot$ python cli.py pose_error_over_time ~/your_experiment_log_directory
+```
+
 ## Tests
 
 ```

--- a/tools/plot/__init__.py
+++ b/tools/plot/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.

--- a/tools/plot/cli.py
+++ b/tools/plot/cli.py
@@ -12,10 +12,10 @@ import logging
 import sys
 from pathlib import Path
 
-from tools.plot import objects_evidence_over_time, pose_error_over_time
-
 monty_root = Path(__file__).resolve().parent.parent.parent
 sys.path.append(str(monty_root))
+
+from tools.plot import objects_evidence_over_time, pose_error_over_time  # noqa: E402
 
 
 def main():

--- a/tools/plot/cli.py
+++ b/tools/plot/cli.py
@@ -1,0 +1,58 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+from tools.plot import objects_evidence_over_time, pose_error_over_time
+
+monty_root = Path(__file__).resolve().parent.parent.parent
+sys.path.append(str(monty_root))
+
+
+def main():
+    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+        dest="debug",
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Plot a figure", parents=[parent_parser]
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    objects_evidence_over_time.add_subparser(subparsers, parent_parser)
+    pose_error_over_time.add_subparser(subparsers, parent_parser)
+
+    args = parser.parse_args()
+
+    log_level = logging.DEBUG if args.debug else logging.INFO
+    handler = logging.StreamHandler(sys.stderr)
+    logging.basicConfig(
+        level=log_level,
+        handlers=[handler],
+    )
+    logger = logging.getLogger(__name__)
+    if args.debug:
+        logger.debug("Debug logging enabled")
+
+    if hasattr(args, "func"):
+        args.func(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/plot/objects_evidence_over_time.py
+++ b/tools/plot/objects_evidence_over_time.py
@@ -23,7 +23,7 @@ from tbp.monty.frameworks.utils.logging_utils import load_stats
 logger = logging.getLogger(__name__)
 
 
-def objects_evidence_over_time(exp_path: str) -> int:
+def plot_objects_evidence_over_time(exp_path: str) -> int:
     """Plot evidence scores for each object over time.
 
     This function visualizes the evidence scores for each object. The plot is produced
@@ -142,5 +142,7 @@ def add_subparser(
         ),
     )
     parser.set_defaults(
-        func=lambda args: sys.exit(objects_evidence_over_time(args.experiment_log_dir))
+        func=lambda args: sys.exit(
+            plot_objects_evidence_over_time(args.experiment_log_dir)
+        )
     )

--- a/tools/plot/objects_evidence_over_time.py
+++ b/tools/plot/objects_evidence_over_time.py
@@ -1,0 +1,146 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import argparse
+import logging
+import os
+import sys
+from typing import Optional
+
+from matplotlib import patches, transforms
+from matplotlib import pyplot as plt
+from matplotlib.ticker import MultipleLocator
+
+from tbp.monty.frameworks.environments.ycb import DISTINCT_OBJECTS
+from tbp.monty.frameworks.utils.logging_utils import load_stats
+
+logger = logging.getLogger(__name__)
+
+
+def objects_evidence_over_time(exp_path: str) -> int:
+    """Plot evidence scores for each object over time.
+
+    This function visualizes the evidence scores for each object. The plot is produced
+    over a sequence of episodes, and overlays colored rectangles highlighting when a
+    particular target object is active.
+
+    Args:
+        exp_path (str): Path to the experiment directory containing the detailed stats
+            file.
+
+    Returns:
+        int: Exit code.
+    """
+    if not os.path.exists(exp_path):
+        logger.error(f"Experiment path not found: {exp_path}")
+        return 1
+
+    # load detailed stats
+    _, _, detailed_stats, _ = load_stats(exp_path, False, False, True, False)
+
+    plt.style.use("seaborn-darkgrid")
+    # fix colors for distinct objects (tab10 supports up to 10 distinct colors)
+    cmap = plt.cm.tab10
+    num_colors = len(DISTINCT_OBJECTS)
+    ycb_colors = {obj: cmap(i / num_colors) for i, obj in enumerate(DISTINCT_OBJECTS)}
+
+    classes = {
+        k: [] for k in list(detailed_stats["0"]["LM_0"]["max_evidence"][0].keys())
+    }
+    target_objects = []  # Objects in each segment, e.g., ['strawberry', 'banana']
+    target_transitions = []  # Transition points on the x-axis, e.g., [49, 99]
+
+    for episode_data in detailed_stats.values():
+        evidences_data = episode_data["LM_0"]["max_evidence"]
+
+        # append evidence data to classes
+        for ts in evidences_data:
+            for k, v in ts.items():
+                classes[k].append(v)
+
+        # collect the target object of this episode
+        target_objects.append(episode_data["target"]["primary_target_object"])
+
+        # collect target transition point
+        target_transitions.append(len(evidences_data))
+
+    # Create the plot
+    _, ax = plt.subplots(figsize=(12, 6))
+
+    # Plot the lines
+    for obj, scores in classes.items():
+        ax.plot(
+            scores,
+            marker="o",
+            linestyle="-",
+            label=obj,
+            color=ycb_colors.get(obj, "gray"),
+        )
+
+    # Add colored rectangles indicating the current target object
+    box_height = 0.02
+    prev_x = 0
+    for obj, x in zip(target_objects, target_transitions):
+        rect = patches.Rectangle(
+            (prev_x, 1 - box_height),
+            (x - 1),
+            box_height,
+            transform=transforms.blended_transform_factory(ax.transData, ax.transAxes),
+            edgecolor="black",
+            facecolor=ycb_colors.get(obj, "gray"),
+            lw=1,
+            alpha=1.0,
+            clip_on=True,
+        )
+        ax.add_patch(rect)
+        prev_x += x - 1
+
+    # Formatting
+    ax.set_xlabel("Timesteps", fontsize=14)
+    ax.set_ylabel("Evidence Scores", fontsize=14)
+    ax.set_title(
+        "Evidence Scores Over Time with Resampling",
+        fontsize=16,
+        fontweight="bold",
+    )
+    ax.legend(title="Objects", fontsize=10, loc="upper left", bbox_to_anchor=(1, 1))
+    ax.grid(True, linestyle="--", alpha=0.6)
+    ax.xaxis.set_major_locator(MultipleLocator(10))
+
+    # Show plot
+    plt.show()
+
+    return 0
+
+
+def add_subparser(
+    subparsers: argparse._SubParsersAction,
+    parent_parser: Optional[argparse.ArgumentParser] = None,
+) -> None:
+    """Add the objects_evidence_over_time subparser to the main parser.
+
+    Args:
+        subparsers: The subparsers object from the main parser.
+        parent_parser: Optional parent parser for shared arguments.
+    """
+    parser = subparsers.add_parser(
+        "objects_evidence_over_time",
+        help="Plot evidence scores for each object over time.",
+        parents=[parent_parser] if parent_parser else [],
+    )
+
+    parser.add_argument(
+        "experiment_log_dir",
+        help=(
+            "The directory containing the experiment log with the detailed stats file."
+        ),
+    )
+    parser.set_defaults(
+        func=lambda args: sys.exit(objects_evidence_over_time(args.experiment_log_dir))
+    )

--- a/tools/plot/objects_evidence_over_time.py
+++ b/tools/plot/objects_evidence_over_time.py
@@ -9,8 +9,8 @@
 
 import argparse
 import logging
-import os
 import sys
+from pathlib import Path
 from typing import Optional
 
 from matplotlib import patches, transforms
@@ -37,7 +37,7 @@ def plot_objects_evidence_over_time(exp_path: str) -> int:
     Returns:
         int: Exit code.
     """
-    if not os.path.exists(exp_path):
+    if not Path(exp_path).exists():
         logger.error(f"Experiment path not found: {exp_path}")
         return 1
 

--- a/tools/plot/pose_error_over_time.py
+++ b/tools/plot/pose_error_over_time.py
@@ -9,8 +9,8 @@
 
 import argparse
 import logging
-import os
 import sys
+from pathlib import Path
 from typing import Optional
 
 import matplotlib.lines as mlines
@@ -43,7 +43,7 @@ def plot_pose_error_over_time(exp_path: str) -> int:
     Returns:
         int: Exit code.
     """
-    if not os.path.exists(exp_path):
+    if not Path(exp_path).exists():
         logger.error(f"Experiment path not found: {exp_path}")
         return 1
 

--- a/tools/plot/pose_error_over_time.py
+++ b/tools/plot/pose_error_over_time.py
@@ -1,0 +1,195 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import argparse
+import logging
+import os
+import sys
+from typing import Optional
+
+import matplotlib.lines as mlines
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from tbp.monty.frameworks.utils.logging_utils import load_stats
+
+logger = logging.getLogger(__name__)
+
+
+def pose_error_over_time(exp_path: str) -> int:
+    """Plot MLH pose error and theoretical limits over time.
+
+    This function visualizes the theoretical pose error limit vs. the actual
+    pose error over time, along with a correctness indicator of whether the
+    predicted object (`mlo`) matches the target object. It generates a two-row
+    plot where the top subplot shows binary correctness (Correct/Wrong) of MLO
+    and the bottom subplot shows pose error metrics.
+    The theoretical limit is calculated by finding the minimum pose error over
+    all existing hypotheses in Monty's hypothesis space. This metric conveys the
+    best possible performance if Monty selects the best hypothesis as its most
+    likely hypothesis (MLH).
+
+    Args:
+        exp_path (str): Path to the experiment directory containing detailed stats
+            data.
+
+    Returns:
+        int: Exit code.
+    """
+    if not os.path.exists(exp_path):
+        logger.error(f"Experiment path not found: {exp_path}")
+        return 1
+
+    # load detailed stats
+    _, _, detailed_stats, _ = load_stats(exp_path, False, False, True, False)
+
+    plt.style.use("seaborn-darkgrid")
+
+    dfs = []
+    for ep_data in detailed_stats.values():
+        steps = len(ep_data["LM_0"]["target_object_theoretical_limit"])
+        target = [ep_data["LM_0"]["target"]["object"] for _ in range(steps)]
+        th_limit = ep_data["LM_0"]["target_object_theoretical_limit"]
+        mlo = [ep_data["LM_0"]["current_mlh"][i]["graph_id"] for i in range(steps)]
+        obj_error = ep_data["LM_0"]["target_object_pose_error"]
+
+        dfs.append(
+            pd.DataFrame(
+                {
+                    "target": target,
+                    "th_limit": th_limit,
+                    "mlo": mlo,
+                    "obj_error": obj_error,
+                }
+            )
+        )
+
+    # Combine all episodes into a single DataFrame
+    df = pd.concat(dfs, ignore_index=True)
+
+    # Create stacked subplots: (MLO accuracy, pose error)
+    _, (ax0, ax1) = plt.subplots(
+        2, 1, figsize=(10, 6), sharex=True, gridspec_kw={"height_ratios": [0.5, 4]}
+    )
+
+    mlo_correct = [
+        1 if mlo == target else 0 for mlo, target in zip(df["mlo"], df["target"])
+    ]
+    colors = ["green" if c else "red" for c in mlo_correct]
+
+    ax0.scatter(
+        np.array(df.index), np.array(mlo_correct), c=colors, marker="o", s=30, alpha=0.8
+    )
+    ax0.set_yticks([0, 1])
+    ax0.set_yticklabels(["wrong", "correct"])
+    ax0.set_ylabel("MLO", fontsize=14)
+    ax0.grid(True, linestyle="--", linewidth=0.5, alpha=0.7)
+
+    ax0.set_ylim(-0.5, 1.5)
+    ax0.tick_params(axis="x", which="both", bottom=False, labelbottom=False)
+
+    ax1.plot(
+        np.array(df.index),
+        np.array(df["th_limit"]),
+        color="black",
+        linestyle="-",
+        linewidth=2,
+        label="Theoretical limit",
+    )
+    ax1.scatter(
+        np.array(df.index),
+        np.array(df["obj_error"]),
+        c="gray",
+        marker="o",
+        s=50,
+        alpha=0.75,
+        label="MLH of target object",
+    )
+
+    # Labels and formatting
+    ax1.set_xlabel("Steps", fontsize=14)
+    ax1.set_ylabel("Pose Error", fontsize=14)
+    ax0.set_title(
+        "MLH Pose Error vs. Theoretical Limit", fontsize=14, fontweight="bold"
+    )
+
+    # Create Legend
+    black_line = mlines.Line2D(
+        [], [], color="black", linewidth=2, label="Theoretical limit"
+    )
+    gray_dots = mlines.Line2D(
+        [],
+        [],
+        color="gray",
+        marker="o",
+        linestyle="None",
+        markersize=8,
+        label="MLH of target object",
+    )
+    green_diamond = mlines.Line2D(
+        [],
+        [],
+        color="green",
+        marker="o",
+        linestyle="None",
+        markersize=8,
+        label="Correct MLO",
+    )
+    red_diamond = mlines.Line2D(
+        [],
+        [],
+        color="red",
+        marker="o",
+        linestyle="None",
+        markersize=8,
+        label="Wrong MLO",
+    )
+
+    ax1.legend(
+        handles=[black_line, gray_dots, green_diamond, red_diamond],
+        loc="lower center",
+        bbox_to_anchor=(0.5, 1.06),
+        ncol=4,
+        frameon=True,
+        shadow=True,
+        fontsize=12,
+    )
+
+    plt.tight_layout()
+    plt.show()
+
+    return 0
+
+
+def add_subparser(
+    subparsers: argparse._SubParsersAction,
+    parent_parser: Optional[argparse.ArgumentParser] = None,
+) -> None:
+    """Add the pose_error_over_time subparser to the main parser.
+
+    Args:
+        subparsers: The subparsers object from the main parser.
+        parent_parser: Optional parent parser for shared arguments.
+    """
+    parser = subparsers.add_parser(
+        "pose_error_over_time",
+        help="Plot MLH pose error and theoretical limits over time.",
+        parents=[parent_parser] if parent_parser else [],
+    )
+
+    parser.add_argument(
+        "experiment_log_dir",
+        help=(
+            "The directory containing the experiment log with the detailed stats file."
+        ),
+    )
+    parser.set_defaults(
+        func=lambda args: sys.exit(pose_error_over_time(args.experiment_log_dir))
+    )

--- a/tools/plot/pose_error_over_time.py
+++ b/tools/plot/pose_error_over_time.py
@@ -23,7 +23,7 @@ from tbp.monty.frameworks.utils.logging_utils import load_stats
 logger = logging.getLogger(__name__)
 
 
-def pose_error_over_time(exp_path: str) -> int:
+def plot_pose_error_over_time(exp_path: str) -> int:
     """Plot MLH pose error and theoretical limits over time.
 
     This function visualizes the theoretical pose error limit vs. the actual
@@ -191,5 +191,5 @@ def add_subparser(
         ),
     )
     parser.set_defaults(
-        func=lambda args: sys.exit(pose_error_over_time(args.experiment_log_dir))
+        func=lambda args: sys.exit(plot_pose_error_over_time(args.experiment_log_dir))
     )

--- a/tools/plot/tests/__init__.py
+++ b/tools/plot/tests/__init__.py
@@ -1,0 +1,9 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+

--- a/tools/plot/tests/objects_evidence_over_time.py
+++ b/tools/plot/tests/objects_evidence_over_time.py
@@ -9,10 +9,10 @@
 
 import unittest
 
-from tools.plot.objects_evidence_over_time import objects_evidence_over_time
+from tools.plot.objects_evidence_over_time import plot_objects_evidence_over_time
 
 
 class TestObjectsEvidenceOverTime(unittest.TestCase):
     def test_exit_1_if_exp_path_does_not_exist(self):
-        exit_code = objects_evidence_over_time("nonexistent_path")
+        exit_code = plot_objects_evidence_over_time("nonexistent_path")
         self.assertEqual(exit_code, 1)

--- a/tools/plot/tests/objects_evidence_over_time.py
+++ b/tools/plot/tests/objects_evidence_over_time.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import unittest
+
+from tools.plot.objects_evidence_over_time import objects_evidence_over_time
+
+
+class TestObjectsEvidenceOverTime(unittest.TestCase):
+    def test_exit_1_if_exp_path_does_not_exist(self):
+        exit_code = objects_evidence_over_time("nonexistent_path")
+        self.assertEqual(exit_code, 1)

--- a/tools/plot/tests/pose_error_over_time_test.py
+++ b/tools/plot/tests/pose_error_over_time_test.py
@@ -9,10 +9,10 @@
 
 import unittest
 
-from tools.plot.pose_error_over_time import pose_error_over_time
+from tools.plot.pose_error_over_time import plot_pose_error_over_time
 
 
 class TestPoseErrorOverTime(unittest.TestCase):
     def test_exit_1_if_exp_path_does_not_exist(self):
-        exit_code = pose_error_over_time("nonexistent_path")
+        exit_code = plot_pose_error_over_time("nonexistent_path")
         self.assertEqual(exit_code, 1)

--- a/tools/plot/tests/pose_error_over_time_test.py
+++ b/tools/plot/tests/pose_error_over_time_test.py
@@ -1,0 +1,18 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import unittest
+
+from tools.plot.pose_error_over_time import pose_error_over_time
+
+
+class TestPoseErrorOverTime(unittest.TestCase):
+    def test_exit_1_if_exp_path_does_not_exist(self):
+        exit_code = pose_error_over_time("nonexistent_path")
+        self.assertEqual(exit_code, 1)


### PR DESCRIPTION
This is an initial implementation of a plot tool. It supports plotting figures proposed in #227.

```
(tbp.monty) tslominski@Overlords-MacBook-Pro tbp.monty % python -m tools.plot.cli -h                                     
usage: cli.py [-h] [--debug] {objects_evidence_over_time,pose_error_over_time} ...

Plot a figure

positional arguments:
  {objects_evidence_over_time,pose_error_over_time}
    objects_evidence_over_time
                        Plot evidence scores for each object over time.
    pose_error_over_time
                        Plot MLH pose error and theoretical limits over time.

optional arguments:
  -h, --help            show this help message and exit
  --debug               Enable debug logging
```

When we added new plots in https://github.com/thousandbrainsproject/tbp.monty/pull/227, I noticed how different that code is from anything in the framework. Yes, it depends on specific logging output in the framework, but other than that, it has different dependencies, and it is mostly `matplotlib` configuration and log file parsing code. Additionally, as a heuristic, whenever I see the string `utils`, it usually highlights to me a group of functionality that likely belongs elsewhere.

If we keep plot utilities in the tools directory, we'll still be able to keep them in sync with the rest of the framework. We can set it up so that the plot tool tests run with Monty tests in case we change something in logging, although there's only a `get_action_name` test.

As a tool, I think plot code will still be usable in a Jupyter Notebook via something like `from tools.plot.objects_evidence_over_time import objects_evidence_over_time` while reducing the dependencies needed for the framework.

https://github.com/user-attachments/assets/de28ec6f-8f2b-48ad-8d55-b35c0e68b134

