### PR TITLE
fix: Fix Omniglot Environment

### DIFF
--- a/src/tbp/monty/frameworks/environments/two_d_data.py
+++ b/src/tbp/monty/frameworks/environments/two_d_data.py
@@ -118,7 +118,7 @@ class OmniglotEnvironment(EmbodiedEnvironment):
         Returns:
             observation (dict).
         """
-        amount = 1 if action.rotation_degrees < 1 else action.rotation_degrees
+        amount = max(action.rotation_degrees, 1)
         self.step_num += int(amount)
         query_loc = self.locations[self.step_num % self.max_steps]
         patch = self.get_image_patch(

--- a/src/tbp/monty/frameworks/environments/two_d_data.py
+++ b/src/tbp/monty/frameworks/environments/two_d_data.py
@@ -111,8 +111,9 @@ class OmniglotEnvironment(EmbodiedEnvironment):
         different points on the second pass.
 
         Args:
-            _action: Not used at the moment since we just follow the draw path.
-            amount: Amount of elements in move path to move at once.
+            action: Not used at the moment since we just follow the draw path. However,
+            we do use the rotation_degrees to determine the amount of pixels to move at
+            each step.
 
         Returns:
             observation (dict).

--- a/src/tbp/monty/frameworks/environments/two_d_data.py
+++ b/src/tbp/monty/frameworks/environments/two_d_data.py
@@ -97,7 +97,7 @@ class OmniglotEnvironment(EmbodiedEnvironment):
         #      interface and how the class hierarchy is defined and used.
         raise NotImplementedError("OmniglotEnvironment does not support adding objects")
 
-    def step(self, _action, amount):
+    def step(self, action: Action):
         """Retrieve the next observation.
 
         Since the omniglot dataset includes stroke information (the order in which
@@ -117,8 +117,7 @@ class OmniglotEnvironment(EmbodiedEnvironment):
         Returns:
             observation (dict).
         """
-        if amount < 1:
-            amount = 1
+        amount = 1 if action.rotation_degrees < 1 else action.rotation_degrees
         self.step_num += int(amount)
         query_loc = self.locations[self.step_num % self.max_steps]
         patch = self.get_image_patch(

--- a/src/tbp/monty/frameworks/environments/two_d_data.py
+++ b/src/tbp/monty/frameworks/environments/two_d_data.py
@@ -118,7 +118,9 @@ class OmniglotEnvironment(EmbodiedEnvironment):
         Returns:
             observation (dict).
         """
-        amount = max(action.rotation_degrees, 1)
+        amount = 1
+        if hasattr(action, "rotation_degrees"):
+            amount = max(action.rotation_degrees, 1)
         self.step_num += int(amount)
         query_loc = self.locations[self.step_num % self.max_steps]
         patch = self.get_image_patch(

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -41,11 +41,14 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
 
     def setup_experiment(self, config):
         super().setup_experiment(config)
-        self.sensor_pos = np.array(
-            config["dataset_args"]["env_init_args"]["agents"][0]["agent_args"][
-                "positions"
-            ]
-        )
+        if "agents" in config["dataset_args"]["env_init_args"].keys():
+            self.sensor_pos = np.array(
+                config["dataset_args"]["env_init_args"]["agents"][0]["agent_args"][
+                    "positions"
+                ]
+            )
+        else:
+            self.sensor_pos = np.array([0, 0, 0])
 
     def run_episode(self):
         """Run a supervised episode on one object in one pose.

--- a/src/tbp/monty/frameworks/models/sensor_modules.py
+++ b/src/tbp/monty/frameworks/models/sensor_modules.py
@@ -506,6 +506,8 @@ class HabitatDistantPatchSM(DetailedLoggingSM, NoiseMixin):
         sensor_position = state["sensors"][self.sensor_module_id + ".rgba"]["position"]
         if "motor_only_step" in state.keys():
             self.motor_only_step = state["motor_only_step"]
+        else:
+            self.motor_only_step = False
 
         agent_rotation = state["rotation"]
         sensor_rotation = state["sensors"][self.sensor_module_id + ".rgba"]["rotation"]


### PR DESCRIPTION
As I was writing the Monty for custom applications tutorial, I noticed that the Omniglot environment was not working properly anymore. This is largely due to the fact that we don't have unit tests for it, so previous changes that broke it were unnoticed. These fixes make it work as intended again. Followup work would include actually testing it, however I think it is a bit more involved since we don't want to have to download the dataset for the unit tests (maybe there is an easy solution I am not aware of).