### PR TITLE
refactor: update np.infty to np.inf (NPY201)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,7 +228,6 @@ ignore = [
     "ISC003", # ISC003: Explicitly concatenated string should be implicitly concatenated
     "N804", # N804: First argument of a class method should be named `cls`
     "NPY002", # NPY002: Replace legacy `np.random.normal` call with `np.random.Generator`
-    "NPY201", # NPY201: `np.infty` will be removed in NumPy 2.0. Use `numpy.inf` instead.
     "PD002", # PD002: `inplace=True` should be avoided; it has inconsistent behavior
     "PD901", # PD901: Avoid using the generic variable name `df` for DataFrames
     "PERF203", # PERF203: `try`-`except` within a loop incurs performance overhead

--- a/src/tbp/monty/frameworks/models/goal_state_generation.py
+++ b/src/tbp/monty/frameworks/models/goal_state_generation.py
@@ -470,7 +470,7 @@ class EvidenceGoalStateGenerator(GraphGoalStateGenerator):
         parent_lm,
         goal_tolerances=None,
         elapsed_steps_factor=10,
-        min_post_goal_success_steps=np.infty,
+        min_post_goal_success_steps=np.inf,
         x_percent_scale_factor=0.75,
         desired_object_distance=0.03,
         wait_growth_multiplier=2,


### PR DESCRIPTION
Updating to use `np.inf`. Not critical as our current numpy version is less than 2.0, but will be removed once we upgrade. Here is the [NumPy 2.0 migration guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html). 