### PR TITLE
refactor!: state is stored in motor system instead of policies

### DIFF
--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -27,7 +27,10 @@ from tbp.monty.frameworks.models.motor_policies import (
     SurfacePolicy,
 )
 from tbp.monty.frameworks.models.motor_system import MotorSystem
-from tbp.monty.frameworks.models.motor_system_state import MotorSystemState
+from tbp.monty.frameworks.models.motor_system_state import (
+    MotorSystemState,
+    ProprioceptiveState,
+)
 
 from .embodied_environment import EmbodiedEnvironment
 
@@ -86,7 +89,7 @@ class EnvironmentDataset(Dataset):
 
         if self.transform is not None:
             observation = self.apply_transform(self.transform, observation, state)
-        return observation, MotorSystemState(state) if state else None
+        return observation, ProprioceptiveState(state) if state else None
 
     def close(self):
         self.env.close()
@@ -104,7 +107,7 @@ class EnvironmentDataset(Dataset):
         state = self.env.get_state()
         if self.transform is not None:
             observation = self.apply_transform(self.transform, observation, state)
-        return observation, MotorSystemState(state) if state else None
+        return observation, ProprioceptiveState(state) if state else None
 
     def __len__(self):
         return math.inf
@@ -139,14 +142,16 @@ class EnvironmentDataLoader:
         self.dataset = dataset
         self.motor_system = motor_system
         self.rng = rng
-        self._observation, self.motor_system._state = self.dataset.reset()
+        self._observation, state = self.dataset.reset()
+        self.motor_system._state = MotorSystemState(state)
         self._action = None
         self._amount = None
         self._counter = 0
 
     def __iter__(self):
         # Reset the environment before iterating
-        self._observation, self.motor_system._state = self.dataset.reset()
+        self._observation, state = self.dataset.reset()
+        self.motor_system._state = MotorSystemState(state)
         self._action = None
         self._amount = None
         self._counter = 0
@@ -160,7 +165,8 @@ class EnvironmentDataLoader:
         else:
             action = self.motor_system()
             self._action = action
-            self._observation, self.motor_system._state = self.dataset[action]
+            self._observation, state = self.dataset[action]
+            self.motor_system._state = MotorSystemState(state)
             self._counter += 1
             return self._observation
 
@@ -381,6 +387,7 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
     def reset_agent(self):
         logging.debug("resetting agent------")
         self._observation, state = self.dataset.reset()
+        state = MotorSystemState(state)
         self._counter = 0
 
         # Make sure to also reset action variables when resetting agent during
@@ -461,6 +468,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 )
 
             self._observation, state = self.dataset[self._action]
+            state = MotorSystemState(state)
 
             # Check whether sensory information is just for feeding back to motor policy
             # TODO refactor so that the motor policy itself is making this update
@@ -576,7 +584,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                     state=self.motor_system._state,
                 )
                 for action in actions:
-                    self._observation, self.motor_system._state = self.dataset[action]
+                    self._observation, state = self.dataset[action]
+                    self.motor_system._state = MotorSystemState(state)
 
         if allow_translation:
             # Move closer to the object, if not already close enough
@@ -589,7 +598,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             # Continue moving to a close distance to the object
             while not close_enough:
                 logging.debug("moving closer!")
-                self._observation, self.motor_system._state = self.dataset[action]
+                self._observation, state = self.dataset[action]
+                self.motor_system._state = MotorSystemState(state)
                 action, close_enough = self.motor_system._policy.move_close_enough(
                     self._observation,
                     sensor_id,
@@ -613,7 +623,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 state=self.motor_system._state,
             )
             for action in actions:
-                self._observation, self.motor_system._state = self.dataset[action]
+                self._observation, state = self.dataset[action]
+                self.motor_system._state = MotorSystemState(state)
             on_target_object = self.motor_system._policy.is_on_target_object(
                 self._observation,
                 sensor_id,
@@ -706,7 +717,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             rotation_quat=quaternion.one,
         )
         _, _ = self.dataset[set_agent_pose]
-        self._observation, self.motor_system._state = self.dataset[set_sensor_rotation]
+        self._observation, state = self.dataset[set_sensor_rotation]
+        self.motor_system._state = MotorSystemState(state)
 
         # Check depth-at-center to see if the object is in front of us
         # As for methods such as touch_object, we use the view-finder
@@ -817,7 +829,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 == pre_jump_state["sensors"][current_sensor]["rotation"]
             ), "Failed to return sensor to orientation"
 
-        self.motor_system._state = state
+        self.motor_system._state = MotorSystemState(state)
 
         # TODO explore reverting to an attempt with touch_object here,
         # only moving back to our starting location if this is unsuccessful
@@ -859,7 +871,8 @@ class OmniglotDataLoader(EnvironmentDataLoaderPerObject):
             )
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, self.motor_system._state = self.dataset.reset()
+        self._observation, state = self.dataset.reset()
+        self.motor_system._state = MotorSystemState(state)
         self._action = None
         self._amount = None
         self._counter = 0
@@ -948,7 +961,8 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
             )
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, self.motor_system._state = self.dataset.reset()
+        self._observation, state = self.dataset.reset()
+        self.motor_system._state = MotorSystemState(state)
         self._action = None
         self._amount = None
         self._counter = 0
@@ -1041,7 +1055,8 @@ class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):
         # TODO: call super init instead of duplication code & generally clean up more
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, self.motor_system._state = self.dataset.reset()
+        self._observation, state = self.dataset.reset()
+        self.motor_system._state = MotorSystemState(state)
         self._action = None
         self._amount = None
         self._counter = 0

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -454,7 +454,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 and self._action is None
             ):
                 self._action = self.motor_system._policy.touch_object(
-                    self._observation, view_sensor_id="view_finder"
+                    self._observation,
+                    view_sensor_id="view_finder",
+                    state=self.motor_system._policy.state,
                 )
 
             self._observation, state = self.dataset[self._action]

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -142,16 +142,20 @@ class EnvironmentDataLoader:
         self.dataset = dataset
         self.motor_system = motor_system
         self.rng = rng
-        self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset.reset()
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
         self._action = None
         self._amount = None
         self._counter = 0
 
     def __iter__(self):
         # Reset the environment before iterating
-        self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset.reset()
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
         self._action = None
         self._amount = None
         self._counter = 0
@@ -165,8 +169,10 @@ class EnvironmentDataLoader:
         else:
             action = self.motor_system()
             self._action = action
-            self._observation, state = self.dataset[action]
-            self.motor_system._state = MotorSystemState(state) if state else None
+            self._observation, proprioceptive_state = self.dataset[action]
+            self.motor_system._state = (
+                MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+            )
             self._counter += 1
             return self._observation
 
@@ -386,17 +392,19 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
 
     def reset_agent(self):
         logging.debug("resetting agent------")
-        self._observation, state = self.dataset.reset()
-        state = MotorSystemState(state)
+        self._observation, proprioceptive_state = self.dataset.reset()
+        motor_system_state = MotorSystemState(proprioceptive_state)
         self._counter = 0
 
         # Make sure to also reset action variables when resetting agent during
         # pre-episode
         self._action = None
         self._amount = None
-        state[self.motor_system._policy.agent_id]["motor_only_step"] = False
+        motor_system_state[self.motor_system._policy.agent_id]["motor_only_step"] = (
+            False
+        )
 
-        self.motor_system._state = state
+        self.motor_system._state = motor_system_state
 
         return self._observation
 
@@ -467,8 +475,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                     state=self.motor_system._state,
                 )
 
-            self._observation, state = self.dataset[self._action]
-            state = MotorSystemState(state)
+            self._observation, proprioceptive_state = self.dataset[self._action]
+            motor_system_state = MotorSystemState(proprioceptive_state)
 
             # Check whether sensory information is just for feeding back to motor policy
             # TODO refactor so that the motor policy itself is making this update
@@ -477,11 +485,15 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 isinstance(self.motor_system._policy, SurfacePolicy)
                 and self._action.name != "orient_vertical"
             ):
-                state[self.motor_system._policy.agent_id]["motor_only_step"] = True
+                motor_system_state[self.motor_system._policy.agent_id][
+                    "motor_only_step"
+                ] = True
             else:
-                state[self.motor_system._policy.agent_id]["motor_only_step"] = False
+                motor_system_state[self.motor_system._policy.agent_id][
+                    "motor_only_step"
+                ] = False
 
-            self.motor_system._state = state
+            self.motor_system._state = motor_system_state
 
             self._counter += 1  # TODO clean up incrementing of counter
 
@@ -584,9 +596,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                     state=self.motor_system._state,
                 )
                 for action in actions:
-                    self._observation, state = self.dataset[action]
+                    self._observation, proprio_state = self.dataset[action]
                     self.motor_system._state = (
-                        MotorSystemState(state) if state else None
+                        MotorSystemState(proprio_state) if proprio_state else None
                     )
 
         if allow_translation:
@@ -600,8 +612,10 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             # Continue moving to a close distance to the object
             while not close_enough:
                 logging.debug("moving closer!")
-                self._observation, state = self.dataset[action]
-                self.motor_system._state = MotorSystemState(state) if state else None
+                self._observation, proprio_state = self.dataset[action]
+                self.motor_system._state = (
+                    MotorSystemState(proprio_state) if proprio_state else None
+                )
                 action, close_enough = self.motor_system._policy.move_close_enough(
                     self._observation,
                     sensor_id,
@@ -625,8 +639,10 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 state=self.motor_system._state,
             )
             for action in actions:
-                self._observation, state = self.dataset[action]
-                self.motor_system._state = MotorSystemState(state) if state else None
+                self._observation, proprio_state = self.dataset[action]
+                self.motor_system._state = (
+                    MotorSystemState(proprio_state) if proprio_state else None
+                )
             on_target_object = self.motor_system._policy.is_on_target_object(
                 self._observation,
                 sensor_id,
@@ -719,8 +735,10 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             rotation_quat=quaternion.one,
         )
         _, _ = self.dataset[set_agent_pose]
-        self._observation, state = self.dataset[set_sensor_rotation]
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset[set_sensor_rotation]
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
 
         # Check depth-at-center to see if the object is in front of us
         # As for methods such as touch_object, we use the view-finder
@@ -810,28 +828,28 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             rotation_quat=pre_jump_state["sensors"][first_sensor]["rotation"],
         )
         _, _ = self.dataset[set_agent_pose]
-        self._observation, state = self.dataset[set_sensor_rotation]
+        self._observation, proprioceptive_state = self.dataset[set_sensor_rotation]
 
         assert np.all(
-            state[self.motor_system._policy.agent_id]["position"]
+            proprioceptive_state[self.motor_system._policy.agent_id]["position"]
             == pre_jump_state["position"]
         ), "Failed to return agent to location"
         assert np.all(
-            state[self.motor_system._policy.agent_id]["rotation"]
+            proprioceptive_state[self.motor_system._policy.agent_id]["rotation"]
             == pre_jump_state["rotation"]
         ), "Failed to return agent to orientation"
 
-        for current_sensor in state[self.motor_system._policy.agent_id][
+        for current_sensor in proprioceptive_state[self.motor_system._policy.agent_id][
             "sensors"
         ].keys():
             assert np.all(
-                state[self.motor_system._policy.agent_id]["sensors"][current_sensor][
-                    "rotation"
-                ]
+                proprioceptive_state[self.motor_system._policy.agent_id]["sensors"][
+                    current_sensor
+                ]["rotation"]
                 == pre_jump_state["sensors"][current_sensor]["rotation"]
             ), "Failed to return sensor to orientation"
 
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(proprioceptive_state)
 
         # TODO explore reverting to an attempt with touch_object here,
         # only moving back to our starting location if this is unsuccessful
@@ -873,8 +891,10 @@ class OmniglotDataLoader(EnvironmentDataLoaderPerObject):
             )
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset.reset()
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
         self._action = None
         self._amount = None
         self._counter = 0
@@ -963,8 +983,10 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
             )
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset.reset()
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
         self._action = None
         self._amount = None
         self._counter = 0
@@ -1057,8 +1079,10 @@ class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):
         # TODO: call super init instead of duplication code & generally clean up more
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset.reset()
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
         self._action = None
         self._amount = None
         self._counter = 0

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -638,6 +638,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
 
         Returns:
             Whether the sensor is on the object.
+
         """
         self.get_good_view("view_finder")
         for patch_id in ("patch", "patch_0"):

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -734,7 +734,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         # makes cleaner use of self.motor_system()
         # Call post_action (normally taken care of __call__ within
         # self.motor_system._policy())
-        self.motor_system._policy.post_action(self.motor_system._policy.action)
+        self.motor_system._policy.post_action(
+            self.motor_system._policy.action, self.motor_system._state
+        )
 
         return self._observation
 

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -143,7 +143,7 @@ class EnvironmentDataLoader:
         self.motor_system = motor_system
         self.rng = rng
         self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
         self._action = None
         self._amount = None
         self._counter = 0
@@ -151,7 +151,7 @@ class EnvironmentDataLoader:
     def __iter__(self):
         # Reset the environment before iterating
         self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
         self._action = None
         self._amount = None
         self._counter = 0
@@ -166,7 +166,7 @@ class EnvironmentDataLoader:
             action = self.motor_system()
             self._action = action
             self._observation, state = self.dataset[action]
-            self.motor_system._state = MotorSystemState(state)
+            self.motor_system._state = MotorSystemState(state) if state else None
             self._counter += 1
             return self._observation
 
@@ -585,7 +585,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 )
                 for action in actions:
                     self._observation, state = self.dataset[action]
-                    self.motor_system._state = MotorSystemState(state)
+                    self.motor_system._state = (
+                        MotorSystemState(state) if state else None
+                    )
 
         if allow_translation:
             # Move closer to the object, if not already close enough
@@ -599,7 +601,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             while not close_enough:
                 logging.debug("moving closer!")
                 self._observation, state = self.dataset[action]
-                self.motor_system._state = MotorSystemState(state)
+                self.motor_system._state = MotorSystemState(state) if state else None
                 action, close_enough = self.motor_system._policy.move_close_enough(
                     self._observation,
                     sensor_id,
@@ -624,7 +626,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             )
             for action in actions:
                 self._observation, state = self.dataset[action]
-                self.motor_system._state = MotorSystemState(state)
+                self.motor_system._state = MotorSystemState(state) if state else None
             on_target_object = self.motor_system._policy.is_on_target_object(
                 self._observation,
                 sensor_id,
@@ -718,7 +720,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         )
         _, _ = self.dataset[set_agent_pose]
         self._observation, state = self.dataset[set_sensor_rotation]
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
 
         # Check depth-at-center to see if the object is in front of us
         # As for methods such as touch_object, we use the view-finder
@@ -872,7 +874,7 @@ class OmniglotDataLoader(EnvironmentDataLoaderPerObject):
         self.dataset = dataset
         self.motor_system = motor_system
         self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
         self._action = None
         self._amount = None
         self._counter = 0
@@ -962,7 +964,7 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
         self.dataset = dataset
         self.motor_system = motor_system
         self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
         self._action = None
         self._amount = None
         self._counter = 0
@@ -1056,7 +1058,7 @@ class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):
         self.dataset = dataset
         self.motor_system = motor_system
         self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
         self._action = None
         self._amount = None
         self._counter = 0

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -27,6 +27,7 @@ from tbp.monty.frameworks.models.motor_policies import (
     SurfacePolicy,
 )
 from tbp.monty.frameworks.models.motor_system import MotorSystem
+from tbp.monty.frameworks.models.motor_system_state import MotorSystemState
 
 from .embodied_environment import EmbodiedEnvironment
 
@@ -85,7 +86,7 @@ class EnvironmentDataset(Dataset):
 
         if self.transform is not None:
             observation = self.apply_transform(self.transform, observation, state)
-        return observation, state
+        return observation, MotorSystemState(state) if state else None
 
     def close(self):
         self.env.close()
@@ -103,7 +104,7 @@ class EnvironmentDataset(Dataset):
         state = self.env.get_state()
         if self.transform is not None:
             observation = self.apply_transform(self.transform, observation, state)
-        return observation, state
+        return observation, MotorSystemState(state) if state else None
 
     def __len__(self):
         return math.inf

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -437,11 +437,11 @@ class MontyBase(Monty):
         Returns:
             State of the agent.
         """
-        return self.motor_system._policy.get_agent_state()
+        return self.motor_system._policy.get_agent_state(self.motor_system._state)
 
     @property
     def is_motor_only_step(self):
-        return self.motor_system._policy.is_motor_only_step
+        return self.motor_system._policy.is_motor_only_step(self.motor_system._state)
 
     @property
     def is_done(self):

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -437,6 +437,8 @@ class MontyBase(Monty):
         Returns:
             State of the agent.
         """
+        # TODO: This is left in place for now to keep PR scope limited, but should be
+        #       refactored in the future to simplify this access pattern.
         return self.motor_system._policy.get_agent_state(self.motor_system._state)
 
     @property

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -38,7 +38,7 @@ from tbp.monty.frameworks.actions.actions import (
     TurnRight,
     VectorXYZ,
 )
-from tbp.monty.frameworks.models.motor_system_state import MotorSystemState
+from tbp.monty.frameworks.models.motor_system_state import AgentState, MotorSystemState
 from tbp.monty.frameworks.utils.spatial_arithmetics import get_angle_beefed_up
 from tbp.monty.frameworks.utils.transform_utils import scipy_to_numpy_quat
 
@@ -248,7 +248,7 @@ class BasePolicy(MotorPolicy):
     # Other required abstract methods, methods called by Monty or Dataloader
     ###
 
-    def get_agent_state(self, state: MotorSystemState):
+    def get_agent_state(self, state: MotorSystemState) -> AgentState:
         """Get agent state (dict).
 
         Note:
@@ -258,16 +258,16 @@ class BasePolicy(MotorPolicy):
             state (MotorSystemState): The current state of the motor system.
 
         Returns:
-            Agent state.
+            (AgentState): Agent state.
         """
         return state[self.agent_id]
 
     def is_motor_only_step(self, state: MotorSystemState):
         """Check if the current step is a motor-only step.
 
-        # TODO: This information is currently stored in motor system state, but
-        # should be stored in the policy state instead as it is tracking policy
-        # state, not motor system state. This will remove MotorSystemState param.
+        TODO: This information is currently stored in motor system state, but
+        should be stored in the policy state instead as it is tracking policy
+        state, not motor system state. This will remove MotorSystemState param.
 
         Args:
             state (MotorSystemState): The current state of the motor system.

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -38,6 +38,7 @@ from tbp.monty.frameworks.actions.actions import (
     TurnRight,
     VectorXYZ,
 )
+from tbp.monty.frameworks.models.motor_system_state import MotorSystemState
 from tbp.monty.frameworks.utils.spatial_arithmetics import get_angle_beefed_up
 from tbp.monty.frameworks.utils.transform_utils import scipy_to_numpy_quat
 
@@ -989,7 +990,9 @@ class SurfacePolicy(InformedPolicy):
 
         return super().pre_episode()
 
-    def touch_object(self, raw_observation, view_sensor_id) -> Action:
+    def touch_object(
+        self, raw_observation, view_sensor_id: str, state: MotorSystemState
+    ) -> Action:
         """The surface agent's policy for moving onto an object for sensing it.
 
         Like the distant agent's get_good_view, this is called at the beginning
@@ -1006,6 +1009,11 @@ class SurfacePolicy(InformedPolicy):
         a point, then orienting down, and finally random orientations along the surface
         of a fixed sphere.
 
+        Args:
+            raw_observation: The raw observation from the simulator.
+            view_sensor_id: The ID of the viewfinder sensor.
+            state: The current state of the motor system.
+
         Returns:
             Action to take.
         """
@@ -1015,9 +1023,9 @@ class SurfacePolicy(InformedPolicy):
             distance = (
                 depth_at_center
                 - self.desired_object_distance
-                - self.state["agent_id_0"]["sensors"][f"{view_sensor_id}.depth"][
-                    "position"
-                ][2]
+                - state["agent_id_0"]["sensors"][f"{view_sensor_id}.depth"]["position"][
+                    2
+                ]
             )
             logging.debug(f"Move to touch visible object, forward by {distance}")
 

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -196,14 +196,14 @@ class BasePolicy(MotorPolicy):
     # Methods that define behavior of __call__
     ###
 
-    def dynamic_call(self, _: Optional[MotorSystemState] = None) -> Action:
+    def dynamic_call(self, _state: Optional[MotorSystemState] = None) -> Action:
         """Return a random action.
 
         The MotorSystemState is ignored.
 
         Args:
-            state (Optional[MotorSystemState]): The current state of the motor system.
-                Defaults to None.
+            _state (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None. Unused.
 
         Returns:
             (Action): A random action.
@@ -957,14 +957,14 @@ class NaiveScanPolicy(InformedPolicy):
     # Methods that define behavior of __call__
     ###
 
-    def dynamic_call(self, _: Optional[MotorSystemState] = None) -> Action:
+    def dynamic_call(self, _state: Optional[MotorSystemState] = None) -> Action:
         """Return the next action in the spiral being executed.
 
         The MotorSystemState is ignored.
 
         Args:
-            _ (Optional[MotorSystemState]): The current state of the motor system.
-                Defaults to None.
+            _state (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None. Unused.
 
         Returns:
             (Action): The action to take.

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -74,8 +74,9 @@ class MotorPolicy(abc.ABC):
     ) -> None:
         """This post action hook will automatically be called at the end of __call__.
 
-        TODO: Remove state parameter as it is only used to serialize the state and
-              should be done within the motor system.
+        TODO: Remove state parameter as it is only used to serialize the state in
+              InformedPolicy.convert_motor_state(state) and should be done within the
+              motor system.
 
         Args:
             action (Action): The action to process the hook for.

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -74,8 +74,8 @@ class MotorPolicy(abc.ABC):
     ) -> None:
         """This post action hook will automatically be called at the end of __call__.
 
-        # TODO: Remove state parameter as it is only used to serialize the state and
-        #       should be done within the motor system.
+        TODO: Remove state parameter as it is only used to serialize the state and
+              should be done within the motor system.
 
         Args:
             action (Action): The action to process the hook for.

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -14,7 +14,7 @@ import json
 import logging
 import math
 import os
-from typing import Dict, List, Literal, Mapping, Tuple, Type, Union, cast
+from typing import Dict, List, Literal, Mapping, Optional, Tuple, Type, Union, cast
 
 import numpy as np
 import quaternion as qt
@@ -50,8 +50,12 @@ class MotorPolicy(abc.ABC):
         self.is_predefined = False
 
     @abc.abstractmethod
-    def dynamic_call(self) -> Action:
+    def dynamic_call(self, state: Optional[MotorSystemState] = None) -> Action:
         """Use this method when actions are not predefined.
+
+        Args:
+            state (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None.
 
         Returns:
             (Action): The action to take.
@@ -65,11 +69,18 @@ class MotorPolicy(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def post_action(self, action: Action) -> None:
+    def post_action(
+        self, action: Action, state: Optional[MotorSystemState] = None
+    ) -> None:
         """This post action hook will automatically be called at the end of __call__.
+
+        # TODO: Remove state parameter as it is only used to serialize the state and
+        #       should be done within the motor system.
 
         Args:
             action (Action): The action to process the hook for.
+            state (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None.
         """
         pass
 
@@ -101,8 +112,12 @@ class MotorPolicy(abc.ABC):
         """
         pass
 
-    def __call__(self) -> Action:
+    def __call__(self, state: Optional[MotorSystemState] = None) -> Action:
         """Select either dynamic or predefined call.
+
+        Args:
+            state (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None.
 
         Returns:
             (Action): The action to take.
@@ -110,8 +125,8 @@ class MotorPolicy(abc.ABC):
         if self.is_predefined:
             action = self.predefined_call()
         else:
-            action = self.dynamic_call()
-        self.post_action(action)
+            action = self.dynamic_call(state)
+        self.post_action(action, state)
         return action
 
 
@@ -154,7 +169,6 @@ class BasePolicy(MotorPolicy):
         self.switch_frequency = float(switch_frequency)
         # Ensure our first action only samples from those that can be random
         self.action = self.get_random_action(self.action_sampler.sample(self.agent_id))
-        self.state = None
 
         ###
         # Load data for predefined actions and amounts if specified
@@ -181,7 +195,18 @@ class BasePolicy(MotorPolicy):
     # Methods that define behavior of __call__
     ###
 
-    def dynamic_call(self) -> Action:
+    def dynamic_call(self, _: Optional[MotorSystemState] = None) -> Action:
+        """Return a random action.
+
+        The MotorSystemState is ignored.
+
+        Args:
+            state (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None.
+
+        Returns:
+            (Action): A random action.
+        """
         return self.get_random_action(self.action)
 
     def get_random_action(self, action: Action) -> Action:
@@ -201,7 +226,7 @@ class BasePolicy(MotorPolicy):
     def predefined_call(self) -> Action:
         return self.action_list[self.episode_step % len(self.action_list)]
 
-    def post_action(self, action: Action) -> None:
+    def post_action(self, action: Action, _: Optional[MotorSystemState] = None) -> None:
         self.action = action
         self.timestep += 1
         self.episode_step += 1
@@ -222,20 +247,34 @@ class BasePolicy(MotorPolicy):
     # Other required abstract methods, methods called by Monty or Dataloader
     ###
 
-    def get_agent_state(self):
+    def get_agent_state(self, state: MotorSystemState):
         """Get agent state (dict).
 
         Note:
             Assumes we only have one agent.
 
+        Args:
+            state (MotorSystemState): The current state of the motor system.
+
         Returns:
             Agent state.
         """
-        return self.state[self.agent_id]
+        return state[self.agent_id]
 
-    @property
-    def is_motor_only_step(self):
-        agent_state = self.get_agent_state()
+    def is_motor_only_step(self, state: MotorSystemState):
+        """Check if the current step is a motor-only step.
+
+        # TODO: This information is currently stored in motor system state, but
+        # should be stored in the policy state instead as it is tracking policy
+        # state, not motor system state. This will remove MotorSystemState param.
+
+        Args:
+            state (MotorSystemState): The current state of the motor system.
+
+        Returns:
+            bool: True if the current step is a motor-only step, False otherwise.
+        """
+        agent_state = self.get_agent_state(state)
         if "motor_only_step" in agent_state.keys() and agent_state["motor_only_step"]:
             return True
         else:
@@ -414,15 +453,22 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
     # Methods that define behavior of __call__
     ###
 
-    def dynamic_call(self) -> Action:
-        """Return the next action and amount.
+    def dynamic_call(self, state: Optional[MotorSystemState] = None) -> Action:
+        """Return the next action to take.
 
         This requires self.processed_observations to be updated at every step
         in the Monty class. self.processed_observations contains the features
         extracted by the sensor module for the guiding sensor (patch).
+
+        Args:
+            state (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None.
+
+        Returns:
+            (Action): The action to take.
         """
         return (
-            super().dynamic_call()
+            super().dynamic_call(state)
             if self.processed_observations.get_on_object()
             else self.fixme_undo_last_action()
         )
@@ -499,14 +545,16 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
         else:
             raise TypeError(f"Invalid action: {last_action}")
 
-    def post_action(self, action: Action) -> None:
+    def post_action(
+        self, action: Action, state: Optional[MotorSystemState] = None
+    ) -> None:
         self.action = action
         self.timestep += 1
         self.episode_step += 1
-        state_copy = self.convert_motor_state()
+        state_copy = self.convert_motor_state(state)
         self.action_sequence.append([action, state_copy])
 
-    def convert_motor_state(self):
+    def convert_motor_state(self, state: MotorSystemState):
         """Convert the motor state into something that can be pickled/saved to JSON.
 
         i.e. substitute vector and quaternion objects; note e.g. copy.deepcopy does not
@@ -515,24 +563,25 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
         TODO ?clean this up with a recursive algorithm, or use BufferEncoder in
         buffer.py
 
+        Args:
+            state (MotorSystemState): The current state of the motor system.
+
         Returns:
-            Copy of the agent state.
+            (dict): Copy of the motor state.
         """
         state_copy = dict()
-        for key in self.state.keys():
+        for key in state.keys():
             state_copy[key] = dict()
-            for key_inner in self.state[key].keys():
-                if type(self.state[key][key_inner]) is dict:
+            for key_inner in state[key].keys():
+                if type(state[key][key_inner]) is dict:
                     state_copy[key][key_inner] = dict()
                     # We need to go deeper
-                    for key_inner_inner in self.state[key][key_inner].keys():
+                    for key_inner_inner in state[key][key_inner].keys():
                         state_copy[key][key_inner][key_inner_inner] = dict()
-                        if type(self.state[key][key_inner][key_inner_inner]) is dict:
+                        if type(state[key][key_inner][key_inner_inner]) is dict:
                             # We need to go even deeper...
                             # (**Hans Zimmer music intensifies**)
-                            for key_i_i_i in self.state[key][key_inner][
-                                key_inner_inner
-                            ]:
+                            for key_i_i_i in state[key][key_inner][key_inner_inner]:
                                 state_copy[key][key_inner][key_inner_inner][
                                     key_i_i_i
                                 ] = dict()
@@ -542,7 +591,7 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
                                     ] = np.array(
                                         [
                                             x
-                                            for x in self.state[key][key_inner][
+                                            for x in state[key][key_inner][
                                                 key_inner_inner
                                             ][key_i_i_i]
                                         ]
@@ -552,27 +601,27 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
                                     state_copy[key][key_inner][key_inner_inner][
                                         key_i_i_i
                                     ] = [
-                                        self.state[key][key_inner][key_inner_inner][
+                                        state[key][key_inner][key_inner_inner][
                                             key_i_i_i
                                         ].real
                                     ] + [
                                         x
-                                        for x in self.state[key][key_inner][
-                                            key_inner_inner
-                                        ][key_i_i_i].imag
+                                        for x in state[key][key_inner][key_inner_inner][
+                                            key_i_i_i
+                                        ].imag
                                     ]
-                elif type(self.state[key][key_inner]) is bool:
+                elif type(state[key][key_inner]) is bool:
                     pass
                 else:
                     try:
                         state_copy[key][key_inner] = np.array(
-                            [x for x in self.state[key][key_inner]]
+                            [x for x in state[key][key_inner]]
                         )
                     except TypeError:
                         # Quaternions
-                        state_copy[key][key_inner] = [
-                            self.state[key][key_inner].real
-                        ] + [x for x in self.state[key][key_inner].imag]
+                        state_copy[key][key_inner] = [state[key][key_inner].real] + [
+                            x for x in state[key][key_inner].imag
+                        ]
         return state_copy
 
     ###
@@ -670,6 +719,7 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
         sensor_id: str,
         target_semantic_id: int,
         multiple_objects_present: bool,
+        state: MotorSystemState,
     ) -> List[Action]:
         """Rotate sensors so that they are centered on the object using a view finder.
 
@@ -683,6 +733,7 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
                 of the target object that we will try to fixate on
             multiple_objects_present: whether there are multiple objects present in the
                 scene.
+            state (MotorSystemState): The current state of the motor system.
 
         Returns:
             A (possibly empty) list of actions and a bool that indicates whether we
@@ -706,9 +757,10 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
             target_semantic_id=target_semantic_id,
             multiple_objects_present=multiple_objects_present,
             sensor_id=sensor_id,
+            state=state,
         )
         down_amount, left_amount = self.compute_look_amounts(
-            relative_location, sensor_id
+            relative_location, sensor_id, state=state
         )
         return [
             LookDown(agent_id=self.agent_id, rotation_degrees=down_amount),
@@ -719,6 +771,7 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
         self,
         relative_location: np.ndarray,
         sensor_id: str,
+        state: MotorSystemState,
     ) -> Tuple[float, float]:
         """Compute the amount to look down and left given a relative location.
 
@@ -736,13 +789,14 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
             relative_location: the x,y,z coordinates of the target with respect
             to the sensor.
             sensor_id: the ID of the sensor used to produce the relative location.
+            state (MotorSystemState): The current state of the motor system.
 
         Returns:
             down_amount: Amount to look down (degrees).
             left_amount: Amount to look left (degrees).
         """
         # Get the sensor's rotation relative to the world.
-        agent_state = self.get_agent_state()
+        agent_state = self.get_agent_state(state)
         # - The agent's rotation relative to the world.
         agent_rotation = agent_state["rotation"]
         # - The sensor's rotation relative to the agent.
@@ -770,6 +824,7 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
         target_semantic_id: int,
         multiple_objects_present: bool,
         sensor_id: str,
+        state: MotorSystemState,
     ) -> np.ndarray:
         """Takes in a semantic 3D observation and returns an x,y,z location.
 
@@ -787,6 +842,7 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
                 scene.
             sensor_id: the ID of the sensor to use for the search. Used for computing
                 the relative location of the new target.
+            state (MotorSystemState): The current state of the motor system.
 
         Returns:
             relative_location: the x,y,z coordinates of the target with respect
@@ -813,10 +869,10 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
         location_to_look_at = sem3d_obs_image[
             idx_loc_to_look_at[0], idx_loc_to_look_at[1], :3
         ]
-        camera_location = self.get_agent_state()["sensors"][f"{sensor_id}.depth"][
+        camera_location = self.get_agent_state(state)["sensors"][f"{sensor_id}.depth"][
             "position"
         ]
-        agent_location = self.get_agent_state()["position"]
+        agent_location = self.get_agent_state(state)["position"]
         # Get the location of the object relative to sensor.
         relative_location = location_to_look_at - (camera_location + agent_location)
 
@@ -900,7 +956,21 @@ class NaiveScanPolicy(InformedPolicy):
     # Methods that define behavior of __call__
     ###
 
-    def dynamic_call(self) -> Action:
+    def dynamic_call(self, _: Optional[MotorSystemState] = None) -> Action:
+        """Return the next action in the spiral being executed.
+
+        The MotorSystemState is ignored.
+
+        Args:
+            _ (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None.
+
+        Returns:
+            (Action): The action to take.
+
+        Raises:
+            StopIteration: If the spiral has completed.
+        """
         if self.steps_per_action * self.fixed_amount >= 90:
             # Raise "StopIteration" to notify the dataloader we need to stop
             # the experiment. This exception is automatically handled by any
@@ -1111,15 +1181,19 @@ class SurfacePolicy(InformedPolicy):
     ###
     # Methods that define behavior of __call__
     ###
-    def dynamic_call(self) -> Action:
+    def dynamic_call(self, state: Optional[MotorSystemState] = None) -> Action:
         """Return the next action to take.
 
         This requires self.processed_observations to be updated at every step
         in the Monty class. self.processed_observations contains the features
         extracted by the sensor module for the guiding sensor (patch).
 
+        Args:
+            state (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None.
+
         Returns:
-            Action to take.
+            (Action): The action to take.
         """
         # Check if we have poor visualization of the object
         if self.processed_observations.get_feature_by_name("object_coverage") < 0.1:
@@ -1148,15 +1222,20 @@ class SurfacePolicy(InformedPolicy):
             # moved forward (e.g. to get a good view)
             self.action = self.action_sampler.sample_move_forward(self.agent_id)
 
-        return self.get_next_action()
+        return self.get_next_action(state)
 
-    def _orient_horizontal(self) -> Action:
+    def _orient_horizontal(self, state: MotorSystemState) -> Action:
         """Orient the agent horizontally.
+
+        Args:
+            state (MotorSystemState): The current state of the motor system.
 
         Returns:
             OrientHorizontal action.
         """
-        rotation_degrees = self.orienting_angle_from_normal("horizontal")
+        rotation_degrees = self.orienting_angle_from_normal(
+            orienting="horizontal", state=state
+        )
         left_distance, forward_distance = self.horizontal_distances(rotation_degrees)
         return OrientHorizontal(
             agent_id=self.agent_id,
@@ -1165,13 +1244,18 @@ class SurfacePolicy(InformedPolicy):
             forward_distance=forward_distance,
         )
 
-    def _orient_vertical(self) -> Action:
+    def _orient_vertical(self, state: MotorSystemState) -> Action:
         """Orient the agent vertically.
+
+        Args:
+            state (MotorSystemState): The current state of the motor system.
 
         Returns:
             OrientVertical action.
         """
-        rotation_degrees = self.orienting_angle_from_normal("vertical")
+        rotation_degrees = self.orienting_angle_from_normal(
+            orienting="vertical", state=state
+        )
         down_distance, forward_distance = self.vertical_distances(rotation_degrees)
         return OrientVertical(
             agent_id=self.agent_id,
@@ -1180,8 +1264,11 @@ class SurfacePolicy(InformedPolicy):
             forward_distance=forward_distance,
         )
 
-    def _move_tangentially(self) -> Action:
+    def _move_tangentially(self, state: MotorSystemState) -> Action:
         """Move tangentially along the object surface.
+
+        Args:
+            state (MotorSystemState): The current state of the motor system.
 
         Returns:
             MoveTangentially action.
@@ -1202,7 +1289,7 @@ class SurfacePolicy(InformedPolicy):
             action.distance = action.distance / 4
             logging.debug(f"Near edge so only moving by {action.distance}")
 
-        action.direction = self.tangential_direction(self.state)
+        action.direction = self.tangential_direction(state)
 
         return action
 
@@ -1221,7 +1308,7 @@ class SurfacePolicy(InformedPolicy):
         )
         return action
 
-    def get_next_action(self):
+    def get_next_action(self, state: MotorSystemState):
         """Retrieve next action from a cycle of four actions.
 
         First move forward to touch the object at the right distance
@@ -1229,6 +1316,9 @@ class SurfacePolicy(InformedPolicy):
         Then orient toward the normal along direction 2
         Then move tangentially along the object surface
         Then start over
+
+        Args:
+            state (MotorSystemState): The current state of the motor system.
 
         Returns:
             Next action in the cycle.
@@ -1240,15 +1330,15 @@ class SurfacePolicy(InformedPolicy):
         last_action = self.last_action
 
         if isinstance(last_action, MoveForward):
-            return self._orient_horizontal()
+            return self._orient_horizontal(state)
         elif isinstance(last_action, OrientHorizontal):
-            return self._orient_vertical()
+            return self._orient_vertical(state)
         elif isinstance(last_action, OrientVertical):
-            return self._move_tangentially()
+            return self._move_tangentially(state)
         elif isinstance(last_action, MoveTangentially):
             # orient around object if it's not centered in view
             if not self.processed_observations.get_on_object():
-                return self._orient_horizontal()
+                return self._orient_horizontal(state)
             # move to the desired_object_distance if it is in view
             else:
                 return self._move_forward()
@@ -1334,7 +1424,7 @@ class SurfacePolicy(InformedPolicy):
 
         return move_down_distance, move_forward_distance
 
-    def get_inverse_agent_rot(self):
+    def get_inverse_agent_rot(self, state: MotorSystemState):
         """Get the inverse rotation of the agent's current orientation.
 
         Used to transform poses of e.g. point normals or principle curvature from
@@ -1345,30 +1435,36 @@ class SurfacePolicy(InformedPolicy):
         identity pose, which will be aquired by transforming the original pose by the
         inverse
 
+        Args:
+            state (MotorSystemState): The current state of the motor system.
+
         Returns:
             Inverse quaternion rotation.
         """
         # Note that quaternion format is [w, x, y, z]
-        [w, x, y, z] = qt.as_float_array(self.state[self.agent_id]["rotation"])
+        [w, x, y, z] = qt.as_float_array(state[self.agent_id]["rotation"])
         # Note that scipy.spatial.transform.Rotation (v1.10.0) format is [x, y, z, w]
         [x, y, z, w] = rot.from_quat([x, y, z, w]).inv().as_quat()
         return qt.quaternion(w, x, y, z)
 
-    def orienting_angle_from_normal(self, orienting: str) -> float:
+    def orienting_angle_from_normal(
+        self, orienting: str, state: MotorSystemState
+    ) -> float:
         """Compute turn angle to face the object.
 
         Based on the point normal, compute the angle that the agent needs
         to turn in order to be oriented directly toward the object
 
         Args:
-            orienting: `"horizontal" or "vertical"`
+            orienting (str): `"horizontal" or "vertical"`
+            state (MotorSystemState): The current state of the motor system.
 
         Returns:
             degrees that the agent needs to turn
         """
         original_point_normal = self.processed_observations.get_point_normal()
 
-        inverse_quaternion_rotation = self.get_inverse_agent_rot()
+        inverse_quaternion_rotation = self.get_inverse_agent_rot(state)
 
         rotated_point_normal = qt.rotate_vectors(
             inverse_quaternion_rotation, original_point_normal
@@ -1674,7 +1770,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
         ):  # Principal curvatures are defined, and counter for a min number of
             # general steps is satisfied
 
-            tang_movement = self.perform_pc_guided_step()
+            tang_movement = self.perform_pc_guided_step(state)
             # Note this may fail if the PC guidance directs us back towards
             # a point we have previously experienced, in which case we revert
             # to a standard tangential movement (as below)
@@ -1695,18 +1791,21 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
 
             self.ignoring_pc_counter += 1
 
-            tang_movement = self.perform_standard_tang_step()
+            tang_movement = self.perform_standard_tang_step(state)
 
         # Save detailed information about tangential steps
         self.update_action_details()
 
         return tang_movement
 
-    def perform_pc_guided_step(self):
+    def perform_pc_guided_step(self, state: MotorSystemState):
         """Inform steps to take using defined directions of principal curvature.
 
         Use the defined directions of principal curvature to inform (ideally a
         series) of steps along the appropriate direction.
+
+        Args:
+            state (MotorSystemState): The current state of the motor system.
 
         Returns:
             VectorXYZ: direction of the action
@@ -1725,7 +1824,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
 
         # Rotate the tangential vector to be in the coordinate frame of the sensory
         # agent (rather than the global reference frame of the environment)
-        inverse_quaternion_rotation = self.get_inverse_agent_rot()
+        inverse_quaternion_rotation = self.get_inverse_agent_rot(state)
         rotated_form = qt.rotate_vectors(inverse_quaternion_rotation, selected_pc_dir)
 
         # Before updating the representation and removing z-axis direction, check
@@ -1746,7 +1845,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
             # and the PC is predominantly defined in the z-direction; note that this
             # step will be weighted by the standard momentum, integrating the previous
             # movement, as we want to move in a consistent heading
-            alternative_movement = self.perform_standard_tang_step()
+            alternative_movement = self.perform_standard_tang_step(state)
 
             # Note that we *don't* re-set the PC buffers, because with any luck,
             # the PC axes will be better defined on the next step; it was also found in
@@ -1763,7 +1862,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
         self.check_for_flipped_pc()
 
         # Check if new heading is necessary
-        self.avoid_revisiting_locations()
+        self.avoid_revisiting_locations(state=state)
 
         # If we are abandoning following PC directions, return the heading that was
         # found in the avoid_revisiting_locations search
@@ -1776,8 +1875,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
             self.following_heading_counter = 0
 
             return qt.rotate_vectors(
-                self.state["agent_id_0"]["rotation"],
-                self.tangential_vec,
+                state["agent_id_0"]["rotation"], self.tangential_vec
             )
 
         # Otherwise our heading is good; we continue and use our original heading (or
@@ -1796,18 +1894,18 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
         self.following_pc_counter += 1
         self.continuous_pc_steps += 1
 
-        return qt.rotate_vectors(
-            self.state["agent_id_0"]["rotation"],
-            self.tangential_vec,
-        )
+        return qt.rotate_vectors(state["agent_id_0"]["rotation"], self.tangential_vec)
 
-    def perform_standard_tang_step(self):
+    def perform_standard_tang_step(self, state: MotorSystemState):
         """Perform a standard tangential step across the object.
 
         This is in contrast to, for example, being guided by principal curvatures.
 
         Note this is still more "intelligent" than the tangential step of the baseline
         surface-agent policy, because it also attempts to avoid revisiting old locations
+
+        Args:
+            state (MotorSystemState): The current state of the motor system.
 
         Returns:
             VectorXYZ: direction of the action
@@ -1842,7 +1940,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
             # and otherwise update it; thus, if
             # we need to avoid a certain direction, we will ignore momentum on this
             # particular iteration, continuing it on the next step
-            self.avoid_revisiting_locations()
+            self.avoid_revisiting_locations(state=state)
             # Note the value for self.tangential_vec and self.tangential_angle is
             # updated by avoid_revisiting_locations (if necessary)
 
@@ -1861,7 +1959,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
         self.following_heading_counter += 1
 
         return qt.rotate_vectors(
-            self.state["agent_id_0"]["rotation"],
+            state["agent_id_0"]["rotation"],
             self.tangential_vec,
         )
 
@@ -1965,6 +2063,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
 
     def avoid_revisiting_locations(
         self,
+        state: MotorSystemState,
         conflict_divisor=3,
         max_steps=100,
     ):
@@ -1983,6 +2082,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
                 initial value that will be dynamically adjusted. Defaults to 3.
             max_steps: Maximum iterations of the search to perform to try to find a
                 non-conflicting heading. Defaults to 100.
+            state (MotorSystemState): The current state of the motor system.
 
         Note that while the policy might have "unrealistic" access to information about
         it's location in the environment, this could easily be replaced by relative
@@ -2002,7 +2102,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
         vec_copy = copy.copy(self.tangential_vec)
 
         if len(self.tangent_locs) > 0:  # Only relevant if prev. locations visited
-            inverse_quaternion_rotation = self.get_inverse_agent_rot()
+            inverse_quaternion_rotation = self.get_inverse_agent_rot(state)
 
             current_loc = self.tangent_locs[-1]
             logging.debug("Checking we don't head for prev. locations")

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1202,7 +1202,7 @@ class SurfacePolicy(InformedPolicy):
             action.distance = action.distance / 4
             logging.debug(f"Near edge so only moving by {action.distance}")
 
-        action.direction = self.tangential_direction()
+        action.direction = self.tangential_direction(self.state)
 
         return action
 
@@ -1253,7 +1253,7 @@ class SurfacePolicy(InformedPolicy):
             else:
                 return self._move_forward()
 
-    def tangential_direction(self) -> VectorXYZ:
+    def tangential_direction(self, state: MotorSystemState) -> VectorXYZ:
         """Set the direction of the action to be a direction 0 - 2pi.
 
         - start at 0 (go up) in the reference frame of the agent; i.e. based on
@@ -1264,6 +1264,9 @@ class SurfacePolicy(InformedPolicy):
         - random action -pi - +pi is given by (rand() - 0.5) * 2pi
         - These are combined and weighted by the alpha parameter
 
+        Args:
+            state: The current state of the motor system.
+
         Returns:
             VectorXYZ: direction of the action
         """
@@ -1273,7 +1276,7 @@ class SurfacePolicy(InformedPolicy):
         )
 
         direction = qt.rotate_vectors(
-            self.state[self.agent_id]["rotation"],
+            state[self.agent_id]["rotation"],
             [
                 np.cos(self.tangential_angle - np.pi / 2),
                 np.sin(self.tangential_angle + np.pi / 2),
@@ -1643,7 +1646,7 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
         else:
             self.action_details["z_defined_pc"].append(None)
 
-    def tangential_direction(self) -> VectorXYZ:
+    def tangential_direction(self, state: MotorSystemState) -> VectorXYZ:
         """Set the direction of action to be a direction 0 - 2pi.
 
         This controls the move_tangential action
@@ -1653,6 +1656,9 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
 
         Tangential movements are the primary means of progressively exploring
         an object's surface
+
+        Args:
+            state: The current state of the motor system.
 
         Returns:
             VectorXYZ: direction of the action

--- a/src/tbp/monty/frameworks/models/motor_system.py
+++ b/src/tbp/monty/frameworks/models/motor_system.py
@@ -8,22 +8,28 @@
 # https://opensource.org/licenses/MIT.
 
 
-from typing import Literal
+from typing import Literal, Optional
 
 from tbp.monty.frameworks.actions.actions import Action
 from tbp.monty.frameworks.models.motor_policies import MotorPolicy
+from tbp.monty.frameworks.models.motor_system_state import MotorSystemState
 
 
 class MotorSystem:
     """The basic motor system implementation."""
 
-    def __init__(self, policy: MotorPolicy) -> None:
+    def __init__(
+        self, policy: MotorPolicy, state: Optional[MotorSystemState] = None
+    ) -> None:
         """Initialize the motor system with a motor policy.
 
         Args:
             policy (MotorPolicy): The motor policy to use.
+            state (Optional[MotorSystemState]): The initial state of the motor system.
+                Defaults to None.
         """
         self._policy = policy
+        self._state = state
 
     @property
     def last_action(self) -> Action:
@@ -54,5 +60,5 @@ class MotorSystem:
         Returns:
             (Action): The action to take.
         """
-        action = self._policy()
+        action = self._policy(self._state)
         return action

--- a/src/tbp/monty/frameworks/models/motor_system_state.py
+++ b/src/tbp/monty/frameworks/models/motor_system_state.py
@@ -12,7 +12,10 @@ import numpy as np
 
 
 class SensorState(TypedDict):
-    """The proprioceptive state of a sensor."""
+    """The proprioceptive state of a sensor.
+
+    TODO: Change into dataclass
+    """
 
     position: Any  # TODO: Stop using magnum.Vector3 and decide on Monty standard
     """The sensor's position relative to the agent."""
@@ -21,7 +24,10 @@ class SensorState(TypedDict):
 
 
 class AgentState(TypedDict):
-    """The proprioceptive state of an agent."""
+    """The proprioceptive state of an agent.
+
+    TODO: Change into dataclass
+    """
 
     sensors: Dict[str, SensorState]
     """The proprioceptive state of the agent's sensors."""
@@ -31,8 +37,21 @@ class AgentState(TypedDict):
     """The agent's rotation relative to some global reference frame."""
 
 
-class MotorSystemState(Dict[str, AgentState]):
-    """The proprioceptive state of the motor system."""
+class ProprioceptiveState(Dict[str, AgentState]):
+    """The proprioceptive state of the motor system.
+
+    TODO: Change into dataclass
+    """
+
+
+class MotorSystemState(Dict[str, Any]):
+    """The state of the motor system.
+
+    TODO: Currently, ProprioceptiveState can be cast to MotorSystemState since
+          MotorSystemState is a generic dictionary. In the future, make
+          ProprioceptiveState a param on MotorSystemState to more clearly distinguish
+          between the two.
+    """
 
     def convert_motor_state(self):
         """Convert the motor state into something that can be pickled/saved to JSON.

--- a/src/tbp/monty/frameworks/models/motor_system_state.py
+++ b/src/tbp/monty/frameworks/models/motor_system_state.py
@@ -8,6 +8,8 @@
 # https://opensource.org/licenses/MIT.
 from typing import Any, Dict, TypedDict
 
+import numpy as np
+
 
 class SensorState(TypedDict):
     """The proprioceptive state of a sensor."""
@@ -29,5 +31,72 @@ class AgentState(TypedDict):
     """The agent's rotation relative to some global reference frame."""
 
 
-MotorSystemState = Dict[str, AgentState]
-"""The proprioceptive state of the motor system."""
+class MotorSystemState(Dict[str, AgentState]):
+    """The proprioceptive state of the motor system."""
+
+    def convert_motor_state(self):
+        """Convert the motor state into something that can be pickled/saved to JSON.
+
+        i.e. substitute vector and quaternion objects; note e.g. copy.deepcopy does not
+        work.
+
+        TODO ?clean this up with a recursive algorithm, or use BufferEncoder in
+        buffer.py
+
+        Returns:
+            (dict): Copy of the motor state.
+        """
+        state_copy = dict()
+        for key in self.keys():
+            state_copy[key] = dict()
+            for key_inner in self[key].keys():
+                if type(self[key][key_inner]) is dict:
+                    state_copy[key][key_inner] = dict()
+                    # We need to go deeper
+                    for key_inner_inner in self[key][key_inner].keys():
+                        state_copy[key][key_inner][key_inner_inner] = dict()
+                        if type(self[key][key_inner][key_inner_inner]) is dict:
+                            # We need to go even deeper...
+                            # (**Hans Zimmer music intensifies**)
+                            for key_i_i_i in self[key][key_inner][key_inner_inner]:
+                                state_copy[key][key_inner][key_inner_inner][
+                                    key_i_i_i
+                                ] = dict()
+                                try:
+                                    state_copy[key][key_inner][key_inner_inner][
+                                        key_i_i_i
+                                    ] = np.array(
+                                        [
+                                            x
+                                            for x in self[key][key_inner][
+                                                key_inner_inner
+                                            ][key_i_i_i]
+                                        ]
+                                    )
+                                except TypeError:
+                                    # Quaternions
+                                    state_copy[key][key_inner][key_inner_inner][
+                                        key_i_i_i
+                                    ] = [
+                                        self[key][key_inner][key_inner_inner][
+                                            key_i_i_i
+                                        ].real
+                                    ] + [
+                                        x
+                                        for x in self[key][key_inner][key_inner_inner][
+                                            key_i_i_i
+                                        ].imag
+                                    ]
+                elif type(self[key][key_inner]) is bool:
+                    pass
+                else:
+                    try:
+                        state_copy[key][key_inner] = np.array(
+                            [x for x in self[key][key_inner]]
+                        )
+                    except TypeError:
+                        # Quaternions
+                        state_copy[key][key_inner] = [self[key][key_inner].real] + [
+                            x for x in self[key][key_inner].imag
+                        ]
+        return state_copy

--- a/src/tbp/monty/frameworks/models/motor_system_state.py
+++ b/src/tbp/monty/frameworks/models/motor_system_state.py
@@ -1,0 +1,33 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from typing import Any, Dict, TypedDict
+
+
+class SensorState(TypedDict):
+    """The proprioceptive state of a sensor."""
+
+    position: Any  # TODO: Stop using magnum.Vector3 and decide on Monty standard
+    """The sensor's position relative to the agent."""
+    rotation: Any  # TODO: Stop using quaternion.quaternion and decide on Monty standard
+    """The sensor's rotation relative to the agent."""
+
+
+class AgentState(TypedDict):
+    """The proprioceptive state of an agent."""
+
+    sensors: Dict[str, SensorState]
+    """The proprioceptive state of the agent's sensors."""
+    position: Any  # TODO: Stop using magnum.Vector3 and decide on Monty standard
+    """The agent's position relative to some global reference frame."""
+    rotation: Any  # TODO: Stop using quaternion.quaternion and decide on Monty standard
+    """The agent's rotation relative to some global reference frame."""
+
+
+MotorSystemState = Dict[str, AgentState]
+"""The proprioceptive state of the motor system."""

--- a/tests/unit/frameworks/models/motor_policies_test.py
+++ b/tests/unit/frameworks/models/motor_policies_test.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import unittest
+from typing import Dict
+
+import numpy as np
+
+from tbp.monty.frameworks.actions.action_samplers import UniformlyDistributedSampler
+from tbp.monty.frameworks.actions.actions import LookUp
+from tbp.monty.frameworks.models.motor_policies import BasePolicy
+from tbp.monty.frameworks.models.motor_system_state import (
+    AgentState,
+    MotorSystemState,
+    SensorState,
+)
+
+
+class BasePolicyTest(unittest.TestCase):
+    def setUp(self):
+        self.rng = np.random.RandomState(42)
+        self.agent_id = f"agent_id_{self.rng.randint(0, 999_999_999)}"
+        self.default_sensor_state: SensorState = {
+            "position": (0.0, 0.0, 0.0),
+            "rotation": (1.0, 0.0, 0.0, 0.0),
+        }
+        self.agent_sensors: Dict[str, SensorState] = {
+            f"sensor_id_{self.rng.randint(0, 999_999_999)}": self.default_sensor_state,
+        }
+        self.default_agent_state: AgentState = {
+            "sensors": self.agent_sensors,
+            **self.default_sensor_state,
+        }
+
+        self.policy = BasePolicy(
+            rng=self.rng,
+            action_sampler_args=dict(actions=[LookUp]),
+            action_sampler_class=UniformlyDistributedSampler,
+            agent_id=self.agent_id,
+            switch_frequency=0.05,
+        )
+
+    def test_get_agent_state_selects_state_matching_agent_id(self):
+        expected_state: AgentState = {
+            "sensors": self.agent_sensors,
+            **self.default_sensor_state,
+        }
+        state: MotorSystemState = {
+            f"{self.agent_id}": expected_state,
+            "different_agent_id": {},
+        }
+        self.assertEqual(self.policy.get_agent_state(state), expected_state)
+
+    def test_is_motor_only_step_returns_false_if_motor_only_step_is_not_in_agent_state(
+        self,
+    ):
+        state: MotorSystemState = {
+            f"{self.agent_id}": self.default_agent_state,
+        }
+        self.assertFalse(self.policy.is_motor_only_step(state))
+
+    def test_is_motor_only_step_returns_true_if_motor_only_step_is_true_in_agent_state(
+        self,
+    ):
+        state: MotorSystemState = {
+            f"{self.agent_id}": {
+                **self.default_agent_state,
+                "motor_only_step": True,
+            },
+        }
+        self.assertTrue(self.policy.is_motor_only_step(state))
+
+    def test_is_motor_only_step_returns_false_if_motor_only_step_is_false_in_agent_state(
+        self,
+    ):
+        state: MotorSystemState = {
+            f"{self.agent_id}": {
+                **self.default_agent_state,
+                "motor_only_step": False,
+            },
+        }
+        self.assertFalse(self.policy.is_motor_only_step(state))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/frameworks/models/motor_policies_test.py
+++ b/tests/unit/frameworks/models/motor_policies_test.py
@@ -76,7 +76,7 @@ class BasePolicyTest(unittest.TestCase):
         }
         self.assertTrue(self.policy.is_motor_only_step(state))
 
-    def test_is_motor_only_step_returns_false_if_motor_only_step_is_false_in_agent_state(
+    def test_is_motor_only_step_returns_false_if_motor_only_step_is_false_in_agent_state(  # noqa: E501
         self,
     ):
         state: MotorSystemState = {

--- a/tests/unit/frameworks/models/motor_policies_test.py
+++ b/tests/unit/frameworks/models/motor_policies_test.py
@@ -51,40 +51,48 @@ class BasePolicyTest(unittest.TestCase):
             "sensors": self.agent_sensors,
             **self.default_sensor_state,
         }
-        state: MotorSystemState = {
-            f"{self.agent_id}": expected_state,
-            "different_agent_id": {},
-        }
+        state = MotorSystemState(
+            {
+                f"{self.agent_id}": expected_state,
+                "different_agent_id": {},
+            }
+        )
         self.assertEqual(self.policy.get_agent_state(state), expected_state)
 
     def test_is_motor_only_step_returns_false_if_motor_only_step_is_not_in_agent_state(
         self,
     ):
-        state: MotorSystemState = {
-            f"{self.agent_id}": self.default_agent_state,
-        }
+        state = MotorSystemState(
+            {
+                f"{self.agent_id}": self.default_agent_state,
+            }
+        )
         self.assertFalse(self.policy.is_motor_only_step(state))
 
     def test_is_motor_only_step_returns_true_if_motor_only_step_is_true_in_agent_state(
         self,
     ):
-        state: MotorSystemState = {
-            f"{self.agent_id}": {
-                **self.default_agent_state,
-                "motor_only_step": True,
-            },
-        }
+        state = MotorSystemState(
+            {
+                f"{self.agent_id}": {
+                    **self.default_agent_state,
+                    "motor_only_step": True,
+                },
+            }
+        )
         self.assertTrue(self.policy.is_motor_only_step(state))
 
     def test_is_motor_only_step_returns_false_if_motor_only_step_is_false_in_agent_state(  # noqa: E501
         self,
     ):
-        state: MotorSystemState = {
-            f"{self.agent_id}": {
-                **self.default_agent_state,
-                "motor_only_step": False,
-            },
-        }
+        state = MotorSystemState(
+            {
+                f"{self.agent_id}": {
+                    **self.default_agent_state,
+                    "motor_only_step": False,
+                },
+            }
+        )
         self.assertFalse(self.policy.is_motor_only_step(state))
 
 

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -938,7 +938,7 @@ class PolicyTest(unittest.TestCase):
             # current orientation
             agent_direction = np.array(
                 hab_utils.quat_rotate_vector(
-                    exp.model.motor_system._policy.state["agent_id_0"]["rotation"],
+                    exp.model.motor_system._state["agent_id_0"]["rotation"],
                     [
                         0,
                         0,
@@ -985,8 +985,8 @@ class PolicyTest(unittest.TestCase):
         )
 
         # Initialize motor-system state
-        motor_system._policy.state = dict(agent_id_0=dict())
-        motor_system._policy.state["agent_id_0"]["rotation"] = qt.quaternion(1, 0, 0, 0)
+        motor_system._state = dict(agent_id_0=dict())
+        motor_system._state["agent_id_0"]["rotation"] = qt.quaternion(1, 0, 0, 0)
 
         # Step 1
         # fake_obs_pc contains observations including the point-normal and principal
@@ -996,9 +996,7 @@ class PolicyTest(unittest.TestCase):
         # Note that the movement is a unit vector because it is a direction, the amount
         # (i.e. size) of the translation is represented separately.
         motor_system._policy.processed_observations = self.fake_obs_pc[0]
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         assert np.all(
             np.isclose(direction, [1, 0, 0])
         ), "Not following correct PC direction"
@@ -1011,9 +1009,7 @@ class PolicyTest(unittest.TestCase):
 
         # Step 2
         motor_system._policy.processed_observations = self.fake_obs_pc[1]
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         assert np.all(
             np.isclose(direction, [1, 0, 0])
         ), "Not following correct PC direction"
@@ -1027,9 +1023,7 @@ class PolicyTest(unittest.TestCase):
         # Step 3: Our bias should change from following minimal to maximal
         # PC
         motor_system._policy.processed_observations = self.fake_obs_pc[2]
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         assert np.all(
             np.isclose(direction, [0, 1, 0])
         ), "Not following correct PC direction"
@@ -1042,9 +1036,7 @@ class PolicyTest(unittest.TestCase):
 
         # Step 4
         motor_system._policy.processed_observations = self.fake_obs_pc[3]
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         assert np.all(
             np.isclose(direction, [0, 1, 0])
         ), "Not following correct PC direction"
@@ -1057,9 +1049,7 @@ class PolicyTest(unittest.TestCase):
 
         # Step 5: Pass observation *without* a well defined PC direction
         motor_system._policy.processed_observations = self.fake_obs_pc[4]
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(
@@ -1088,12 +1078,10 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.ignoring_pc_counter = motor_system_args["policy_args"][
             "min_general_steps"
         ]
-        motor_system._policy.state["agent_id_0"]["rotation"] = qt.quaternion(0, 0, 1, 0)
+        motor_system._state["agent_id_0"]["rotation"] = qt.quaternion(0, 0, 1, 0)
 
         motor_system._policy.processed_observations = self.fake_obs_pc[5]
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         assert np.all(
             np.isclose(direction, [1.0, 0.0, 0])
         ), "Not following correct PC direction"
@@ -1124,8 +1112,8 @@ class PolicyTest(unittest.TestCase):
         )
 
         # Initialize motor system state
-        motor_system._policy.state = dict(agent_id_0=dict())
-        motor_system._policy.state["agent_id_0"]["rotation"] = qt.quaternion(1, 0, 0, 0)
+        motor_system._state = dict(agent_id_0=dict())
+        motor_system._state["agent_id_0"]["rotation"] = qt.quaternion(1, 0, 0, 0)
 
         # Step 1 : PC-guided information, but we haven't taken the minimum number of
         # non-PC steps, so take random step
@@ -1135,9 +1123,7 @@ class PolicyTest(unittest.TestCase):
         # done in graph_matching.py normally
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[0].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(
@@ -1157,9 +1143,7 @@ class PolicyTest(unittest.TestCase):
         # done in graph_matching.py normally
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[0].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         assert np.all(
             np.isclose(direction, [1, 0, 0])
         ), "Not following correct PC direction"
@@ -1175,9 +1159,7 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.processed_observations = self.fake_obs_advanced_pc[1]
         motor_system._policy.tangent_locs.append(self.fake_obs_advanced_pc[1].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         assert np.all(
             np.isclose(direction, [1, 0, 0])
         ), "Not following correct PC direction"
@@ -1192,9 +1174,7 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.processed_observations = self.fake_obs_advanced_pc[2]
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[2].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(
@@ -1221,9 +1201,7 @@ class PolicyTest(unittest.TestCase):
         # following PC would cause it to visit the observation 1 again (which it is
         # designed to avoid)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -996,7 +996,9 @@ class PolicyTest(unittest.TestCase):
         # Note that the movement is a unit vector because it is a direction, the amount
         # (i.e. size) of the translation is represented separately.
         motor_system._policy.processed_observations = self.fake_obs_pc[0]
-        direction = motor_system._policy.tangential_direction()
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         assert np.all(
             np.isclose(direction, [1, 0, 0])
         ), "Not following correct PC direction"
@@ -1009,7 +1011,9 @@ class PolicyTest(unittest.TestCase):
 
         # Step 2
         motor_system._policy.processed_observations = self.fake_obs_pc[1]
-        direction = motor_system._policy.tangential_direction()
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         assert np.all(
             np.isclose(direction, [1, 0, 0])
         ), "Not following correct PC direction"
@@ -1023,7 +1027,9 @@ class PolicyTest(unittest.TestCase):
         # Step 3: Our bias should change from following minimal to maximal
         # PC
         motor_system._policy.processed_observations = self.fake_obs_pc[2]
-        direction = motor_system._policy.tangential_direction()
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         assert np.all(
             np.isclose(direction, [0, 1, 0])
         ), "Not following correct PC direction"
@@ -1036,7 +1042,9 @@ class PolicyTest(unittest.TestCase):
 
         # Step 4
         motor_system._policy.processed_observations = self.fake_obs_pc[3]
-        direction = motor_system._policy.tangential_direction()
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         assert np.all(
             np.isclose(direction, [0, 1, 0])
         ), "Not following correct PC direction"
@@ -1049,7 +1057,9 @@ class PolicyTest(unittest.TestCase):
 
         # Step 5: Pass observation *without* a well defined PC direction
         motor_system._policy.processed_observations = self.fake_obs_pc[4]
-        direction = motor_system._policy.tangential_direction()
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(
@@ -1081,7 +1091,9 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.state["agent_id_0"]["rotation"] = qt.quaternion(0, 0, 1, 0)
 
         motor_system._policy.processed_observations = self.fake_obs_pc[5]
-        direction = motor_system._policy.tangential_direction()
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         assert np.all(
             np.isclose(direction, [1.0, 0.0, 0])
         ), "Not following correct PC direction"
@@ -1123,7 +1135,9 @@ class PolicyTest(unittest.TestCase):
         # done in graph_matching.py normally
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[0].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction()
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(
@@ -1143,7 +1157,9 @@ class PolicyTest(unittest.TestCase):
         # done in graph_matching.py normally
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[0].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction()
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         assert np.all(
             np.isclose(direction, [1, 0, 0])
         ), "Not following correct PC direction"
@@ -1159,7 +1175,9 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.processed_observations = self.fake_obs_advanced_pc[1]
         motor_system._policy.tangent_locs.append(self.fake_obs_advanced_pc[1].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction()
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         assert np.all(
             np.isclose(direction, [1, 0, 0])
         ), "Not following correct PC direction"
@@ -1174,7 +1192,9 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.processed_observations = self.fake_obs_advanced_pc[2]
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[2].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction()
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(
@@ -1201,7 +1221,9 @@ class PolicyTest(unittest.TestCase):
         # following PC would cause it to visit the observation 1 again (which it is
         # designed to avoid)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction()
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(


### PR DESCRIPTION
In a previous refactor (#234), I separated the `MotorSystem` from `MotorPolicy` and set things up so that a policy was a `motor_system._policy` attribute. However, the motor system state remained attached to the motor policy.

Since we want to be able to swap motor policies, we want to maintain the motor system state outside of the motor policy.

This pull request consolidates motor system state to be a `MotorSystem._state` property. Additionally, since motor policies no longer track motor system state, all motor policy code is passed the motor state explicitly via a `state: Optional[MotorSystemState]` argument.

One consequence of this is in dataloaders (`embodied_data.py`). We see two directly invoked policy methods being passed the motor system state explicitly, for example:
```python
                self._action = self.motor_system._policy.touch_object(
                    self._observation, view_sensor_id="view_finder"
                    self._observation,
                    view_sensor_id="view_finder",
                    state=self.motor_system._state,
                )
```
```python
                actions = self.motor_system._policy.orient_to_object(
                    self._observation,
                    sensor_id,
                    target_semantic_id=self.primary_target["semantic_id"],
                    multiple_objects_present=multiple_objects_present,
                    state=self.motor_system._state,
                )
```
Otherwise, most explicit state passing is confined to `motor_policies.py` internally.

Two outliers in `motor_policies.py` indicate a need for future refactoring: `is_motor_only_step()` and `convert_motor_state()`. 

`is_motor_only_step()` seems to no longer belong on a policy, as it is solely concerned with the motor system, but it is attached to `agent_id`, which is still tied to policy.

Similarly, `convert_motor_state`, only converts motor system state. ~~This particular one is left in place in case of weird things with the state assignment that InformedPolicy does. A future goal is to move it to the motor system after further analysis.~~ This was moved to `MotorSystemState.convert_motor_state` (unaltered for now).

I added a dash of unit tests for `BasePolicy` since the methods are easier to test with `state` being explicitly passed in. I deferred writing unit tests for other policies as they look complicated. I figure we'll get around to those eventually.

FYI: @scottcanoe @hlee9212 @ramyamounir @jeremyshoemaker 