### PR TITLE
refactor: update deprecated syntax (UP005)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,7 +299,6 @@ ignore = [
     "TRY002", # TRY002: Create your own exception
     "TRY003", # TRY003: Avoid specifying long messages outside the exception class
     "TRY004", # TRY004: Prefer `TypeError` exception for invalid type
-    "UP005", # UP005: `assertEquals` is deprecated, use `assertEqual`
     "UP006", # UP006: Use `type` instead of `Type` for type annotation
     "UP008", # UP008: Use `super()` instead of `super(__class__, self)`
     "UP015", # UP015: Unnecessary open mode parameters

--- a/tests/unit/habitat_sim_test.py
+++ b/tests/unit/habitat_sim_test.py
@@ -85,7 +85,7 @@ class HabitatSimTest(unittest.TestCase):
         with HabitatSim(agents=agents) as sim:
             # Check agent configuration
             actual_agent_config = sim.get_agent(agent_id).agent_config
-            self.assertEquals(actual_agent_config, agent_config)
+            self.assertEqual(actual_agent_config, agent_config)
 
             # Check if 2 sensors were created for the agent (RGB and Depth)
             obs = sim.get_observations()
@@ -115,7 +115,7 @@ class HabitatSimTest(unittest.TestCase):
             for agent in agents:
                 actual_agent_config = sim.get_agent(agent.agent_id).agent_config
                 agent_config = agent.get_spec()
-                self.assertEquals(actual_agent_config, agent_config)
+                self.assertEqual(actual_agent_config, agent_config)
 
             # Check if 2 sensors were created for each agent
             obs = sim.get_observations()


### PR DESCRIPTION
Not critical yet but `assertEquals` will be deprecated from python 3.12 ([UP005](https://docs.astral.sh/ruff/rules/deprecated-unittest-alias/)). 