### PR TITLE
fix: temporary fix for featLM voting logic

### DIFF
--- a/src/tbp/monty/frameworks/models/feature_location_matching.py
+++ b/src/tbp/monty/frameworks/models/feature_location_matching.py
@@ -160,12 +160,12 @@ class FeatureGraphLM(GraphLM):
                 # Check that object is still in matches after ID update
                 if possible_obj in self.possible_matches:
                     # TODO: better way to dynamically adapt k
-                    if vote_data["pos_location_votes"][possible_obj].shape[0] < 5:
+                    if vote_data["pos_location_votes"][possible_obj].shape[0] < 4:
                         k = vote_data["pos_location_votes"][possible_obj].shape[0]
                         print(f"only received {k} votes")
                     else:
-                        k = 5
-
+                        # TODO: k should not be > num_lms
+                        k = 4
                     vote_location_tree = KDTree(
                         vote_data["pos_location_votes"][possible_obj],
                         leaf_size=2,


### PR DESCRIPTION
This is really more of a hacky patch than a fix. The featureLM voting logic looked at the number of incoming location votes to determine how many of them need to agree. However, a signed sending LM might have multiple hypotheses. For this to be correct, the receiving LM needs to use the number of LMs that it receives input from to determine k. However, I don't think it currently has access to this information so I hardcoded it to 4 since all our voting experiments use 5LMs. I would spend more time on an actual solution if this was the evidenceLM but since we don't really use the featureLM anymore I didn't want to go too far down this path.

@jeremyshoemaker this should be the last remaining fix necessary for the 5LM unit test to work (in addition to the changes on my branch here: https://github.com/vkakerbeck/tbp.monty/tree/my_5lm_test_branch )