### PR TITLE
fix: MontyBase._step_learning_modules now works

### DIFF
--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -203,7 +203,7 @@ class MontyBase(Monty):
     def _step_learning_modules(self):
         for i in range(len(self.learning_modules)):
             sensory_inputs = self._collect_inputs_to_lm(i)
-            getattr(self.learning_modules[i], self.step_type, sensory_inputs)
+            getattr(self.learning_modules[i], self.step_type)(sensory_inputs)
 
     def _collect_inputs_to_lm(self, lm_id):
         """Use sm_to_lm_matrix and lm_to_lm_matrix to collect inputs to LM i.


### PR DESCRIPTION
We probably never noticed this because `MontyForGraphMatching(MontyBase)` overrides this method with its own implementation. Within that override, you'll notice the correct usage of `getattr`:
```python
                lm_step_method = getattr(self.learning_modules[i], self.step_type)
                assert callable(lm_step_method), f"{lm_step_method} must be callable"
                lm_step_method(sensory_inputs)
```