### PR TITLE
refactor!: remove unusued Monty._post_step method

### DIFF
--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -27,7 +27,6 @@ class Monty(metaclass=abc.ABCMeta):
         self._pass_goal_states()
         self._pass_infos_to_motor_system()
         self._set_step_type_and_check_if_done()
-        self._post_step()
 
     def _exploratory_step(self, observation):
         """Step format for adding data to an existing model.
@@ -38,7 +37,6 @@ class Monty(metaclass=abc.ABCMeta):
         self._step_learning_modules()
         self._pass_infos_to_motor_system()
         self._set_step_type_and_check_if_done()
-        self._post_step()
 
     @abc.abstractmethod
     def step(self, observation):
@@ -88,11 +86,6 @@ class Monty(metaclass=abc.ABCMeta):
 
         Update what self.is_done returns to the experiment.
         """
-        pass
-
-    @abc.abstractmethod
-    def _post_step(self):
-        """Hook for doing things like updating counters."""
         pass
 
     ###

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -321,9 +321,6 @@ class MontyBase(Monty):
                         f"finished evaluating after {self.matching_steps} steps"
                     )
 
-    def _post_step(self):
-        pass
-
     ###
     # Methods (other than step) that interact with the experiment
     ###


### PR DESCRIPTION
This method is unused. While it mentions updating counters, we update counters in `_set_step_type_and_check_if_done`.