### PR TITLE
refactor: enable most comprehension lints

### DIFF
--- a/benchmarks/configs/follow_ups/__init__.py
+++ b/benchmarks/configs/follow_ups/__init__.py
@@ -20,7 +20,7 @@ current_dir = pathlib.Path(__file__).parent
 files = [file for file in os.listdir(current_dir) if file.endswith(".pkl")]
 names = [file.split(".")[0] for file in files]
 
-CONFIGS = dict()
+CONFIGS = {}
 for file, name in zip(files, names):
     with open(os.path.join(current_dir, file), "rb") as f:
         config = pickle.load(f)

--- a/benchmarks/configs/follow_ups/names.py
+++ b/benchmarks/configs/follow_ups/names.py
@@ -7,4 +7,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-NAMES = list()
+NAMES = []

--- a/benchmarks/configs/load.py
+++ b/benchmarks/configs/load.py
@@ -33,7 +33,7 @@ def load_configs(experiments: list[str]) -> dict:
     Returns:
         The imported configuration groups for the given experiments.
     """
-    configs = dict()
+    configs = {}
 
     for experiment in experiments:
         configs.update(select_config(experiment))

--- a/benchmarks/configs/monty_world_experiments.py
+++ b/benchmarks/configs/monty_world_experiments.py
@@ -95,7 +95,7 @@ world_image_from_stream_on_scanned_model = copy.deepcopy(world_image_on_scanned_
 world_image_from_stream_on_scanned_model.update(
     dataset_args=WorldImageFromStreamDatasetArgs(),
     eval_dataloader_class=ED.SaccadeOnImageFromStreamDataLoader,
-    eval_dataloader_args=dict(),
+    eval_dataloader_args={},
     logging_config=EvalEvidenceLMLoggingConfig(
         wandb_handlers=[], python_log_level="INFO"
     ),

--- a/benchmarks/configs/names.py
+++ b/benchmarks/configs/names.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, fields
 
 from benchmarks.configs.follow_ups.names import NAMES as FOLLOW_UP_NAMES
 
-NAMES = list()
+NAMES = []
 
 NAMES.extend(FOLLOW_UP_NAMES)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ select = [
 ignore = [
     ###
     # Original inherited flake8 ignores
-    "C4", # C4XX: ignore all Flake8 comprehensions
     "D1", # D1XX: Missing Docstrings
     "ERA001", # ERA001: Found commented out code
     "F541", # F541: f-string is missing placeholders
@@ -196,7 +195,7 @@ ignore = [
     "T203", # T203: pprint found
     # TODO: ruff=0.11.4 upgrade introduced the errors ignored below, resolve these
     "LOG015", # LOG015: root-logger-call,
-    "PTH208", # PTH208: os-listdir 
+    "PTH208", # PTH208: os-listdir
     "RUF022", # RUF022: unsorted-dunder-all
     "TC006", # TC006: runtime-cast-value
     ###
@@ -302,6 +301,10 @@ ignore = [
     "UP008", # UP008: Use `super()` instead of `super(__class__, self)`
     "UP015", # UP015: Unnecessary open mode parameters
 ]
+
+[tool.ruff.lint.flake8-comprehensions]
+# Our configurations use this all the time
+allow-dict-calls-with-keyword-arguments = true
 
 [tool.ruff.lint.flake8-copyright]
 author = "Thousand Brains Project"

--- a/src/tbp/monty/frameworks/config_utils/config_args.py
+++ b/src/tbp/monty/frameworks/config_utils/config_args.py
@@ -570,7 +570,7 @@ class SingleCameraMontyConfig(MontyConfig):
         default_factory=lambda: dict(
             learning_module_1=dict(
                 learning_module_class=LearningModuleBase,
-                learning_module_args=dict(),
+                learning_module_args={},
             )
         )
     )
@@ -601,11 +601,11 @@ class BaseMountMontyConfig(MontyConfig):
         default_factory=lambda: dict(
             learning_module_0=dict(
                 learning_module_class=LearningModuleBase,
-                learning_module_args=dict(),
+                learning_module_args={},
             ),
             learning_module_1=dict(
                 learning_module_class=LearningModuleBase,
-                learning_module_args=dict(),
+                learning_module_args={},
             ),
         )
     )

--- a/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
+++ b/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
@@ -112,7 +112,7 @@ class EnvInitArgsMontyWorldMultiObjectScenes:
 @dataclass
 class OmniglotDatasetArgs:
     env_init_func: Callable = field(default=OmniglotEnvironment)
-    env_init_args: Dict = field(default_factory=lambda: dict())
+    env_init_args: Dict = field(default_factory=lambda: {})
     transform: Union[Callable, list, None] = None
 
     def __post_init__(self):
@@ -143,7 +143,7 @@ class WorldImageDatasetArgs:
 @dataclass
 class WorldImageFromStreamDatasetArgs:
     env_init_func: Callable = field(default=SaccadeOnImageFromStreamEnvironment)
-    env_init_args: Dict = field(default_factory=lambda: dict())
+    env_init_args: Dict = field(default_factory=lambda: {})
     transform: Union[Callable, list, None] = None
 
     def __post_init__(self):
@@ -411,16 +411,11 @@ def get_omniglot_train_dataloader(num_versions, alphabet_ids, data_path=None):
     all_version_idx = []
     for a_idx in alphabet_ids:
         alphabet = alphabet_folders[a_idx]
-        characters_in_a = [
-            c for c in os.listdir(data_path + "images_background/" + alphabet)
-        ]
+        characters_in_a = list(os.listdir(data_path + "images_background/" + alphabet))
         for c_idx, character in enumerate(characters_in_a):
-            versions_of_char = [
-                v
-                for v in os.listdir(
+            versions_of_char = list(os.listdir(
                     data_path + "images_background/" + alphabet + "/" + character
-                )
-            ]
+                ))
             for v_idx in range(len(versions_of_char)):
                 if v_idx < num_versions:
                     all_alphabet_idx.append(a_idx)
@@ -466,17 +461,12 @@ def get_omniglot_eval_dataloader(
     all_version_idx = []
     for a_idx in alphabet_ids:
         alphabet = alphabet_folders[a_idx]
-        characters_in_a = [
-            c for c in os.listdir(data_path + "images_background/" + alphabet)
-        ]
+        characters_in_a = list(os.listdir(data_path + "images_background/" + alphabet))
         for c_idx, character in enumerate(characters_in_a):
             if num_versions is None:
-                versions_of_char = [
-                    v
-                    for v in os.listdir(
+                versions_of_char = list(os.listdir(
                         data_path + "images_background/" + alphabet + "/" + character
-                    )
-                ]
+                    ))
                 num_versions = len(versions_of_char) - start_at_version
 
             for v_idx in range(num_versions + start_at_version):
@@ -827,7 +817,7 @@ def make_sensor_positions_on_grid(
             angles = np.arctan2(i_mid - inds[:, 1], inds[:, 0] - i_mid)
             sorting_inds = np.argsort(angles)
             inds = inds[sorting_inds]
-            indices.extend([row for row in inds])
+            indices.extend(list(inds))
 
     elif order_by == "spiral":
         indices = [(i_mid, i_mid)]

--- a/src/tbp/monty/frameworks/experiments/profile.py
+++ b/src/tbp/monty/frameworks/experiments/profile.py
@@ -64,7 +64,7 @@ class ProfileExperimentMixin:
         super().__init_subclass__(**kwargs)
         if cls.__bases__[0] is not ProfileExperimentMixin:
             raise TypeError("ProfileExperimentMixin must be leftmost base class.")
-        if not any([issubclass(b, MontyExperiment) for b in cls.__bases__]):
+        if not any(issubclass(b, MontyExperiment) for b in cls.__bases__):
             raise TypeError("ProfileExperimentMixin must be mixed in with a subclass "
                             "of MontyExperiment.")
 

--- a/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
+++ b/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
@@ -61,18 +61,18 @@ class BasicGraphMatchingLogger(BaseMontyLogger):
         self.handlers = handlers
         self.data = dict(
             BASIC=dict(
-                train_stats=dict(),
-                train_overall_stats=dict(),
-                train_targets=dict(),
-                train_actions=dict(),
-                train_timing=dict(),
-                eval_stats=dict(),
-                eval_overall_stats=dict(),
-                eval_actions=dict(),
-                eval_targets=dict(),
-                eval_timing=dict(),
+                train_stats={},
+                train_overall_stats={},
+                train_targets={},
+                train_actions={},
+                train_timing={},
+                eval_stats={},
+                eval_overall_stats={},
+                eval_actions={},
+                eval_targets={},
+                eval_timing={},
             ),
-            DETAILED=dict(),
+            DETAILED={},
         )
         self.overall_train_stats = dict(
             num_episodes=0,
@@ -156,18 +156,18 @@ class BasicGraphMatchingLogger(BaseMontyLogger):
     def flush(self):
         self.data = dict(
             BASIC=dict(
-                train_stats=dict(),
-                train_overall_stats=dict(),
-                train_targets=dict(),
-                train_actions=dict(),
-                train_timing=dict(),
-                eval_stats=dict(),
-                eval_overall_stats=dict(),
-                eval_actions=dict(),
-                eval_targets=dict(),
-                eval_timing=dict(),
+                train_stats={},
+                train_overall_stats={},
+                train_targets={},
+                train_actions={},
+                train_timing={},
+                eval_stats={},
+                eval_overall_stats={},
+                eval_actions={},
+                eval_targets={},
+                eval_timing={},
             ),
-            DETAILED=dict(),
+            DETAILED={},
         )
 
     def log_episode(self, logger_args, output_dir, model):
@@ -446,8 +446,8 @@ class DetailedGraphMatchingLogger(BasicGraphMatchingLogger):
         """Initialize stats dicts."""
         super().__init__(handlers)
 
-        self.train_episodes_to_total = dict()
-        self.eval_episodes_to_total = dict()
+        self.train_episodes_to_total = {}
+        self.eval_episodes_to_total = {}
 
     def log_episode(self, logger_args, output_dir, model):
         mode = model.experiment_mode
@@ -481,9 +481,9 @@ class DetailedGraphMatchingLogger(BasicGraphMatchingLogger):
         self.train_episodes_to_total[logger_args["train_episodes"]] = episodes
         self.eval_episodes_to_total[logger_args["eval_episodes"]] = episodes
 
-        buffer_data = dict()
+        buffer_data = {}
         for i, lm in enumerate(model.learning_modules):
-            lm_dict = dict()
+            lm_dict = {}
             lm_dict.update(logger_args)
             lm_dict.update({"locations": lm.buffer.locations})
             lm_dict.update(lm.buffer.features)
@@ -498,7 +498,7 @@ class DetailedGraphMatchingLogger(BasicGraphMatchingLogger):
                 buffer_data[f"SM_{i}"] = sm.state_dict()
 
         # TODO ensure will work with multiple, independent sensor agents
-        buffer_data["motor_system"] = dict()
+        buffer_data["motor_system"] = {}
         buffer_data["motor_system"]["action_sequence"] = (
             model.motor_system._policy.action_sequence
         )
@@ -526,8 +526,8 @@ class SelectiveEvidenceLogger(BasicGraphMatchingLogger):
         """Initialize stats dicts."""
         super().__init__(handlers)
 
-        self.train_episodes_to_total = dict()
-        self.eval_episodes_to_total = dict()
+        self.train_episodes_to_total = {}
+        self.eval_episodes_to_total = {}
 
     def log_episode(self, logger_args, output_dir, model):
         mode = model.experiment_mode
@@ -555,9 +555,9 @@ class SelectiveEvidenceLogger(BasicGraphMatchingLogger):
         self.train_episodes_to_total[logger_args["train_episodes"]] = episodes
         self.eval_episodes_to_total[logger_args["eval_episodes"]] = episodes
 
-        buffer_data = dict()
+        buffer_data = {}
         for i, lm in enumerate(model.learning_modules):
-            lm_dict = dict()
+            lm_dict = {}
             lm_dict.update(
                 {
                     # Save evidences and hypotheses only for last step to save storage

--- a/src/tbp/monty/frameworks/loggers/monty_handlers.py
+++ b/src/tbp/monty/frameworks/loggers/monty_handlers.py
@@ -66,7 +66,7 @@ class DetailedJSONHandler(MontyHandler):
         Changed name to report episode since we are currently running with
         reporting and flushing exactly once per episode.
         """
-        output_data = dict()
+        output_data = {}
         if mode == "train":
             total = kwargs["train_episodes_to_total"][episode]
             stats = data["BASIC"]["train_stats"][episode]
@@ -105,14 +105,14 @@ class BasicCSVStatsHandler(MontyHandler):
         We only want to include the header the first time we write to a file. This
         keeps track of writes per file so we can format the file properly.
         """
-        self.reports_per_file = dict()
+        self.reports_per_file = {}
 
     def report_episode(self, data, output_dir, episode, mode="train", **kwargs):
         # Look for train_stats or eval_stats under BASIC logs
         basic_logs = data["BASIC"]
         mode_key = f"{mode}_stats"
         output_file = os.path.join(output_dir, f"{mode}_stats.csv")
-        stats = basic_logs.get(mode_key, dict())
+        stats = basic_logs.get(mode_key, {})
         logging.debug(pformat(stats))
 
         # Remove file if it existed before to avoid appending to previous results file

--- a/src/tbp/monty/frameworks/loggers/wandb_handlers.py
+++ b/src/tbp/monty/frameworks/loggers/wandb_handlers.py
@@ -60,7 +60,7 @@ class WandbWrapper(MontyHandler):
         for handler in self.wandb_handlers:
             handler.report_episode(data, output_dir, episode, mode=mode, **kwargs)
 
-        wandb.log(dict())  # TODO: What is this for?
+        wandb.log({})  # TODO: What is this for?
 
     @classmethod
     def log_level(cls):
@@ -119,14 +119,14 @@ class BasicWandbTableStatsHandler(WandbHandler):
         basic_logs = data["BASIC"]
         mode_key = f"{mode}_stats"
         stats_table = f"{mode}_stats_table"
-        stats = basic_logs.get(mode_key, dict())
+        stats = basic_logs.get(mode_key, {})
 
         # if len(stats) > 0:
         df = lm_stats_to_dataframe(stats, format_for_wandb=True)
 
         # Filter df to only include columns without variable length entries, like
         # possible_object_poses
-        const_columns = list(set(list(df.columns)) - set(self.variable_length_columns))
+        const_columns = list(set(df.columns) - set(self.variable_length_columns))
         const_df = df[const_columns]
 
         # shorthand for self.train_table = df or self.eval_table = df
@@ -163,7 +163,7 @@ class DetailedWandbTableStatsHandler(BasicWandbTableStatsHandler):
         basic_logs = data["BASIC"]
         # Get actions depending on mode (train or eval)
         action_key = f"{mode}_actions"
-        action_data = basic_logs.get(action_key, dict())
+        action_data = basic_logs.get(action_key, {})
 
         assert len(action_data) == 1, "why do we have keys for multiple or no episodes"
         # Log one table of actions per episode
@@ -202,7 +202,7 @@ class BasicWandbChartStatsHandler(WandbHandler):
     def report_episode(self, data, output_dir, episode, mode="train", **kwargs):
         basic_logs = data["BASIC"]
         mode_key = f"{mode}_overall_stats"
-        stats = basic_logs.get(mode_key, dict())
+        stats = basic_logs.get(mode_key, {})
         wandb.log(stats[episode], step=episode, commit=False)
 
     def get_safe_columns_per_lm(self, stats):
@@ -214,7 +214,7 @@ class BasicWandbChartStatsHandler(WandbHandler):
         Returns:
             The formatted stats.
         """
-        safe_stats = dict()
+        safe_stats = {}
         for lm, lm_dict in stats.items():
             safe_lm_dict = {
                 lm_col: lm_val
@@ -238,7 +238,7 @@ class DetailedWandbHandler(WandbHandler):
         self.report_key = "raw_rgba"
 
     def get_episode_frames(self, episode_stats):
-        frames_per_sm = dict()
+        frames_per_sm = {}
         sm_ids = [sm for sm in episode_stats.keys() if sm.startswith("SM_")]
         for sm in sm_ids:
             observations = episode_stats[sm]["raw_observations"]

--- a/src/tbp/monty/frameworks/models/buffer.py
+++ b/src/tbp/monty/frameworks/models/buffer.py
@@ -50,12 +50,12 @@ class FeatureAtLocationBuffer(BaseBuffer):
 
     def __init__(self):
         """Initialize buffer dicts for locations, features, displacements and stats."""
-        self.locations = dict()
-        self.features = dict()
+        self.locations = {}
+        self.features = {}
         self.on_object = []
         self.input_states = []
 
-        self.displacements = dict()
+        self.displacements = {}
 
         self.stats = {
             "detected_path": None,
@@ -91,7 +91,7 @@ class FeatureAtLocationBuffer(BaseBuffer):
         Returns:
             The features observed at time step idx.
         """
-        features_at_idx = dict()
+        features_at_idx = {}
         for input_channel in self.features.keys():
             features_at_idx[input_channel] = {
                 attribute: self.features[input_channel][attribute][idx]
@@ -121,7 +121,7 @@ class FeatureAtLocationBuffer(BaseBuffer):
             input_channel = state.sender_id
             self._add_loc_to_location_buffer(input_channel, state.location)
             if input_channel not in self.features.keys():
-                self.features[input_channel] = dict()
+                self.features[input_channel] = {}
             for attr in state.morphological_features.keys():
                 attr_val = state.morphological_features[attr]
                 self._add_attr_to_feature_buffer(input_channel, attr, attr_val)
@@ -295,7 +295,7 @@ class FeatureAtLocationBuffer(BaseBuffer):
             The current displacement.
         """
         if input_channel == "all" or input_channel is None:
-            all_disps = dict()
+            all_disps = {}
             for input_channel in self.displacements.keys():
                 all_disps[input_channel] = self.get_current_displacement(input_channel)
             return all_disps
@@ -344,7 +344,7 @@ class FeatureAtLocationBuffer(BaseBuffer):
         Returns:
             All observed features that were on the object.
         """
-        all_features_on_object = dict()
+        all_features_on_object = {}
         # Number of steps where at least one input was on the object
         global_on_object_ids = np.where(self.on_object)[0]
         logging.debug(
@@ -362,7 +362,7 @@ class FeatureAtLocationBuffer(BaseBuffer):
                 "on object observations"
             )
 
-            channel_features_on_object = dict()
+            channel_features_on_object = {}
             for feature in self.features[input_channel].keys():
                 # Pad end of array with 0s if last steps of episode were off object
                 # for this channel
@@ -544,7 +544,7 @@ class FeatureAtLocationBuffer(BaseBuffer):
             disp_val: Value of the displacement.
         """
         if input_channel not in self.displacements.keys():
-            self.displacements[input_channel] = dict()
+            self.displacements[input_channel] = {}
         if disp_name not in self.displacements[input_channel].keys():
             self.displacements[input_channel][disp_name] = (
                 np.empty((len(self.locations), len(disp_val))) * np.nan

--- a/src/tbp/monty/frameworks/models/displacement_matching.py
+++ b/src/tbp/monty/frameworks/models/displacement_matching.py
@@ -537,7 +537,7 @@ class DisplacementGraphMemory(GraphMemory):
         if self.match_attribute == "PPF":
             model.add_ppf_to_graph()
         if graph_id not in self.models_in_memory:
-            self.models_in_memory[graph_id] = dict()
+            self.models_in_memory[graph_id] = {}
         self.models_in_memory[graph_id][input_channel] = model
         logging.info(f"Added new graph with id {graph_id} to memory.")
 

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -86,7 +86,7 @@ class MontyForEvidenceGraphMatching(MontyForGraphMatching):
         """
         combined_votes = []
         for i in range(len(self.learning_modules)):
-            lm_state_votes = dict()
+            lm_state_votes = {}
             if votes_per_lm[i] is not None:
                 receiving_lm_pose = votes_per_lm[i]["sensed_pose_rel_body"]
                 for j in self.lm_to_lm_vote_matrix[i]:
@@ -294,7 +294,7 @@ class EvidenceGraphLM(GraphLM):
             num_model_voxels_per_dim=num_model_voxels_per_dim,
         )
         if gsg_args is None:
-            gsg_args = dict()
+            gsg_args = {}
         self.gsg = gsg_class(self, **gsg_args)
         self.gsg.reset()
         # --- Matching Params ---
@@ -459,7 +459,7 @@ class EvidenceGraphLM(GraphLM):
             # Get pose of first sensor stored in buffer.
             sensed_pose = self.buffer.get_current_pose(input_channel="first")
 
-            possible_states = dict()
+            possible_states = {}
             evidences = get_scaled_evidences(self.get_all_evidences())
             for graph_id in evidences.keys():
                 interesting_hyp = np.where(
@@ -726,7 +726,7 @@ class EvidenceGraphLM(GraphLM):
         """
         poses = self.possible_poses.copy()
         if as_euler:
-            all_poses = dict()
+            all_poses = {}
             for obj in poses.keys():
                 euler_poses = []
                 for pose in poses[obj]:
@@ -1535,12 +1535,12 @@ class EvidenceGraphLM(GraphLM):
         """
         # TODO H: Make this based on object similarity
         # For now just taking sum of character ids in object name
-        id_feature = sum([ord(i) for i in object_id])
+        id_feature = sum(ord(i) for i in object_id)
         return id_feature
 
     # ------------------------ Helper --------------------------
     def _check_use_features_for_matching(self):
-        use_features = dict()
+        use_features = {}
         for input_channel in self.tolerances.keys():
             if input_channel not in self.feature_weights.keys():
                 use_features[input_channel] = False
@@ -1556,7 +1556,7 @@ class EvidenceGraphLM(GraphLM):
     def _fill_feature_weights_with_default(self, default):
         for input_channel in self.tolerances.keys():
             if input_channel not in self.feature_weights.keys():
-                self.feature_weights[input_channel] = dict()
+                self.feature_weights[input_channel] = {}
             for key in self.tolerances[input_channel].keys():
                 if key not in self.feature_weights[input_channel].keys():
                     if hasattr(self.tolerances[input_channel][key], "shape"):
@@ -1864,7 +1864,7 @@ class EvidenceGraphMemory(GraphMemory):
             graph_id: id of graph that should be added
 
         """
-        self.models_in_memory[graph_id] = dict()
+        self.models_in_memory[graph_id] = {}
         for input_channel in model.keys():
             channel_model = model[input_channel]
             try:
@@ -1919,7 +1919,7 @@ class EvidenceGraphMemory(GraphMemory):
             model.build_model(locations=locations, features=features)
 
             if graph_id not in self.models_in_memory:
-                self.models_in_memory[graph_id] = dict()
+                self.models_in_memory[graph_id] = {}
             self.models_in_memory[graph_id][input_channel] = model
 
             logging.info(f"Added new graph with id {graph_id} to memory.")

--- a/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
@@ -643,7 +643,7 @@ class EvidenceSDRLMMixin:
         Returns:
             A dictionary indicating whether to use features for each input channel.
         """
-        use_features = dict()
+        use_features = {}
         for input_channel in self.tolerances.keys():
             if input_channel not in self.feature_weights.keys():
                 use_features[input_channel] = False

--- a/src/tbp/monty/frameworks/models/feature_location_matching.py
+++ b/src/tbp/monty/frameworks/models/feature_location_matching.py
@@ -118,7 +118,7 @@ class FeatureGraphLM(GraphLM):
         """
         possible_matches = self.get_possible_matches()
         all_objects = self.get_all_known_object_ids()
-        object_id_vote = dict()
+        object_id_vote = {}
         for obj in all_objects:
             object_id_vote[obj] = obj in possible_matches
         logging.info(
@@ -341,7 +341,7 @@ class FeatureGraphLM(GraphLM):
         Args:
             query: current features at location.
         """
-        consistent_objects = dict()
+        consistent_objects = {}
         for graph_id in self.possible_matches:
             consistent = self._update_matches_using_features(
                 query[0], query[1], graph_id

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -184,15 +184,15 @@ class MontyForGraphMatching(MontyBase):
 
     # ------------------ Logging & Saving ----------------------
     def load_state_dict_from_parallel(self, parallel_dirs, save=False):
-        lm_dict = dict()
+        lm_dict = {}
         for pdir in parallel_dirs:
             state_dict = torch.load(os.path.join(pdir, "model.pt"))
             for lm in state_dict["lm_dict"].keys():
                 if lm not in lm_dict:
                     lm_dict[lm] = dict(
-                        graph_memory=dict(),
-                        target_to_graph_id=dict(),
-                        graph_id_to_target=dict(),
+                        graph_memory={},
+                        target_to_graph_id={},
+                        graph_id_to_target={},
                     )
 
                 lm_dict[lm]["graph_memory"].update(
@@ -318,10 +318,10 @@ class MontyForGraphMatching(MontyBase):
                     else:
                         vote = vote.union(set(votes_per_lm[j]))
             else:
-                neg_object_id_votes = dict()
-                pos_object_id_votes = dict()
-                lm_object_location_votes = dict()
-                lm_object_rotation_votes = dict()
+                neg_object_id_votes = {}
+                pos_object_id_votes = {}
+                lm_object_location_votes = {}
+                lm_object_rotation_votes = {}
                 receiving_lm_pose = votes_per_lm[i]["sensed_pose_rel_body"]
                 for j in self.lm_to_lm_vote_matrix[i]:
                     lm_object_id_vote = votes_per_lm[j]["object_id_vote"]
@@ -600,8 +600,8 @@ class GraphLM(LearningModule):
         self.mode = None  # initialize to neither training nor testing
         # Dictionaries to tell which objects were involved in building a graph
         # and which graphs correspond to each target object
-        self.target_to_graph_id = dict()
-        self.graph_id_to_target = dict()
+        self.target_to_graph_id = {}
+        self.graph_id_to_target = {}
         self.primary_target = None
         self.detected_object = None
         self.detected_pose = [None for _ in range(7)]
@@ -819,7 +819,7 @@ class GraphLM(LearningModule):
 
     def get_possible_locations(self):
         possible_paths = self.get_possible_paths()
-        possible_locations = dict()
+        possible_locations = {}
         for obj in possible_paths.keys():
             possible_paths_obj = np.array(possible_paths[obj])
             if len(possible_paths_obj.shape) > 1:
@@ -848,7 +848,7 @@ class GraphLM(LearningModule):
         """
         poses = self.possible_poses.copy()
         if as_euler:
-            all_poses = dict()
+            all_poses = {}
             for obj in poses.keys():
                 euler_poses = []
                 for path in poses[obj]:
@@ -1029,12 +1029,12 @@ class GraphLM(LearningModule):
         """Update dicts that keep track which graphs were built from which objects."""
         if detected_object is not None:
             if detected_object not in self.graph_id_to_target.keys():
-                self.graph_id_to_target[detected_object] = set([target_object])
+                self.graph_id_to_target[detected_object] = {target_object}
             else:
                 self.graph_id_to_target[detected_object].add(target_object)
 
             if target_object not in self.target_to_graph_id.keys():
-                self.target_to_graph_id[target_object] = set([detected_object])
+                self.target_to_graph_id[target_object] = {detected_object}
             else:
                 self.target_to_graph_id[target_object].add(detected_object)
 
@@ -1074,10 +1074,10 @@ class GraphLM(LearningModule):
         Returns:
             Features to use.
         """
-        features_to_use = dict()
+        features_to_use = {}
         for state in states:
             input_channel = state.sender_id
-            features_to_use[input_channel] = dict()
+            features_to_use[input_channel] = {}
             for feature in state.morphological_features.keys():
                 # in evidence matching pose_vectors are always added to tolerances
                 # since they are requires for matching.
@@ -1298,10 +1298,8 @@ class GraphMemory(LMMemory):
             return self.models_in_memory[graph_id][input_channel].x.shape[0]
         else:
             return sum(
-                [
-                    self.get_num_nodes_in_graph(graph_id, input_channel)
+                self.get_num_nodes_in_graph(graph_id, input_channel)
                     for input_channel in self.get_input_channels_in_graph(graph_id)
-                ]
             )
 
     def get_features_at_node(self, graph_id, input_channel, node_id, feature_keys=None):
@@ -1397,7 +1395,7 @@ class GraphMemory(LMMemory):
             graph_delta_thresholds=graph_delta_thresholds,
         )
         if graph_id not in self.models_in_memory:
-            self.models_in_memory[graph_id] = dict()
+            self.models_in_memory[graph_id] = {}
         self.models_in_memory[graph_id][input_channel] = model
 
         logging.info(f"Added new graph with id {graph_id} to memory.")

--- a/src/tbp/monty/frameworks/models/mixins/no_reset_evidence.py
+++ b/src/tbp/monty/frameworks/models/mixins/no_reset_evidence.py
@@ -38,7 +38,7 @@ class TheoreticalLimitLMLoggingMixin:
             TypeError: If the mixin is used with a non-compatible learning module.
         """
         super().__init_subclass__(**kwargs)
-        if not any([issubclass(b, (EvidenceGraphLM)) for b in cls.__bases__]):
+        if not any(issubclass(b, (EvidenceGraphLM)) for b in cls.__bases__):
             raise TypeError(
                 "TheoreticalLimitLMLoggingMixin must be mixed in with a subclass of "
                 f"EvidenceGraphLM, got {cls.__bases__}"

--- a/src/tbp/monty/frameworks/models/motor_system_state.py
+++ b/src/tbp/monty/frameworks/models/motor_system_state.py
@@ -65,32 +65,31 @@ class MotorSystemState(Dict[str, Any]):
         Returns:
             (dict): Copy of the motor state.
         """
-        state_copy = dict()
+        state_copy = {}
         for key in self.keys():
-            state_copy[key] = dict()
+            state_copy[key] = {}
             for key_inner in self[key].keys():
                 if type(self[key][key_inner]) is dict:
-                    state_copy[key][key_inner] = dict()
+                    state_copy[key][key_inner] = {}
                     # We need to go deeper
                     for key_inner_inner in self[key][key_inner].keys():
-                        state_copy[key][key_inner][key_inner_inner] = dict()
+                        state_copy[key][key_inner][key_inner_inner] = {}
                         if type(self[key][key_inner][key_inner_inner]) is dict:
                             # We need to go even deeper...
                             # (**Hans Zimmer music intensifies**)
                             for key_i_i_i in self[key][key_inner][key_inner_inner]:
                                 state_copy[key][key_inner][key_inner_inner][
                                     key_i_i_i
-                                ] = dict()
+                                ] = {}
                                 try:
                                     state_copy[key][key_inner][key_inner_inner][
                                         key_i_i_i
                                     ] = np.array(
-                                        [
-                                            x
-                                            for x in self[key][key_inner][
-                                                key_inner_inner
-                                            ][key_i_i_i]
-                                        ]
+                                        list(
+                                            self[key][key_inner][key_inner_inner][
+                                                key_i_i_i
+                                            ]
+                                        )
                                     )
                                 except TypeError:
                                     # Quaternions
@@ -100,22 +99,21 @@ class MotorSystemState(Dict[str, Any]):
                                         self[key][key_inner][key_inner_inner][
                                             key_i_i_i
                                         ].real
-                                    ] + [
-                                        x
-                                        for x in self[key][key_inner][key_inner_inner][
+                                    ] + list(
+                                        self[key][key_inner][key_inner_inner][
                                             key_i_i_i
                                         ].imag
-                                    ]
+                                    )
                 elif type(self[key][key_inner]) is bool:
                     pass
                 else:
                     try:
                         state_copy[key][key_inner] = np.array(
-                            [x for x in self[key][key_inner]]
+                            list(self[key][key_inner])
                         )
                     except TypeError:
                         # Quaternions
-                        state_copy[key][key_inner] = [self[key][key_inner].real] + [
-                            x for x in self[key][key_inner].imag
-                        ]
+                        state_copy[key][key_inner] = [self[key][key_inner].real] + list(
+                            self[key][key_inner].imag
+                        )
         return state_copy

--- a/src/tbp/monty/frameworks/models/object_model.py
+++ b/src/tbp/monty/frameworks/models/object_model.py
@@ -188,7 +188,7 @@ class GraphObjectModel(ObjectModel):
         old_points = self.pos
         feature_mapping = self.feature_mapping
 
-        all_features = dict()
+        all_features = {}
 
         # Iterate through the different feature types, stacking on (i.e. appending)
         # those features associated w/ candidate new points to the old-graph point
@@ -258,7 +258,7 @@ class GraphObjectModel(ObjectModel):
         )
         num_nodes = locations_reduced.shape[0]
         node_features = np.linspace(0, num_nodes - 1, num_nodes).reshape((num_nodes, 1))
-        feature_mapping = dict()
+        feature_mapping = {}
         feature_mapping["node_ids"] = [0, 1]
 
         for feature_id in features.keys():
@@ -705,7 +705,7 @@ class GridObjectModel(GraphObjectModel):
             feature_mapping: Dictionary with feature names as keys and their
                 corresponding indices in feature_array as values.
         """
-        feature_mapping = dict()
+        feature_mapping = {}
         feature_array = None
         for feature in feature_dict.keys():
             feats = feature_dict[feature]

--- a/src/tbp/monty/frameworks/models/sensor_modules.py
+++ b/src/tbp/monty/frameworks/models/sensor_modules.py
@@ -238,7 +238,7 @@ class DetailedLoggingSM(SensorModuleBase):
         half_obs_dim = obs_dim // 2
         center_id = half_obs_dim + obs_dim * half_obs_dim
         # Extract all specified features
-        features = dict()
+        features = {}
         if "object_coverage" in self.features:
             # Last dimension is semantic ID (integer >0 if on any object)
             features["object_coverage"] = sum(obs_3d[:, 3] > 0) / len(obs_3d[:, 3])
@@ -265,7 +265,7 @@ class DetailedLoggingSM(SensorModuleBase):
             )
         else:
             invalid_signals = True
-            morphological_features = dict()
+            morphological_features = {}
 
         obs_3d_center = obs_3d[center_id]
         x, y, z, semantic_id = obs_3d_center

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -87,7 +87,7 @@ def get_episode_stats(exp, mode):
 
 
 def get_overall_stats(stats):
-    overall_stats = dict()
+    overall_stats = {}
     # combines correct and correct_mlh
     overall_stats["overall/percent_correct"] = np.mean(stats["episode/correct"]) * 100
     overall_stats["overall/percent_confused"] = np.mean(stats["episode/confused"]) * 100
@@ -129,7 +129,7 @@ def get_overall_stats(stats):
 
 
 def sample_params_to_init_args(params):
-    new_params = dict()
+    new_params = {}
     new_params["positions"] = [params["position"]]
     new_params["scales"] = [params["scale"]]
     new_params["rotations"] = [params["euler_rotation"]]
@@ -361,7 +361,7 @@ def run_episodes_parallel(
                 p.map(single_train, configs)
             else:
                 if configs[0]["logging_config"]["log_parallel_wandb"]:
-                    all_episode_stats = dict()
+                    all_episode_stats = {}
                     for result in p.imap(single_evaluate, configs):
                         run.log(result)
                         if not all_episode_stats:  # first episode

--- a/src/tbp/monty/frameworks/utils/dataclass_utils.py
+++ b/src/tbp/monty/frameworks/utils/dataclass_utils.py
@@ -171,7 +171,7 @@ def config_to_dict(config):
 def get_subset_of_args(arguments, function):
     dict_args = config_to_dict(arguments)
     _fields = extract_fields(function)
-    common_fields = dict()
+    common_fields = {}
     for field in _fields:
         field_name = field[0]
         if field_name in dict_args:

--- a/src/tbp/monty/frameworks/utils/follow_up_configs.py
+++ b/src/tbp/monty/frameworks/utils/follow_up_configs.py
@@ -196,7 +196,7 @@ def create_eval_config_multiple_episodes(
     # Accumulate episode-specific data: actions and object params
     ###
 
-    file_names_per_episode = dict()
+    file_names_per_episode = {}
     target_objects = []
     target_positions = []
     target_rotations = []

--- a/src/tbp/monty/frameworks/utils/logging_utils.py
+++ b/src/tbp/monty/frameworks/utils/logging_utils.py
@@ -115,7 +115,7 @@ def deserialize_json_chunks(json_file, start=0, stop=None, episodes=None):
         else:
             return (counter >= start) and (counter < stop)
 
-    detailed_json = dict()
+    detailed_json = {}
     stop = stop or np.inf
     with open(json_file, "r") as f:
         line_counter = 0
@@ -169,7 +169,7 @@ def matches_to_target_str(possible_matches, graph_to_target):
         targets = graph_to_target[match]
         possible_match_sources.update(targets)
 
-    sorted_targets = sorted(list(possible_match_sources))
+    sorted_targets = sorted(possible_match_sources)
     str_targets = "-".join(sorted_targets)
     return dict(possible_match_sources=str_targets)
 
@@ -726,7 +726,7 @@ def get_stats_per_lm(model, target):
     Returns:
         performance_dict: dict with stats per lm
     """
-    performance_dict = dict()
+    performance_dict = {}
     primary_target_dict = target_data_to_dict(target)
     for i, lm in enumerate(model.learning_modules):
         lm_stats = get_graph_lm_episode_stats(lm)
@@ -814,7 +814,7 @@ def target_data_to_dict(target):
     Returns:
         output_dict: dict with target params
     """
-    output_dict = dict()
+    output_dict = {}
     output_dict["primary_target_object"] = target["object"]
     output_dict["primary_target_position"] = target["position"]
     output_dict["primary_target_rotation_euler"] = target["euler_rotation"]
@@ -867,7 +867,7 @@ def lm_stats_to_dataframe(stats, format_for_wandb=False):
     """
     df_list = []
     for episode in stats.values():
-        lm_dict = dict()
+        lm_dict = {}
         # Loop over things like LM_*, SM_*, motor_system and get only LM_*
         for key in episode.keys():
             if isinstance(key, str):

--- a/src/tbp/monty/frameworks/utils/object_model_utils.py
+++ b/src/tbp/monty/frameworks/utils/object_model_utils.py
@@ -39,7 +39,7 @@ def torch_graph_to_numpy(torch_graph):
     Returns:
         NumpyGraph.
     """
-    numpy_graph = dict()
+    numpy_graph = {}
     for key in list(torch_graph.keys):
         if isinstance(torch_graph[key], torch.Tensor):
             numpy_graph[key] = np.array(torch_graph[key])

--- a/src/tbp/monty/simulators/habitat/simulator.py
+++ b/src/tbp/monty/simulators/habitat/simulator.py
@@ -107,7 +107,7 @@ class HabitatSim(HabitatActuator):
         agent_configs = []
         self._agents = agents
         self._action_space = set()
-        self._agent_id_to_index = dict()
+        self._agent_id_to_index = {}
 
         self._object_counter = 0  # Track the number of objects added to an environment
 

--- a/tests/unit/base_config_test.py
+++ b/tests/unit/base_config_test.py
@@ -114,9 +114,9 @@ class BaseConfigTest(unittest.TestCase):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
         with MontyExperiment(base_config) as exp:
-            monty_module_sids = set(
-                [s.sensor_module_id for s in exp.model.sensor_modules]
-            )
+            monty_module_sids = {
+                s.sensor_module_id for s in exp.model.sensor_modules
+            }
 
             # Handle the training loop manually for this interim test
             max_count = 5

--- a/tests/unit/frameworks/actions/habitat/actuator_test.py
+++ b/tests/unit/frameworks/actions/habitat/actuator_test.py
@@ -75,7 +75,7 @@ class HabitatAcutatorTest(unittest.TestCase):
 @patch("tests.unit.frameworks.actions.habitat.actuator_test.FakeHabitat.get_agent")
 class HabitatActuatorsTest(unittest.TestCase):
     def setUp(self):
-        self.action_space = dict()
+        self.action_space = {}
         mock_agent_config = Mock(spec=AgentConfiguration)
         mock_agent_config.action_space = self.action_space
         self.mock_agent = Mock(spec=Agent)

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -598,7 +598,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
                                 0
                             ].buffer.get_nth_displacement(0, input_channel="first")
                         ),
-                        list([0, 0, 0]),
+                        [0, 0, 0],
                         "displacement at step 0 should be 0.",
                     )
                 self.assertEqual(

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -985,7 +985,7 @@ class PolicyTest(unittest.TestCase):
         )
 
         # Initialize motor-system state
-        motor_system._state = dict(agent_id_0=dict())
+        motor_system._state = dict(agent_id_0={})
         motor_system._state["agent_id_0"]["rotation"] = qt.quaternion(1, 0, 0, 0)
 
         # Step 1
@@ -1112,7 +1112,7 @@ class PolicyTest(unittest.TestCase):
         )
 
         # Initialize motor system state
-        motor_system._state = dict(agent_id_0=dict())
+        motor_system._state = dict(agent_id_0={})
         motor_system._state["agent_id_0"]["rotation"] = qt.quaternion(1, 0, 0, 0)
 
         # Step 1 : PC-guided information, but we haven't taken the minimum number of

--- a/tests/unit/resources/unit_test_utils.py
+++ b/tests/unit/resources/unit_test_utils.py
@@ -454,8 +454,8 @@ class BaseGraphTestCases:
 
         def check_possible_paths_or_poses(self, stats_1, stats_2, key):
             for paths1, paths2 in zip(stats_1[key], stats_2[key]):
-                possible_objects_1 = set(list(paths1.keys()))
-                possible_objects_2 = set(list(paths2.keys()))
+                possible_objects_1 = set(paths1.keys())
+                possible_objects_2 = set(paths2.keys())
                 self.assertEqual(possible_objects_1, possible_objects_2)
                 for obj in possible_objects_1:
                     # I refuse to go deeper


### PR DESCRIPTION
This change enables all of the comprehension lints but configures ruff to ignore `dict()` calls that have keyword arguments, because our configs use `dict()` all the time instead of dictionary literals.