### PR TITLE
refactor!: GetGoodView positioning procedure

### DIFF
--- a/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
+++ b/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
@@ -316,18 +316,22 @@ class EnvironmentDataLoaderPerObjectTrainArgs(EnvironmentDataloaderPerObjectArgs
     object_names: List = field(default_factory=lambda: DefaultTrainObjectList().objects)
     object_init_sampler: Callable = field(default_factory=DefaultObjectInitializer)
 
+
 @dataclass
 class InformedEnvironmentDataLoaderTrainArgs(EnvironmentDataLoaderPerObjectTrainArgs):
     use_get_good_view_positioning_procedure: bool = False
+
 
 @dataclass
 class EnvironmentDataLoaderPerObjectEvalArgs(EnvironmentDataloaderPerObjectArgs):
     object_names: List = field(default_factory=lambda: DefaultTrainObjectList().objects)
     object_init_sampler: Callable = field(default_factory=DefaultObjectInitializer)
 
+
 @dataclass
 class InformedEnvironmentDataLoaderEvalArgs(EnvironmentDataLoaderPerObjectEvalArgs):
     use_get_good_view_positioning_procedure: bool = False
+
 
 @dataclass
 class FixedRotationEnvironmentDataLoaderPerObjectTrainArgs(

--- a/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
+++ b/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
@@ -316,12 +316,18 @@ class EnvironmentDataLoaderPerObjectTrainArgs(EnvironmentDataloaderPerObjectArgs
     object_names: List = field(default_factory=lambda: DefaultTrainObjectList().objects)
     object_init_sampler: Callable = field(default_factory=DefaultObjectInitializer)
 
+@dataclass
+class InformedEnvironmentDataLoaderTrainArgs(EnvironmentDataLoaderPerObjectTrainArgs):
+    use_get_good_view_positioning_procedure: bool = False
 
 @dataclass
 class EnvironmentDataLoaderPerObjectEvalArgs(EnvironmentDataloaderPerObjectArgs):
     object_names: List = field(default_factory=lambda: DefaultTrainObjectList().objects)
     object_init_sampler: Callable = field(default_factory=DefaultObjectInitializer)
 
+@dataclass
+class InformedEnvironmentDataLoaderEvalArgs(EnvironmentDataLoaderPerObjectEvalArgs):
+    use_get_good_view_positioning_procedure: bool = False
 
 @dataclass
 class FixedRotationEnvironmentDataLoaderPerObjectTrainArgs(

--- a/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
+++ b/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
@@ -355,6 +355,13 @@ class EnvironmentDataloaderMultiObjectArgs:
     object_init_sampler: Callable
 
 
+@dataclass
+class InformedEnvironmentDataloaderMultiObjectArgs(
+    EnvironmentDataloaderMultiObjectArgs
+):
+    use_get_good_view_positioning_procedure: bool = False
+
+
 def get_object_names_by_idx(
     start, stop, list_of_indices=None, object_list=SHUFFLED_YCB_OBJECTS
 ):

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -650,6 +650,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
 
         Returns:
             Whether the sensor is on the object.
+
         """
         self.get_good_view("view_finder")
         for patch_id in ("patch", "patch_0"):

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -590,8 +590,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
 
             self.motor_system._policy = GetGoodView(
                 agent_id=self.motor_system._policy.agent_id,
-                desired_object_distance=0.03,
-                good_view_percentage=0.5,
+                desired_object_distance=_configured_policy.desired_object_distance,
+                good_view_percentage=_configured_policy.good_view_percentage,
                 multiple_objects_present=self.num_distractors > 0,
                 sensor_id=sensor_id,
                 target_semantic_id=self.primary_target["semantic_id"],
@@ -600,7 +600,14 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 # TODO: Remaining arguments are unused but required by BasePolicy.
                 #       These will be removed when PositioningProcedure is split from
                 #       BasePolicy
-                rng=self.rng,
+                #
+                # Note that if we use rng=self.rng below, then the following test will
+                # fail:
+                #   tests/unit/evidence_lm_test.py::EvidenceLMTest::test_two_lm_heterarchy_experiment  # noqa: E501
+                # The test result seems to be coupled to the random seed and the
+                # specific sequence of rng calls (rng is called once on GetGoodView
+                # initialization).
+                rng=np.random.RandomState(),
                 action_sampler_args=dict(actions=[LookUp]),
                 action_sampler_class=UniformlyDistributedSampler,
                 switch_frequency=0.0,

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -142,20 +142,14 @@ class EnvironmentDataLoader:
         self.dataset = dataset
         self.motor_system = motor_system
         self.rng = rng
-        self._observation, proprioceptive_state = self.dataset.reset()
-        self.motor_system._state = (
-            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
-        )
+        self._observation, self.motor_system._state = self.dataset.reset()
         self._action = None
         self._amount = None
         self._counter = 0
 
     def __iter__(self):
         # Reset the environment before iterating
-        self._observation, proprioceptive_state = self.dataset.reset()
-        self.motor_system._state = (
-            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
-        )
+        self._observation, self.motor_system._state = self.dataset.reset()
         self._action = None
         self._amount = None
         self._counter = 0
@@ -169,10 +163,7 @@ class EnvironmentDataLoader:
         else:
             action = self.motor_system()
             self._action = action
-            self._observation, proprioceptive_state = self.dataset[action]
-            self.motor_system._state = (
-                MotorSystemState(proprioceptive_state) if proprioceptive_state else None
-            )
+            self._observation, self.motor_system._state = self.dataset[action]
             self._counter += 1
             return self._observation
 
@@ -472,7 +463,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 self._action = self.motor_system._policy.touch_object(
                     self._observation,
                     view_sensor_id="view_finder",
-                    state=self.motor_system._policy.state,
+                    state=self.motor_system._state,
                 )
 
             self._observation, proprioceptive_state = self.dataset[self._action]
@@ -596,10 +587,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                     state=self.motor_system._state,
                 )
                 for action in actions:
-                    self._observation, proprio_state = self.dataset[action]
-                    self.motor_system._state = (
-                        MotorSystemState(proprio_state) if proprio_state else None
-                    )
+                    self._observation, self.motor_system._state = self.dataset[action]
 
         if allow_translation:
             # Move closer to the object, if not already close enough
@@ -612,10 +600,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             # Continue moving to a close distance to the object
             while not close_enough:
                 logging.debug("moving closer!")
-                self._observation, proprio_state = self.dataset[action]
-                self.motor_system._state = (
-                    MotorSystemState(proprio_state) if proprio_state else None
-                )
+                self._observation, self.motor_system._state = self.dataset[action]
                 action, close_enough = self.motor_system._policy.move_close_enough(
                     self._observation,
                     sensor_id,
@@ -639,10 +624,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 state=self.motor_system._state,
             )
             for action in actions:
-                self._observation, proprio_state = self.dataset[action]
-                self.motor_system._state = (
-                    MotorSystemState(proprio_state) if proprio_state else None
-                )
+                self._observation, self.motor_system._state = self.dataset[action]
             on_target_object = self.motor_system._policy.is_on_target_object(
                 self._observation,
                 sensor_id,
@@ -668,7 +650,6 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
 
         Returns:
             Whether the sensor is on the object.
-
         """
         self.get_good_view("view_finder")
         for patch_id in ("patch", "patch_0"):
@@ -735,10 +716,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             rotation_quat=quaternion.one,
         )
         _, _ = self.dataset[set_agent_pose]
-        self._observation, proprioceptive_state = self.dataset[set_sensor_rotation]
-        self.motor_system._state = (
-            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
-        )
+        self._observation, self.motor_system._state = self.dataset[set_sensor_rotation]
 
         # Check depth-at-center to see if the object is in front of us
         # As for methods such as touch_object, we use the view-finder
@@ -891,10 +869,7 @@ class OmniglotDataLoader(EnvironmentDataLoaderPerObject):
             )
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, proprioceptive_state = self.dataset.reset()
-        self.motor_system._state = (
-            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
-        )
+        self._observation, self.motor_system._state = self.dataset.reset()
         self._action = None
         self._amount = None
         self._counter = 0
@@ -983,10 +958,7 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
             )
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, proprioceptive_state = self.dataset.reset()
-        self.motor_system._state = (
-            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
-        )
+        self._observation, self.motor_system._state = self.dataset.reset()
         self._action = None
         self._amount = None
         self._counter = 0
@@ -1079,10 +1051,7 @@ class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):
         # TODO: call super init instead of duplication code & generally clean up more
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, proprioceptive_state = self.dataset.reset()
-        self.motor_system._state = (
-            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
-        )
+        self._observation, self.motor_system._state = self.dataset.reset()
         self._action = None
         self._amount = None
         self._counter = 0

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -48,8 +48,6 @@ __all__ = [
     "SaccadeOnImageFromStreamDataLoader",
 ]
 
-USE_GET_GOOD_VIEW_POSITIONING_PROCEDURE = True
-
 
 class EnvironmentDataset(Dataset):
     """Wraps an embodied environment with a :class:`torch.utils.data.Dataset`.
@@ -439,8 +437,18 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
     iv) Supports hypothesis-testing "jump" policy
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self, use_get_good_view_positioning_procedure: bool = False, *args, **kwargs
+    ):
         super(InformedEnvironmentDataLoader, self).__init__(*args, **kwargs)
+        self._use_get_good_view_positioning_procedure = (
+            use_get_good_view_positioning_procedure
+        )
+        """Feature flag to use the GetGoodView positioning procedure.
+
+        This is a temporary feature flag to allow for testing the GetGoodView
+        positioning procedure.
+        """
 
     def __iter__(self):
         # Overwrite original because we don't want to reset agent at this stage
@@ -585,7 +593,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         TODO M : move most of this to the motor systems, shouldn't be in embodied_data
             class
         """
-        if USE_GET_GOOD_VIEW_POSITIONING_PROCEDURE:
+        if self._use_get_good_view_positioning_procedure:
             _configured_policy = self.motor_system._policy
 
             self.motor_system._policy = GetGoodView(

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -472,7 +472,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 self._action = self.motor_system._policy.touch_object(
                     self._observation,
                     view_sensor_id="view_finder",
-                    state=self.motor_system._state,
+                    state=self.motor_system._policy.state,
                 )
 
             self._observation, proprioceptive_state = self.dataset[self._action]

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -143,7 +143,7 @@ class EnvironmentDataLoader:
         self.motor_system = motor_system
         self.rng = rng
         self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
         self._action = None
         self._amount = None
         self._counter = 0
@@ -151,7 +151,7 @@ class EnvironmentDataLoader:
     def __iter__(self):
         # Reset the environment before iterating
         self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
         self._action = None
         self._amount = None
         self._counter = 0
@@ -166,7 +166,7 @@ class EnvironmentDataLoader:
             action = self.motor_system()
             self._action = action
             self._observation, state = self.dataset[action]
-            self.motor_system._state = MotorSystemState(state)
+            self.motor_system._state = MotorSystemState(state) if state else None
             self._counter += 1
             return self._observation
 
@@ -591,7 +591,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 )
                 for action in actions:
                     self._observation, state = self.dataset[action]
-                    self.motor_system._state = MotorSystemState(state)
+                    self.motor_system._state = (
+                        MotorSystemState(state) if state else None
+                    )
 
         if allow_translation:
             # Move closer to the object, if not already close enough
@@ -605,7 +607,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             while not close_enough:
                 logging.debug("moving closer!")
                 self._observation, state = self.dataset[action]
-                self.motor_system._state = MotorSystemState(state)
+                self.motor_system._state = MotorSystemState(state) if state else None
                 action, close_enough = self.motor_system._policy.move_close_enough(
                     self._observation,
                     sensor_id,
@@ -630,7 +632,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             )
             for action in actions:
                 self._observation, state = self.dataset[action]
-                self.motor_system._state = MotorSystemState(state)
+                self.motor_system._state = MotorSystemState(state) if state else None
             on_target_object = self.motor_system._policy.is_on_target_object(
                 self._observation,
                 sensor_id,
@@ -724,7 +726,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         )
         _, _ = self.dataset[set_agent_pose]
         self._observation, state = self.dataset[set_sensor_rotation]
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
 
         # Check depth-at-center to see if the object is in front of us
         # As for methods such as touch_object, we use the view-finder
@@ -878,7 +880,7 @@ class OmniglotDataLoader(EnvironmentDataLoaderPerObject):
         self.dataset = dataset
         self.motor_system = motor_system
         self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
         self._action = None
         self._amount = None
         self._counter = 0
@@ -968,7 +970,7 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
         self.dataset = dataset
         self.motor_system = motor_system
         self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
         self._action = None
         self._amount = None
         self._counter = 0
@@ -1062,7 +1064,7 @@ class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):
         self.dataset = dataset
         self.motor_system = motor_system
         self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state)
+        self.motor_system._state = MotorSystemState(state) if state else None
         self._action = None
         self._amount = None
         self._counter = 0

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -142,16 +142,20 @@ class EnvironmentDataLoader:
         self.dataset = dataset
         self.motor_system = motor_system
         self.rng = rng
-        self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset.reset()
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
         self._action = None
         self._amount = None
         self._counter = 0
 
     def __iter__(self):
         # Reset the environment before iterating
-        self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset.reset()
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
         self._action = None
         self._amount = None
         self._counter = 0
@@ -165,8 +169,10 @@ class EnvironmentDataLoader:
         else:
             action = self.motor_system()
             self._action = action
-            self._observation, state = self.dataset[action]
-            self.motor_system._state = MotorSystemState(state) if state else None
+            self._observation, proprioceptive_state = self.dataset[action]
+            self.motor_system._state = (
+                MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+            )
             self._counter += 1
             return self._observation
 
@@ -590,9 +596,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                     state=self.motor_system._state,
                 )
                 for action in actions:
-                    self._observation, state = self.dataset[action]
+                    self._observation, proprio_state = self.dataset[action]
                     self.motor_system._state = (
-                        MotorSystemState(state) if state else None
+                        MotorSystemState(proprio_state) if proprio_state else None
                     )
 
         if allow_translation:
@@ -606,8 +612,10 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             # Continue moving to a close distance to the object
             while not close_enough:
                 logging.debug("moving closer!")
-                self._observation, state = self.dataset[action]
-                self.motor_system._state = MotorSystemState(state) if state else None
+                self._observation, proprio_state = self.dataset[action]
+                self.motor_system._state = (
+                    MotorSystemState(proprio_state) if proprio_state else None
+                )
                 action, close_enough = self.motor_system._policy.move_close_enough(
                     self._observation,
                     sensor_id,
@@ -631,8 +639,10 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 state=self.motor_system._state,
             )
             for action in actions:
-                self._observation, state = self.dataset[action]
-                self.motor_system._state = MotorSystemState(state) if state else None
+                self._observation, proprio_state = self.dataset[action]
+                self.motor_system._state = (
+                    MotorSystemState(proprio_state) if proprio_state else None
+                )
             on_target_object = self.motor_system._policy.is_on_target_object(
                 self._observation,
                 sensor_id,
@@ -725,8 +735,10 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             rotation_quat=quaternion.one,
         )
         _, _ = self.dataset[set_agent_pose]
-        self._observation, state = self.dataset[set_sensor_rotation]
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset[set_sensor_rotation]
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
 
         # Check depth-at-center to see if the object is in front of us
         # As for methods such as touch_object, we use the view-finder
@@ -879,8 +891,10 @@ class OmniglotDataLoader(EnvironmentDataLoaderPerObject):
             )
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset.reset()
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
         self._action = None
         self._amount = None
         self._counter = 0
@@ -969,8 +983,10 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
             )
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset.reset()
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
         self._action = None
         self._amount = None
         self._counter = 0
@@ -1063,8 +1079,10 @@ class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):
         # TODO: call super init instead of duplication code & generally clean up more
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, state = self.dataset.reset()
-        self.motor_system._state = MotorSystemState(state) if state else None
+        self._observation, proprioceptive_state = self.dataset.reset()
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
         self._action = None
         self._amount = None
         self._counter = 0

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -623,9 +623,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             )
             while not result.terminated and not result.truncated:
                 for action in result.actions:
-                    self._observation, state = self.dataset[action]
+                    self._observation, proprio_state = self.dataset[action]
                     self.motor_system._state = (
-                        MotorSystemState(state) if state else None
+                        MotorSystemState(proprio_state) if proprio_state else None
                     )
 
                 result = self.motor_system._policy.positioning_call(

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -142,14 +142,16 @@ class EnvironmentDataLoader:
         self.dataset = dataset
         self.motor_system = motor_system
         self.rng = rng
-        self._observation, self.motor_system._state = self.dataset.reset()
+        self._observation, state = self.dataset.reset()
+        self.motor_system._state = MotorSystemState(state)
         self._action = None
         self._amount = None
         self._counter = 0
 
     def __iter__(self):
         # Reset the environment before iterating
-        self._observation, self.motor_system._state = self.dataset.reset()
+        self._observation, state = self.dataset.reset()
+        self.motor_system._state = MotorSystemState(state)
         self._action = None
         self._amount = None
         self._counter = 0
@@ -163,7 +165,8 @@ class EnvironmentDataLoader:
         else:
             action = self.motor_system()
             self._action = action
-            self._observation, self.motor_system._state = self.dataset[action]
+            self._observation, state = self.dataset[action]
+            self.motor_system._state = MotorSystemState(state)
             self._counter += 1
             return self._observation
 
@@ -587,7 +590,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                     state=self.motor_system._state,
                 )
                 for action in actions:
-                    self._observation, self.motor_system._state = self.dataset[action]
+                    self._observation, state = self.dataset[action]
+                    self.motor_system._state = MotorSystemState(state)
 
         if allow_translation:
             # Move closer to the object, if not already close enough
@@ -600,7 +604,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             # Continue moving to a close distance to the object
             while not close_enough:
                 logging.debug("moving closer!")
-                self._observation, self.motor_system._state = self.dataset[action]
+                self._observation, state = self.dataset[action]
+                self.motor_system._state = MotorSystemState(state)
                 action, close_enough = self.motor_system._policy.move_close_enough(
                     self._observation,
                     sensor_id,
@@ -624,7 +629,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 state=self.motor_system._state,
             )
             for action in actions:
-                self._observation, self.motor_system._state = self.dataset[action]
+                self._observation, state = self.dataset[action]
+                self.motor_system._state = MotorSystemState(state)
             on_target_object = self.motor_system._policy.is_on_target_object(
                 self._observation,
                 sensor_id,
@@ -717,7 +723,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             rotation_quat=quaternion.one,
         )
         _, _ = self.dataset[set_agent_pose]
-        self._observation, self.motor_system._state = self.dataset[set_sensor_rotation]
+        self._observation, state = self.dataset[set_sensor_rotation]
+        self.motor_system._state = MotorSystemState(state)
 
         # Check depth-at-center to see if the object is in front of us
         # As for methods such as touch_object, we use the view-finder
@@ -870,7 +877,8 @@ class OmniglotDataLoader(EnvironmentDataLoaderPerObject):
             )
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, self.motor_system._state = self.dataset.reset()
+        self._observation, state = self.dataset.reset()
+        self.motor_system._state = MotorSystemState(state)
         self._action = None
         self._amount = None
         self._counter = 0
@@ -959,7 +967,8 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
             )
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, self.motor_system._state = self.dataset.reset()
+        self._observation, state = self.dataset.reset()
+        self.motor_system._state = MotorSystemState(state)
         self._action = None
         self._amount = None
         self._counter = 0
@@ -1052,7 +1061,8 @@ class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):
         # TODO: call super init instead of duplication code & generally clean up more
         self.dataset = dataset
         self.motor_system = motor_system
-        self._observation, self.motor_system._state = self.dataset.reset()
+        self._observation, state = self.dataset.reset()
+        self.motor_system._state = MotorSystemState(state)
         self._action = None
         self._amount = None
         self._counter = 0

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -465,8 +465,6 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
 
         # Check if any LM's have output a goal-state (such as hypothesis-testing
         # goal-state)
-
-
         elif (
             isinstance(self.motor_system._policy, InformedPolicy)
             and self.motor_system._policy.use_goal_state_driven_actions

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -248,7 +248,7 @@ class BasePolicy(MotorPolicy):
     # Other required abstract methods, methods called by Monty or Dataloader
     ###
 
-    def get_agent_state(self, state: MotorSystemState) -> AgentState:
+    def get_agent_state(self, state: MotorSystemState):
         """Get agent state (dict).
 
         Note:
@@ -1220,7 +1220,7 @@ class SurfacePolicy(InformedPolicy):
             action.distance = action.distance / 4
             logging.debug(f"Near edge so only moving by {action.distance}")
 
-        action.direction = self.tangential_direction(self.state)
+        action.direction = self.tangential_direction(state)
 
         return action
 

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -8,12 +8,15 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+from __future__ import annotations
+
 import abc
 import copy
 import json
 import logging
 import math
 import os
+from dataclasses import dataclass, field
 from typing import Dict, List, Literal, Mapping, Optional, Tuple, Type, Union, cast
 
 import numpy as np
@@ -351,6 +354,371 @@ class JumpToGoalStateMixin:
 
         else:
             return None, None
+
+
+@dataclass
+class PositioningProcedureResult:
+    """Result of a positioning procedure.
+
+    For more on the terminated/truncated terminology, see https://farama.org/Gymnasium-Terminated-Truncated-Step-API.
+    """
+
+    actions: List[Action] = field(default_factory=list)
+    """Actions to take."""
+    success: bool = False
+    """Whether the procedure succeeded in its positioning goal."""
+    terminated: bool = False
+    """Whether the procedure reached a terminal state with success or failure."""
+    truncated: bool = False
+    """Whether the procedure was truncated due to a limit on the number of attempts or
+    other criteria."""
+
+
+class PositioningProcedure(BasePolicy):
+    """Policy to position the agent in the scene.
+
+    TODO: Remove from MotorPolicy hierarchy and refactor to standalone
+          PositioningProcedure hierarchy when they get separated.
+    """
+
+    @abc.abstractmethod
+    def positioning_call(
+        self,
+        observation: Mapping,
+        state: Optional[MotorSystemState] = None,
+    ) -> PositioningProcedureResult:
+        """Return a list of actions to position the agent in the scene.
+
+        TODO: When this becomes a PositioningProcedure it can be a __call__ method.
+
+        Args:
+            observation (Optional[Mapping]): The observation to use for positioning.
+            state (Optional[MotorSystemState]): The current state of the motor system.
+
+        Returns:
+            (PositioningProcedureResult): Any actions to take, whether the procedure
+                succeeded, whether the procedure terminated, and whether the procedure
+                truncated.
+        """
+        pass
+
+
+class GetGoodView(PositioningProcedure):
+    """Positioning procedure to get a good view of the object before an episode."""
+
+    def __init__(
+        self,
+        desired_object_distance: float,
+        good_view_percentage: float,
+        multiple_objects_present: bool,
+        sensor_id: str,
+        target_semantic_id: int,
+        allow_translation: bool = True,
+        max_orientation_attempts: int = 1,
+        **kwargs,
+    ) -> None:
+        """Initialize the GetGoodView policy.
+
+        Args:
+            desired_object_distance (float): The desired distance to the object.
+            good_view_percentage (float): The percentage of the sensor that should be
+                filled with the object.
+            multiple_objects_present (bool): Whether there are multiple objects in
+                the scene.
+            sensor_id (str): The ID of the sensor to use for positioning.
+            target_semantic_id (int): The semantic ID of the target object.
+            allow_translation (bool): Whether to allow movement toward the object via
+                the motor systems's move_close_enough method. If False, only
+                orientienting movements are performed. Defaults to True.
+            max_orientation_attempts (int): The maximum number of orientation attempts
+                allowed before giving up and truncating the procedure indicating that
+                the sensor is not on the target object.
+            **kwargs: Additional keyword arguments.
+        """
+        super().__init__(**kwargs)
+        self._desired_object_distance = desired_object_distance
+        self._good_view_percentage = good_view_percentage
+        self._multiple_objects_present = multiple_objects_present
+        self._sensor_id = sensor_id
+        self._target_semantic_id = target_semantic_id
+        self._allow_translation = allow_translation
+        self._max_orientation_attempts = max_orientation_attempts
+
+        self._num_orientation_attempts = 0
+
+    def compute_look_amounts(
+        self, relative_location: np.ndarray, state: Optional[MotorSystemState] = None
+    ) -> Tuple[float, float]:
+        """Compute the amount to look down and left given a relative location.
+
+        This function computes the amount needed to look down and left in order
+        for the sensor to be aimed at the target. The returned amounts are relative
+        to the agent's current position and rotation.
+
+        TODO: Test whether this function works when the agent is facing in the
+        positive z-direction. It may be fine, but there were some adjustments to
+        accommodate the z-axis positive direction pointing opposite the body's initial
+        orientation (e.g., using negative  `z` in
+        `left_amount = -np.degrees(np.arctan2(x_rot, -z_rot)))`.
+
+        Args:
+            relative_location: the x,y,z coordinates of the target with respect
+            to the sensor.
+            state (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None.
+
+        Returns:
+            down_amount: Amount to look down (degrees).
+            left_amount: Amount to look left (degrees).
+        """
+        # Get the sensor's rotation relative to the world.
+        agent_state = self.get_agent_state(state)
+        # - The agent's rotation relative to the world.
+        agent_rotation = agent_state["rotation"]
+        # - The sensor's rotation relative to the agent.
+        sensor_rotation = agent_state["sensors"][f"{self._sensor_id}.depth"]["rotation"]
+        # - The sensor's rotation relative to the world.
+        sensor_rotation_rel_world = agent_rotation * sensor_rotation
+
+        # Invert the location to align it with sensor's rotation.
+        w, x, y, z = qt.as_float_array(sensor_rotation_rel_world)
+        rotation = rot.from_quat([x, y, z, w])
+        rotated_location = rotation.inv().apply(relative_location)
+
+        # Calculate the necessary rotation amounts.
+        x_rot, y_rot, z_rot = rotated_location
+        left_amount = -np.degrees(np.arctan2(x_rot, -z_rot))
+        distance_horiz = np.sqrt(x_rot**2 + z_rot**2)
+        down_amount = -np.degrees(np.arctan2(y_rot, distance_horiz))
+
+        return down_amount, left_amount
+
+    def find_location_to_look_at(
+        self,
+        sem3d_obs: np.ndarray,
+        image_shape: Tuple[int, int],
+        state: Optional[MotorSystemState] = None,
+    ) -> np.ndarray:
+        """Find the location to look at in the observation.
+
+        Takes in a semantic 3D observation and returns an x,y,z location.
+
+        The location is on the object and surrounded by pixels that are also on
+        the object. This is done by smoothing the on_object image and then
+        taking the maximum of this smoothed image.
+
+        Args:
+            sem3d_obs (np.ndarray): The location of each pixel and the semantic ID
+                associated with that location.
+            image_shape (Tuple[int, int]): The shape of the camera image.
+            state (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None.
+
+        Returns:
+            (np.ndarray): The x,y,z coordinates of the target with respect
+                to the sensor.
+        """
+        sem3d_obs_image = sem3d_obs.reshape((image_shape[0], image_shape[1], 4))
+        on_object_image = sem3d_obs_image[:, :, 3]
+
+        if not self._multiple_objects_present:
+            on_object_image[on_object_image > 0] = self._target_semantic_id
+
+        on_object_image = on_object_image == self._target_semantic_id
+        on_object_image = on_object_image.astype(float)
+
+        # TODO add unit test that we make sure find_location_to_look at functions
+        # as expected, which can otherwise break if e.g. on_object_image is passed
+        # as an int or boolean rather than float
+        kernel_size = on_object_image.shape[0] // 16
+        smoothed_on_object_image = scipy.ndimage.gaussian_filter(
+            on_object_image, kernel_size, mode="constant"
+        )
+        idx_loc_to_look_at = np.argmax(smoothed_on_object_image * on_object_image)
+        idx_loc_to_look_at = np.unravel_index(idx_loc_to_look_at, on_object_image.shape)
+        location_to_look_at = sem3d_obs_image[
+            idx_loc_to_look_at[0], idx_loc_to_look_at[1], :3
+        ]
+        camera_location = self.get_agent_state(state)["sensors"][
+            f"{self._sensor_id}.depth"
+        ]["position"]
+        agent_location = self.get_agent_state(state)["position"]
+        # Get the location of the object relative to sensor.
+        relative_location = location_to_look_at - (camera_location + agent_location)
+
+        return relative_location
+
+    def is_on_target_object(self, observation: Mapping) -> bool:
+        """Check if a sensor is on the target object.
+
+        Args:
+            observation (Mapping): The observation to use for positioning.
+
+        Returns:
+            bool: Whether the sensor is on the target object.
+        """
+        # Reconstruct the 2D semantic/surface map embedded in 'semantic_3d'.
+        image_shape = observation[self.agent_id][self._sensor_id]["depth"].shape[0:2]
+        semantic_3d = observation[self.agent_id][self._sensor_id]["semantic_3d"]
+        semantic = semantic_3d[:, 3].reshape(image_shape).astype(int)
+        if not self._multiple_objects_present:
+            semantic[semantic > 0] = self._target_semantic_id
+
+        # Check if the central pixel is on the target object.
+        y_mid, x_mid = image_shape[0] // 2, image_shape[1] // 2
+        on_target_object = semantic[y_mid, x_mid] == self._target_semantic_id
+        return on_target_object
+
+    def move_close_enough(self, observation: Mapping) -> Action | None:
+        """Move closer to the object until we are close enough.
+
+        Args:
+            observation (Mapping): The observation to use for positioning.
+
+        Returns:
+            (Action | None): The next action to take, or None if we are already close
+                enough to the object.
+
+        Raises:
+            ValueError: If the object is not visible.
+        """
+        # Reconstruct 2D semantic map.
+        depth_image = observation[self.agent_id][self._sensor_id]["depth"]
+        semantic_3d = observation[self.agent_id][self._sensor_id]["semantic_3d"]
+        semantic_image = semantic_3d[:, 3].reshape(depth_image.shape).astype(int)
+
+        if not self._multiple_objects_present:
+            semantic_image[semantic_image > 0] = self._target_semantic_id
+
+        points_on_target_obj = semantic_image == self._target_semantic_id
+        n_points_on_target_obj = points_on_target_obj.sum()
+
+        # For multi-object experiments, handle the possibility that object is no
+        # longer visible.
+        if self._multiple_objects_present and n_points_on_target_obj == 0:
+            logging.debug("Object not visible, cannot move closer")
+            return None
+
+        if n_points_on_target_obj > 0:
+            closest_point_on_target_obj = np.min(depth_image[points_on_target_obj])
+            logging.debug(
+                "closest target object point: " + str(closest_point_on_target_obj)
+            )
+        else:
+            raise ValueError(
+                "May be initializing experiment with no visible target object"
+            )
+
+        perc_on_target_obj = get_perc_on_obj_semantic(
+            semantic_image, semantic_id=self._target_semantic_id
+        )
+        logging.debug("% on target object: " + str(perc_on_target_obj))
+
+        # Also calculate closest point on *any* object so that we don't get too close
+        # and clip into objects; NB that any object will have a semantic ID > 0
+        points_on_any_obj = semantic_image > 0
+        closest_point_on_any_obj = np.min(depth_image[points_on_any_obj])
+        logging.debug("closest point on any object: " + str(closest_point_on_any_obj))
+
+        if perc_on_target_obj < self._good_view_percentage:
+            if closest_point_on_target_obj > self._desired_object_distance:
+                if self._multiple_objects_present and (
+                    closest_point_on_any_obj < self._desired_object_distance / 4
+                ):
+                    logging.debug(
+                        "Getting too close to other objects, not moving forward."
+                    )
+                    return None
+                else:
+                    logging.debug("Moving forward")
+                    return MoveForward(agent_id=self.agent_id, distance=0.01)
+            else:
+                logging.debug("Close enough.")
+                return None
+        else:
+            logging.debug("Enough percent visible.")
+            return None
+
+    def orient_to_object(
+        self, observation: Mapping, state: Optional[MotorSystemState] = None
+    ) -> List[Action]:
+        """Rotate sensors so that they are centered on the object using the view finder.
+
+        The view finder needs to be in the same position as the sensor patch
+        and the object needs to be somewhere in the view finders view.
+
+        Args:
+            observation (Mapping): The observation to use for positioning.
+            state (Optional[MotorSystemState]): The current state of the motor system.
+                Defaults to None.
+
+        Returns:
+            (List[Action]): A list of actions of length two composed of actions needed
+                to get us onto the target object.
+        """
+        # Reconstruct 2D semantic map.
+        depth_image = observation[self.agent_id][self._sensor_id]["depth"]
+        obs_dim = depth_image.shape[0:2]
+        sem3d_obs = observation[self.agent_id][self._sensor_id]["semantic_3d"]
+        sem_obs = sem3d_obs[:, 3].reshape(obs_dim).astype(int)
+
+        if not self._multiple_objects_present:
+            sem_obs[sem_obs > 0] = self._target_semantic_id
+
+        logging.debug("Searching for object")
+        relative_location = self.find_location_to_look_at(
+            sem3d_obs,
+            image_shape=obs_dim,
+            state=state,
+        )
+        down_amount, left_amount = self.compute_look_amounts(
+            relative_location, state=state
+        )
+        return [
+            LookDown(agent_id=self.agent_id, rotation_degrees=down_amount),
+            TurnLeft(agent_id=self.agent_id, rotation_degrees=left_amount),
+        ]
+
+    def positioning_call(
+        self,
+        observation: Mapping,
+        state: Optional[MotorSystemState] = None,
+    ) -> PositioningProcedureResult:
+        if self._multiple_objects_present:
+            on_target_object = self.is_on_target_object(observation)
+            if not on_target_object:
+                return PositioningProcedureResult(
+                    actions=self.orient_to_object(observation, state)
+                )
+
+        if self._allow_translation:
+            action = self.move_close_enough(observation)
+            if action is not None:
+                logging.debug("Moving closer to object.")
+                return PositioningProcedureResult(actions=[action])
+
+        on_target_object = self.is_on_target_object(observation)
+        if (
+            not on_target_object
+            and self._num_orientation_attempts < self._max_orientation_attempts
+        ):
+            self._num_orientation_attempts += 1
+            return PositioningProcedureResult(
+                actions=self.orient_to_object(observation, state)
+            )
+
+        if on_target_object:
+            return PositioningProcedureResult(
+                success=True,
+                terminated=True,
+                truncated=False,
+            )
+        else:
+            return PositioningProcedureResult(
+                success=False,
+                terminated=False,
+                truncated=True,
+            )
 
 
 class InformedPolicy(BasePolicy, JumpToGoalStateMixin):

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -38,7 +38,7 @@ from tbp.monty.frameworks.actions.actions import (
     TurnRight,
     VectorXYZ,
 )
-from tbp.monty.frameworks.models.motor_system_state import AgentState, MotorSystemState
+from tbp.monty.frameworks.models.motor_system_state import MotorSystemState
 from tbp.monty.frameworks.utils.spatial_arithmetics import get_angle_beefed_up
 from tbp.monty.frameworks.utils.transform_utils import scipy_to_numpy_quat
 

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -38,7 +38,7 @@ from tbp.monty.frameworks.actions.actions import (
     TurnRight,
     VectorXYZ,
 )
-from tbp.monty.frameworks.models.motor_system_state import MotorSystemState
+from tbp.monty.frameworks.models.motor_system_state import AgentState, MotorSystemState
 from tbp.monty.frameworks.utils.spatial_arithmetics import get_angle_beefed_up
 from tbp.monty.frameworks.utils.transform_utils import scipy_to_numpy_quat
 
@@ -248,7 +248,7 @@ class BasePolicy(MotorPolicy):
     # Other required abstract methods, methods called by Monty or Dataloader
     ###
 
-    def get_agent_state(self, state: MotorSystemState):
+    def get_agent_state(self, state: MotorSystemState) -> AgentState:
         """Get agent state (dict).
 
         Note:

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1220,7 +1220,7 @@ class SurfacePolicy(InformedPolicy):
             action.distance = action.distance / 4
             logging.debug(f"Near edge so only moving by {action.distance}")
 
-        action.direction = self.tangential_direction(state)
+        action.direction = self.tangential_direction(self.state)
 
         return action
 

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -27,7 +27,6 @@ from typing import (
     Tuple,
     Type,
     cast,
-    override,
 )
 
 import numpy as np
@@ -707,7 +706,6 @@ class GetGoodView(PositioningProcedure):
             TurnLeft(agent_id=self.agent_id, rotation_degrees=left_amount),
         ]
 
-    @override
     def positioning_call(
         self,
         observation: Mapping,

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -375,10 +375,13 @@ class PositioningProcedureResult:
 
 
 class PositioningProcedure(BasePolicy):
-    """Policy to position the agent in the scene.
+    """Positioning procedure to position the agent in the scene.
 
     TODO: Remove from MotorPolicy hierarchy and refactor to standalone
           PositioningProcedure hierarchy when they get separated.
+
+    The positioning_call method should be repeatedly called until the procedure result
+    indicates that the procedure has terminated or truncated.
     """
 
     @abc.abstractmethod
@@ -708,17 +711,9 @@ class GetGoodView(PositioningProcedure):
             )
 
         if on_target_object:
-            return PositioningProcedureResult(
-                success=True,
-                terminated=True,
-                truncated=False,
-            )
+            return PositioningProcedureResult(success=True, terminated=True)
         else:
-            return PositioningProcedureResult(
-                success=False,
-                terminated=False,
-                truncated=True,
-            )
+            return PositioningProcedureResult(truncated=True)
 
 
 class InformedPolicy(BasePolicy, JumpToGoalStateMixin):

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -911,7 +911,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 pprint("...training...")
-                # First episode will be used to learn object (no_match is triggered before  # noqa: E501
+                # First episode will be used to learn object (no_match is triggered before
                 # min_steps is reached and the sensor moves off the object). In the second  # noqa: E501
                 # episode the sensor moves off the sphere on episode steps 6+
 

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -68,6 +68,9 @@ from tbp.monty.simulators.habitat.configs import (
     PatchViewFinderMountHabitatDatasetArgs,
     TwoLMStackedDistantMountHabitatDatasetArgs,
 )
+from tests.unit.feature_flags import (
+    create_config_with_get_good_view_positioning_procedure,
+)
 from tests.unit.resources.unit_test_utils import BaseGraphTestCases
 
 
@@ -810,35 +813,12 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
 
         return graph_lm
 
-    def create_config_with_get_good_view_positioning_procedure(self, config):
-        """Creates a duplicate configuration testing GetGoodView positioning procedure.
-
-        Args:
-            config (dict): The configuration to duplicate.
-
-        Returns:
-            dict: A duplicate of the configuration with the
-                use_get_good_view_positioning_procedure feature flag enabled.
-        """
-        config_with_get_good_view_positioning_procedure = copy.deepcopy(config)
-        eval_dataloader_args = copy.deepcopy(config["eval_dataloader_args"].__dict__)
-        eval_dataloader_args["use_get_good_view_positioning_procedure"] = True
-        config_with_get_good_view_positioning_procedure["eval_dataloader_args"] = (
-            InformedEnvironmentDataLoaderEvalArgs(**eval_dataloader_args)
-        )
-        train_dataloader_args = copy.deepcopy(config["train_dataloader_args"].__dict__)
-        train_dataloader_args["use_get_good_view_positioning_procedure"] = True
-        config_with_get_good_view_positioning_procedure["train_dataloader_args"] = (
-            InformedEnvironmentDataLoaderTrainArgs(**train_dataloader_args)
-        )
-        return config_with_get_good_view_positioning_procedure
-
     def test_can_run_evidence_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_config)
         for c in [
             config,
-            self.create_config_with_get_good_view_positioning_procedure(config),
+            create_config_with_get_good_view_positioning_procedure(config),
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 pprint("...training...")
@@ -852,7 +832,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         config = copy.deepcopy(self.fixed_actions_evidence)
         for c in [
             config,
-            self.create_config_with_get_good_view_positioning_procedure(config),
+            create_config_with_get_good_view_positioning_procedure(config),
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 # self.exp.model.set_experiment_mode("eval")
@@ -899,7 +879,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         config = copy.deepcopy(self.fixed_actions_evidence)
         for c in [
             config,
-            self.create_config_with_get_good_view_positioning_procedure(config),
+            create_config_with_get_good_view_positioning_procedure(config),
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 exp.model.set_experiment_mode("train")
@@ -927,7 +907,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         config = copy.deepcopy(self.evidence_tests_off_object)
         for c in [
             config,
-            self.create_config_with_get_good_view_positioning_procedure(config),
+            create_config_with_get_good_view_positioning_procedure(config),
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 pprint("...training...")
@@ -1014,7 +994,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         config = copy.deepcopy(self.evidence_tests_time_out)
         for c in [
             config,
-            self.create_config_with_get_good_view_positioning_procedure(config),
+            create_config_with_get_good_view_positioning_procedure(config),
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 pprint("...training...")
@@ -1081,7 +1061,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         config = copy.deepcopy(self.fixed_actions_evidence)
         for c in [
             config,
-            self.create_config_with_get_good_view_positioning_procedure(config),
+            create_config_with_get_good_view_positioning_procedure(config),
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 exp.model.set_experiment_mode("train")
@@ -1138,7 +1118,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         config = copy.deepcopy(self.evidence_test_uniform_initial_poses)
         for c in [
             config,
-            self.create_config_with_get_good_view_positioning_procedure(config),
+            create_config_with_get_good_view_positioning_procedure(config),
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 pprint("...training...")
@@ -1165,7 +1145,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         config = copy.deepcopy(self.fixed_possible_poses_evidence)
         for c in [
             config,
-            self.create_config_with_get_good_view_positioning_procedure(config),
+            create_config_with_get_good_view_positioning_procedure(config),
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 pprint("...training...")
@@ -1749,7 +1729,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         config = copy.deepcopy(self.no_features_evidence)
         for c in [
             config,
-            self.create_config_with_get_good_view_positioning_procedure(config),
+            create_config_with_get_good_view_positioning_procedure(config),
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 pprint("...training...")
@@ -1775,7 +1755,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         config = copy.deepcopy(self.evidence_5lm_config)
         for c in [
             config,
-            self.create_config_with_get_good_view_positioning_procedure(config),
+            create_config_with_get_good_view_positioning_procedure(config),
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 pprint("...training...")
@@ -1813,7 +1793,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         config = copy.deepcopy(self.evidence_5lm_3done_config)
         for c in [
             config,
-            self.create_config_with_get_good_view_positioning_procedure(config),
+            create_config_with_get_good_view_positioning_procedure(config),
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 pprint("...training...")
@@ -1844,62 +1824,69 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_off_object_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
 
-            exp.train()
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-            # Just checking that objects are still recognized correctly when moving off
-            # the object.
-            self.check_train_results(train_stats, num_lms=5)
+                exp.train()
+                train_stats = pd.read_csv(
+                    os.path.join(exp.output_dir, "train_stats.csv")
+                )
+                # Just checking that objects are still recognized correctly when moving off  # noqa: E501
+                # the object.
+                self.check_train_results(train_stats, num_lms=5)
+                # now lets check the number of steps
+                for row in range(5 * 6):
+                    self.assertLess(
+                        train_stats["num_steps"][row],
+                        train_stats["monty_steps"][row],
+                        "Should have less steps per lm (matching and exploratory"
+                        " steps that were on the object) than monty_steps.",
+                    )
+                    self.assertLess(
+                        train_stats["monty_matching_steps"][row],
+                        train_stats["num_steps"][row],
+                        "Should have less steps monty_matching_steps than"
+                        " overall steps since some steps were off the object.",
+                    )
+
+                exp.evaluate()
+
+            pprint("...loading and checking eval statistics...")
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+
+            self.check_eval_results(eval_stats, num_lms=5)
+
             # now lets check the number of steps
-            for row in range(5 * 6):
+            for row in range(5 * 3):
                 self.assertLess(
-                    train_stats["num_steps"][row],
-                    train_stats["monty_steps"][row],
-                    "Should have less steps per lm (matching and exploratory"
-                    " steps that were on the object) than monty_steps.",
+                    eval_stats["monty_matching_steps"][row],
+                    eval_stats["monty_steps"][row],
+                    "Should have less matching steps than overall monty steps since we"
+                    " were completely off the object for a while.",
                 )
+                self.assertGreaterEqual(
+                    eval_stats["monty_matching_steps"][row],
+                    eval_stats["num_steps"][row],
+                    "Individual lms shhould not have more steps that monty matching"
+                    " steps during evaluation (no exploration).",
+                )
+                self.assertEqual(
+                    eval_stats["monty_matching_steps"][row],
+                    13,
+                    "All eval episodes should have recognized the object "
+                    "after 13 steps.",
+                )
+            for lm_id in [0, 2, 3, 4]:
                 self.assertLess(
-                    train_stats["monty_matching_steps"][row],
-                    train_stats["num_steps"][row],
-                    "Should have less steps monty_matching_steps than"
-                    " overall steps since some steps were off the object.",
+                    eval_stats["num_steps"][5 + lm_id],
+                    13,
+                    f"LM {lm_id} in episode 1 should have less than 13 steps"
+                    f" since it was off the object for longer than other LMs.",
                 )
-
-            exp.evaluate()
-
-        pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
-
-        self.check_eval_results(eval_stats, num_lms=5)
-
-        # now lets check the number of steps
-        for row in range(5 * 3):
-            self.assertLess(
-                eval_stats["monty_matching_steps"][row],
-                eval_stats["monty_steps"][row],
-                "Should have less matching steps than overall monty steps since we"
-                " were completely off the object for a while.",
-            )
-            self.assertGreaterEqual(
-                eval_stats["monty_matching_steps"][row],
-                eval_stats["num_steps"][row],
-                "Individual lms shhould not have more steps that monty matching"
-                " steps during evaluation (no exploration).",
-            )
-            self.assertEqual(
-                eval_stats["monty_matching_steps"][row],
-                13,
-                "All eval episodes should have recognized the object after 13 steps.",
-            )
-        for lm_id in [0, 2, 3, 4]:
-            self.assertLess(
-                eval_stats["num_steps"][5 + lm_id],
-                13,
-                f"LM {lm_id} in episode 1 should have less than 13 steps"
-                f" since it was off the object for longer than other LMs.",
-            )
 
     def test_starting_off_object_5lms(self):
         """Test that patch_off_object is logged when no object is present.
@@ -1909,49 +1896,58 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            exp.model.set_experiment_mode("train")
-            exp.pre_epoch()
-            exp.pre_episode()
-            pprint("...removing all objects...")
-            exp.dataset.env._env.remove_all_objects()
-            exp.dataloader.reset_agent()
-            pprint("...training...")
-            last_step = exp.run_episode_steps()
-            exp.post_episode(last_step)
-            exp.post_epoch()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                exp.model.set_experiment_mode("train")
+                exp.pre_epoch()
+                exp.pre_episode()
+                pprint("...removing all objects...")
+                exp.dataset.env._env.remove_all_objects()
+                exp.dataloader.reset_agent()
+                pprint("...training...")
+                last_step = exp.run_episode_steps()
+                exp.post_episode(last_step)
+                exp.post_epoch()
 
-        pprint("...checking run stats...")
-        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-        self.assertEqual(
-            train_stats["primary_performance"][0],
-            "patch_off_object",
-            "episode should log patch_off_object performance.",
-        )
+            pprint("...checking run stats...")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            self.assertEqual(
+                train_stats["primary_performance"][0],
+                "patch_off_object",
+                "episode should log patch_off_object performance.",
+            )
 
     def test_5lm_basic_logging(self):
         """Test that 5LM setup works with BASIC logging and stores correct data."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_basic_logging)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
-            for key in [
-                "possible_rotations",
-                "possible_locations",
-                "evidences",
-                "symmetry_evidence",
-            ]:
-                self.assertNotIn(
-                    key,
-                    exp.model.learning_modules[0].buffer.stats.keys(),
-                    f"{key} should not be stored in buffer when using BASIC logging.",
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                exp.train()
+                for key in [
+                    "possible_rotations",
+                    "possible_locations",
+                    "evidences",
+                    "symmetry_evidence",
+                ]:
+                    self.assertNotIn(
+                        key,
+                        exp.model.learning_modules[0].buffer.stats.keys(),
+                        f"{key} should not be stored in buffer when using "
+                        f"BASIC logging.",
+                    )
+                self.assertEqual(
+                    len(exp.model.learning_modules[0].buffer.stats["possible_matches"]),
+                    1,
+                    "When using basic logging we don't append stats for every step.",
                 )
-            self.assertEqual(
-                len(exp.model.learning_modules[0].buffer.stats["possible_matches"]),
-                1,
-                "When using basic logging we don't append stats for every step.",
-            )
 
     def test_can_run_with_no_multithreading_5lms(self):
         """Standard evaluation setup but using only pose features.
@@ -1960,21 +1956,27 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.no_multithreding_5lm_evidence)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
-            pprint("...loading and checking train statistics...")
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(config) as exp:
+                pprint("...training...")
+                exp.train()
+                pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-            self.check_train_results(train_stats, num_lms=5)
+                train_stats = pd.read_csv(
+                    os.path.join(exp.output_dir, "train_stats.csv")
+                )
+                self.check_train_results(train_stats, num_lms=5)
 
-            pprint("...evaluating...")
-            exp.evaluate()
+                pprint("...evaluating...")
+                exp.evaluate()
 
-        pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+            pprint("...loading and checking eval statistics...")
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
-        self.check_eval_results(eval_stats, num_lms=5)
+            self.check_eval_results(eval_stats, num_lms=5)
 
     def test_can_run_with_maxnn1_5lms(self):
         """Standard evaluation setup but using max_nneighbors=1.
@@ -1983,41 +1985,53 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.maxnn1_5lm_evidence)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
-            pprint("...loading and checking train statistics...")
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                exp.train()
+                pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-            self.check_train_results(train_stats, num_lms=5)
+                train_stats = pd.read_csv(
+                    os.path.join(exp.output_dir, "train_stats.csv")
+                )
+                self.check_train_results(train_stats, num_lms=5)
 
-            pprint("...evaluating...")
-            exp.evaluate()
+                pprint("...evaluating...")
+                exp.evaluate()
 
-        pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+            pprint("...loading and checking eval statistics...")
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
-        self.check_eval_results(eval_stats, num_lms=5)
+            self.check_eval_results(eval_stats, num_lms=5)
 
     def test_can_run_with_bounded_evidence_5lms(self):
         """Standard evaluation setup with 5lm and bounded evidence."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.bounded_evidence_5lm_evidence)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
-            pprint("...loading and checking train statistics...")
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                exp.train()
+                pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-            self.check_train_results(train_stats, num_lms=5)
+                train_stats = pd.read_csv(
+                    os.path.join(exp.output_dir, "train_stats.csv")
+                )
+                self.check_train_results(train_stats, num_lms=5)
 
-            pprint("...evaluating...")
-            exp.evaluate()
+                pprint("...evaluating...")
+                exp.evaluate()
 
-        pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+            pprint("...loading and checking eval statistics...")
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
-        self.check_eval_results(eval_stats, num_lms=5)
+            self.check_eval_results(eval_stats, num_lms=5)
 
     def test_noise_mixing_evidence(self):
         """Test standard fixed action setting with noisy sensor module.
@@ -2029,35 +2043,41 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.noise_mixin_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            # self.exp.model.set_experiment_mode("eval")
-            pprint("...training...")
-            exp.train()
-            pprint("...loading and checking train statistics...")
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                # self.exp.model.set_experiment_mode("eval")
+                pprint("...training...")
+                exp.train()
+                pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-            # NOTE: This might fail if the model becomes more noise robust or
-            # better able to deal with few incomplete objects in memory.
-            for i in range(6):
+                train_stats = pd.read_csv(
+                    os.path.join(exp.output_dir, "train_stats.csv")
+                )
+                # NOTE: This might fail if the model becomes more noise robust or
+                # better able to deal with few incomplete objects in memory.
+                for i in range(6):
+                    self.assertEqual(
+                        train_stats["primary_performance"][i],
+                        "no_match",
+                        f"Train episode {i} didnt reach no_match."
+                        "Is noise being applied correctly?",
+                    )
+
+                pprint("...evaluating...")
+                exp.evaluate()
+
+            pprint("...loading and checking eval statistics...")
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+            for i in range(3):
                 self.assertEqual(
-                    train_stats["primary_performance"][i],
+                    eval_stats["primary_performance"][i],
                     "no_match",
-                    f"Train episode {i} didnt reach no_match."
+                    f"Eval episode {i} didnt reach no_match."
                     "Is noise being applied correctly?",
                 )
-
-            pprint("...evaluating...")
-            exp.evaluate()
-
-        pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
-        for i in range(3):
-            self.assertEqual(
-                eval_stats["primary_performance"][i],
-                "no_match",
-                f"Eval episode {i} didnt reach no_match."
-                "Is noise being applied correctly?",
-            )
 
     def test_raw_sensor_noise_evidence(self):
         """Test standard fixed action setting with raw sensor noise.
@@ -2069,35 +2089,41 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.noisy_sensor_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            # self.exp.model.set_experiment_mode("eval")
-            pprint("...training...")
-            exp.train()
-            pprint("...loading and checking train statistics...")
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                # self.exp.model.set_experiment_mode("eval")
+                pprint("...training...")
+                exp.train()
+                pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-            # NOTE: This might fail if the model becomes more noise robust or
-            # better able to deal with few incomplete objects in memory.
-            for i in range(6):
+                train_stats = pd.read_csv(
+                    os.path.join(exp.output_dir, "train_stats.csv")
+                )
+                # NOTE: This might fail if the model becomes more noise robust or
+                # better able to deal with few incomplete objects in memory.
+                for i in range(6):
+                    self.assertEqual(
+                        train_stats["primary_performance"][i],
+                        "no_match",
+                        f"Train episode {i} didnt reach no_match."
+                        "Is noise being applied correctly?",
+                    )
+
+                pprint("...evaluating...")
+                exp.evaluate()
+
+            pprint("...loading and checking eval statistics...")
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+            for i in range(3):
                 self.assertEqual(
-                    train_stats["primary_performance"][i],
+                    eval_stats["primary_performance"][i],
                     "no_match",
-                    f"Train episode {i} didnt reach no_match."
+                    f"Eval episode {i} didnt reach no_match."
                     "Is noise being applied correctly?",
                 )
-
-            pprint("...evaluating...")
-            exp.evaluate()
-
-        pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
-        for i in range(3):
-            self.assertEqual(
-                eval_stats["primary_performance"][i],
-                "no_match",
-                f"Eval episode {i} didnt reach no_match."
-                "Is noise being applied correctly?",
-            )
 
     def test_two_lm_heterarchy_experiment(self):
         """Test two LMs stacked on top of each other.
@@ -2138,19 +2164,25 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.two_lms_heterarchy_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-            self.check_hierarchical_lm_train_results(train_stats)
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                exp.train()
+                train_stats = pd.read_csv(
+                    os.path.join(exp.output_dir, "train_stats.csv")
+                )
+                self.check_hierarchical_lm_train_results(train_stats)
 
-            models = load_models_from_dir(exp.output_dir)
-            self.check_hierarchical_models(models)
+                models = load_models_from_dir(exp.output_dir)
+                self.check_hierarchical_models(models)
 
-            pprint("...evaluating...")
-            exp.evaluate()
-            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
-            self.check_hierarchical_lm_eval_results(eval_stats)
+                pprint("...evaluating...")
+                exp.evaluate()
+                eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+                self.check_hierarchical_lm_eval_results(eval_stats)
 
 
 if __name__ == "__main__":

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -1728,6 +1728,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
 
         pprint("...loading and checking eval statistics...")
         eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+
         self.check_eval_results(eval_stats, num_lms=5)
 
     def test_5lm_3done_evidence(self):

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -893,8 +893,8 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         config = copy.deepcopy(self.evidence_tests_off_object)
         with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
-            # First episode will be used to learn object (no_match is triggered before  # noqa: E501
-            # min_steps is reached and the sensor moves off the object). In the second  # noqa: E501
+            # First episode will be used to learn object (no_match is triggered before
+            # min_steps is reached and the sensor moves off the object). In the second
             # episode the sensor moves off the sphere on episode steps 6+
 
             # Since process_all_obs == False by default, the off_object points are
@@ -1766,7 +1766,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
 
             exp.train()
             train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-            # Just checking that objects are still recognized correctly when moving off  # noqa: E501
+            # Just checking that objects are still recognized correctly when moving off
             # the object.
             self.check_train_results(train_stats, num_lms=5)
             # now lets check the number of steps

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -911,7 +911,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         ]:
             with MontyObjectRecognitionExperiment(c) as exp:
                 pprint("...training...")
-                # First episode will be used to learn object (no_match is triggered before
+                # First episode will be used to learn object (no_match is triggered before  # noqa: E501
                 # min_steps is reached and the sensor moves off the object). In the second  # noqa: E501
                 # episode the sensor moves off the sphere on episode steps 6+
 

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -1960,7 +1960,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             config,
             create_config_with_get_good_view_positioning_procedure(config),
         ]:
-            with MontyObjectRecognitionExperiment(config) as exp:
+            with MontyObjectRecognitionExperiment(c) as exp:
                 pprint("...training...")
                 exp.train()
                 pprint("...loading and checking train statistics...")

--- a/tests/unit/feature_flags.py
+++ b/tests/unit/feature_flags.py
@@ -43,11 +43,12 @@ def create_config_with_get_good_view_positioning_procedure(config):
             use_get_good_view_positioning_procedure feature flag enabled.
     """
     config_with_get_good_view_positioning_procedure = copy.deepcopy(config)
-    eval_dataloader_args = copy.deepcopy(to_dict(config["eval_dataloader_args"]))
-    eval_dataloader_args["use_get_good_view_positioning_procedure"] = True
-    config_with_get_good_view_positioning_procedure["eval_dataloader_args"] = (
-        InformedEnvironmentDataLoaderEvalArgs(**eval_dataloader_args)
-    )
+    if hasattr(config, "eval_dataloader_args"):
+        eval_dataloader_args = copy.deepcopy(to_dict(config["eval_dataloader_args"]))
+        eval_dataloader_args["use_get_good_view_positioning_procedure"] = True
+        config_with_get_good_view_positioning_procedure["eval_dataloader_args"] = (
+            InformedEnvironmentDataLoaderEvalArgs(**eval_dataloader_args)
+        )
     train_dataloader_args = copy.deepcopy(to_dict(config["train_dataloader_args"]))
     train_dataloader_args["use_get_good_view_positioning_procedure"] = True
     config_with_get_good_view_positioning_procedure["train_dataloader_args"] = (

--- a/tests/unit/feature_flags.py
+++ b/tests/unit/feature_flags.py
@@ -1,0 +1,56 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+from __future__ import annotations
+
+import copy
+from dataclasses import asdict, is_dataclass
+from typing import Dict
+
+from tbp.monty.frameworks.config_utils.config_args import Dataclass
+from tbp.monty.frameworks.config_utils.make_dataset_configs import (
+    InformedEnvironmentDataLoaderEvalArgs,
+    InformedEnvironmentDataLoaderTrainArgs,
+)
+
+
+def to_dict(maybe_dataclass: Dataclass | Dict) -> dict:
+    """Convert a dataclass or dict to a dict.
+
+    Args:
+        maybe_dataclass: The object to convert to a dict.
+
+    Returns:
+        dict: The dict.
+    """
+    return asdict(maybe_dataclass) if is_dataclass(maybe_dataclass) else maybe_dataclass
+
+
+def create_config_with_get_good_view_positioning_procedure(config):
+    """Creates a duplicate configuration testing GetGoodView positioning procedure.
+
+    Args:
+        config (dict): The configuration to duplicate.
+
+    Returns:
+        dict: A duplicate of the configuration with the
+            use_get_good_view_positioning_procedure feature flag enabled.
+    """
+    config_with_get_good_view_positioning_procedure = copy.deepcopy(config)
+    eval_dataloader_args = copy.deepcopy(to_dict(config["eval_dataloader_args"]))
+    eval_dataloader_args["use_get_good_view_positioning_procedure"] = True
+    config_with_get_good_view_positioning_procedure["eval_dataloader_args"] = (
+        InformedEnvironmentDataLoaderEvalArgs(**eval_dataloader_args)
+    )
+    train_dataloader_args = copy.deepcopy(to_dict(config["train_dataloader_args"]))
+    train_dataloader_args["use_get_good_view_positioning_procedure"] = True
+    config_with_get_good_view_positioning_procedure["train_dataloader_args"] = (
+        InformedEnvironmentDataLoaderTrainArgs(**train_dataloader_args)
+    )
+    return config_with_get_good_view_positioning_procedure

--- a/tests/unit/graph_building_test.py
+++ b/tests/unit/graph_building_test.py
@@ -248,8 +248,7 @@ class GraphLearningTest(unittest.TestCase):
             exp (MontySupervisedObjectPretrainingExperiment): The experiment.
         """
         pprint("...parsing experiment...")
-        config = self.spth_feat
-        with MontySupervisedObjectPretrainingExperiment(config) as exp:
+        with MontySupervisedObjectPretrainingExperiment(self.spth_feat) as exp:
             exp.model.set_experiment_mode("train")
 
             pprint("...training...")

--- a/tests/unit/graph_building_test.py
+++ b/tests/unit/graph_building_test.py
@@ -226,22 +226,14 @@ class GraphLearningTest(unittest.TestCase):
             "node ids not stored in graph",
         )
 
-    def build_and_save_supervised_graph(
-        self, use_get_good_view_positioning_procedure=False
-    ):
+    def build_and_save_supervised_graph(self):
         """Builds and saves a supervised graph.
-
-        Args:
-            use_get_good_view_positioning_procedure (bool): Whether to use the
-                GetGoodView positioning procedure.
 
         Returns:
             exp (MontySupervisedObjectPretrainingExperiment): The experiment.
         """
         pprint("...parsing experiment...")
         config = self.supervised_pre_training_in_habitat
-        if use_get_good_view_positioning_procedure:
-            config = create_config_with_get_good_view_positioning_procedure(config)
         with MontySupervisedObjectPretrainingExperiment(config) as exp:
             exp.model.set_experiment_mode("train")
 
@@ -249,22 +241,14 @@ class GraphLearningTest(unittest.TestCase):
             exp.train()
         return exp
 
-    def build_and_save_supervised_graph_feat(
-        self, use_get_good_view_positioning_procedure=False
-    ):
+    def build_and_save_supervised_graph_feat(self):
         """Builds and saves a supervised graph with feature matching.
-
-        Args:
-            use_get_good_view_positioning_procedure (bool): Whether to use the
-                GetGoodView positioning procedure.
 
         Returns:
             exp (MontySupervisedObjectPretrainingExperiment): The experiment.
         """
         pprint("...parsing experiment...")
         config = self.spth_feat
-        if use_get_good_view_positioning_procedure:
-            config = create_config_with_get_good_view_positioning_procedure(config)
         with MontySupervisedObjectPretrainingExperiment(config) as exp:
             exp.model.set_experiment_mode("train")
 
@@ -281,151 +265,148 @@ class GraphLearningTest(unittest.TestCase):
         self.assertEqual(get_correct_k_n(5, 2), None)
 
     def test_can_build_graph_habitat_supervised(self):
-        for use_get_good_view_positioning_procedure in [False, True]:
-            exp = self.build_and_save_supervised_graph(
-                use_get_good_view_positioning_procedure
-            )
-            pprint("...Checking graphs...")
+        exp = self.build_and_save_supervised_graph()
+        pprint("...Checking graphs...")
 
-            self.assertListEqual(
-                self.supervised_pre_training_in_habitat[
-                    "train_dataloader_args"
-                ].object_names,
-                exp.model.learning_modules[0].get_all_known_object_ids(),
-                "Object ids of learned objects and graphs in memory.",
+        self.assertListEqual(
+            self.supervised_pre_training_in_habitat[
+                "train_dataloader_args"
+            ].object_names,
+            exp.model.learning_modules[0].get_all_known_object_ids(),
+            "Object ids of learned objects and graphs in memory.",
+        )
+        for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
+            graph = exp.model.learning_modules[0].get_graph(
+                graph_id, input_channel="first"
             )
+            # Make sure that all features that are extracted by the SM are stored in
+            # the graph.
+            self.check_graph_formatting(
+                graph,
+                features_to_check=exp.model.sensor_modules[0].features,
+            )
+            self.assertIsNot(
+                graph.edge_index,
+                None,
+                "graph contains no edges",
+            )
+            self.assertEqual(
+                graph.edge_attr.shape[1],
+                3,
+                "Edge attributes don't store 3d displacements",
+            )
+
+    def test_can_load_disp_graph(self):
+        self.build_and_save_supervised_graph()
+        pprint("...parsing experiment...")
+        config = copy.deepcopy(self.load_habitat_config)
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("checking loaded graphs")
             for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
                 graph = exp.model.learning_modules[0].get_graph(
                     graph_id, input_channel="first"
                 )
-                # Make sure that all features that are extracted by the SM are stored in
-                # the graph.
                 self.check_graph_formatting(
                     graph,
                     features_to_check=exp.model.sensor_modules[0].features,
                 )
-                self.assertIsNot(
-                    graph.edge_index,
-                    None,
-                    "graph contains no edges",
+            pprint("...evaluating on loaded models...")
+            exp.evaluate()
+
+    def test_can_load_disp_graph_for_ppf_matching(self):
+        self.build_and_save_supervised_graph()
+        pprint("...parsing experiment...")
+        config = copy.deepcopy(self.load_habitat_for_ppf)
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("checking loaded graphs")
+            for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
+                graph = exp.model.learning_modules[0].get_graph(
+                    graph_id, input_channel="first"
+                )
+                self.check_graph_formatting(
+                    graph,
+                    features_to_check=exp.model.sensor_modules[0].features,
+                )
+                self.assertEqual(
+                    graph.edge_attr.shape[1],
+                    4,
+                    "Edge attributes don't store 4d PPF (should be added when loading)",
+                )
+            pprint("...evaluating on loaded models...")
+            exp.evaluate()
+
+    def test_can_load_disp_graph_for_feature_matching(self):
+        self.build_and_save_supervised_graph()
+        pprint("...parsing experiment...")
+        config = copy.deepcopy(self.load_habitat_for_feat)
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("checking loaded graphs")
+            for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
+                graph = exp.model.learning_modules[0].get_graph(
+                    graph_id, input_channel="first"
+                )
+                self.check_graph_formatting(
+                    graph,
+                    features_to_check=exp.model.sensor_modules[0].features,
                 )
                 self.assertEqual(
                     graph.edge_attr.shape[1],
                     3,
                     "Edge attributes don't store 3d displacements",
                 )
-
-    def test_can_load_disp_graph(self):
-        for use_get_good_view_positioning_procedure in [False, True]:
-            self.build_and_save_supervised_graph(
-                use_get_good_view_positioning_procedure
-            )
-            pprint("...parsing experiment...")
-            config = copy.deepcopy(self.load_habitat_config)
-            if use_get_good_view_positioning_procedure:
-                config = create_config_with_get_good_view_positioning_procedure(config)
-            with MontyObjectRecognitionExperiment(config) as exp:
-                pprint("checking loaded graphs")
-                for graph_id in exp.model.learning_modules[
-                    0
-                ].get_all_known_object_ids():
-                    graph = exp.model.learning_modules[0].get_graph(
-                        graph_id, input_channel="first"
-                    )
-                    self.check_graph_formatting(
-                        graph,
-                        features_to_check=exp.model.sensor_modules[0].features,
-                    )
-                pprint("...evaluating on loaded models...")
-                exp.evaluate()
-
-    def test_can_load_disp_graph_for_ppf_matching(self):
-        for use_get_good_view_positioning_procedure in [False, True]:
-            self.build_and_save_supervised_graph(
-                use_get_good_view_positioning_procedure
-            )
-            pprint("...parsing experiment...")
-            config = copy.deepcopy(self.load_habitat_for_ppf)
-            if use_get_good_view_positioning_procedure:
-                config = create_config_with_get_good_view_positioning_procedure(config)
-            with MontyObjectRecognitionExperiment(config) as exp:
-                pprint("checking loaded graphs")
-                for graph_id in exp.model.learning_modules[
-                    0
-                ].get_all_known_object_ids():
-                    graph = exp.model.learning_modules[0].get_graph(
-                        graph_id, input_channel="first"
-                    )
-                    self.check_graph_formatting(
-                        graph,
-                        features_to_check=exp.model.sensor_modules[0].features,
-                    )
-                    self.assertEqual(
-                        graph.edge_attr.shape[1],
-                        4,
-                        "Edge attributes don't store 4d PPF (should be added when loading)",  # noqa: E501
-                    )
-                pprint("...evaluating on loaded models...")
-                exp.evaluate()
-
-    def test_can_load_disp_graph_for_feature_matching(self):
-        for use_get_good_view_positioning_procedure in [False, True]:
-            self.build_and_save_supervised_graph(
-                use_get_good_view_positioning_procedure
-            )
-            pprint("...parsing experiment...")
-            config = copy.deepcopy(self.load_habitat_for_feat)
-            if use_get_good_view_positioning_procedure:
-                config = create_config_with_get_good_view_positioning_procedure(config)
-            with MontyObjectRecognitionExperiment(config) as exp:
-                pprint("checking loaded graphs")
-                for graph_id in exp.model.learning_modules[
-                    0
-                ].get_all_known_object_ids():
-                    graph = exp.model.learning_modules[0].get_graph(
-                        graph_id, input_channel="first"
-                    )
-                    self.check_graph_formatting(
-                        graph,
-                        features_to_check=exp.model.sensor_modules[0].features,
-                    )
-                    self.assertEqual(
-                        graph.edge_attr.shape[1],
-                        3,
-                        "Edge attributes don't store 3d displacements",
-                    )
-                pprint("...evaluating on loaded models...")
-                exp.evaluate()
+            pprint("...evaluating on loaded models...")
+            exp.evaluate()
 
     def test_can_extend_and_save_feat_graph(self):
-        for use_get_good_view_positioning_procedure in [False, True]:
-            self.build_and_save_supervised_graph_feat(
-                use_get_good_view_positioning_procedure
+        self.build_and_save_supervised_graph_feat()
+        config = copy.deepcopy(self.load_habitat_for_feat)
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("checking loaded graphs")
+            for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
+                graph = exp.model.learning_modules[0].get_graph(
+                    graph_id, input_channel="first"
+                )
+                self.check_graph_formatting(
+                    graph,
+                    features_to_check=exp.model.sensor_modules[0].features,
+                )
+                # TODO: not sure if we want this check. Right now it doesn't but I
+                # also don't see a reason why it couldn't in the future.
+                self.assertIs(
+                    graph.edge_attr,
+                    None,
+                    "feature at location graph should not contain edges.",
+                )
+            pprint("...evaluating on loaded models...")
+            exp.train()
+
+
+class GraphLearningTestWithGetGoodViewPositioningProcedure(GraphLearningTest):
+    def setUp(self):
+        super().setUp()
+        self.supervised_pre_training_in_habitat = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.supervised_pre_training_in_habitat
             )
-            config = copy.deepcopy(self.load_habitat_for_feat)
-            if use_get_good_view_positioning_procedure:
-                config = create_config_with_get_good_view_positioning_procedure(config)
-            with MontyObjectRecognitionExperiment(config) as exp:
-                pprint("checking loaded graphs")
-                for graph_id in exp.model.learning_modules[
-                    0
-                ].get_all_known_object_ids():
-                    graph = exp.model.learning_modules[0].get_graph(
-                        graph_id, input_channel="first"
-                    )
-                    self.check_graph_formatting(
-                        graph,
-                        features_to_check=exp.model.sensor_modules[0].features,
-                    )
-                    # TODO: not sure if we want this check. Right now it doesn't but I
-                    # also don't see a reason why it couldn't in the future.
-                    self.assertIs(
-                        graph.edge_attr,
-                        None,
-                        "feature at location graph should not contain edges.",
-                    )
-                pprint("...evaluating on loaded models...")
-                exp.train()
+        )
+        self.load_habitat_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.load_habitat_config
+            )
+        )
+        self.load_habitat_for_ppf = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.load_habitat_for_ppf
+            )
+        )
+        self.load_habitat_for_feat = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.load_habitat_for_feat
+            )
+        )
+        self.spth_feat = create_config_with_get_good_view_positioning_procedure(
+            self.spth_feat
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -558,145 +558,113 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        for c in [
-            base_config,
-            create_config_with_get_good_view_positioning_procedure(base_config),
-        ]:
-            with MontyObjectRecognitionExperiment(c):
-                pass
+        with MontyObjectRecognitionExperiment(base_config):
+            pass
 
     def test_can_run_train_episode(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        for c in [
-            base_config,
-            create_config_with_get_good_view_positioning_procedure(base_config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("train")
-                pprint("...training...")
-                exp.pre_epoch()
-                exp.run_episode()
+        with MontyObjectRecognitionExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            exp.pre_epoch()
+            exp.run_episode()
 
     def test_right_data_in_buffer(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        for c in [
-            base_config,
-            create_config_with_get_good_view_positioning_procedure(base_config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("train")
-                pprint("...training...")
-                exp.pre_epoch()
-                exp.pre_episode()
-                for step, observation in enumerate(exp.dataloader):
-                    exp.model.step(observation)
-                    self.assertEqual(
-                        step + 1,
-                        len(exp.model.learning_modules[0].buffer),
-                        "buffer does not contain the right amount of elements.",
-                    )
-                    self.assertEqual(
-                        step + 1,
-                        len(
-                            exp.model.learning_modules[
-                                0
-                            ].buffer.get_all_locations_on_object(input_channel="first")
+        with MontyObjectRecognitionExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            exp.pre_epoch()
+            exp.pre_episode()
+            for step, observation in enumerate(exp.dataloader):
+                exp.model.step(observation)
+                self.assertEqual(
+                    step + 1,
+                    len(exp.model.learning_modules[0].buffer),
+                    "buffer does not contain the right amount of elements.",
+                )
+                self.assertEqual(
+                    step + 1,
+                    len(
+                        exp.model.learning_modules[
+                            0
+                        ].buffer.get_all_locations_on_object(input_channel="first")
+                    ),
+                    "buffer does not contain the right amount of locations.",
+                )
+                if step == 0:
+                    self.assertListEqual(
+                        list(
+                            exp.model.learning_modules[0].buffer.get_nth_displacement(
+                                0, input_channel="first"
+                            )
                         ),
-                        "buffer does not contain the right amount of locations.",
+                        [0, 0, 0],
+                        "displacement at step 0 should be 0.",
                     )
-                    if step == 0:
-                        self.assertListEqual(
-                            list(
-                                exp.model.learning_modules[
-                                    0
-                                ].buffer.get_nth_displacement(0, input_channel="first")
-                            ),
-                            [0, 0, 0],
-                            "displacement at step 0 should be 0.",
-                        )
-                    self.assertEqual(
-                        step + 1,
-                        len(
-                            exp.model.learning_modules[0].buffer.displacements["patch"][
-                                "displacement"
-                            ]
-                        ),
-                        "buffer does not contain the right amount of displacements.",
-                    )
-                    self.assertSetEqual(
-                        set(exp.model.sensor_modules[0].features),
-                        set(exp.model.learning_modules[0].buffer[-1]["patch"].keys()),
-                        "buffer doesn't contain all features required for matching.",
-                    )
-                    if step == 3:
-                        break
+                self.assertEqual(
+                    step + 1,
+                    len(
+                        exp.model.learning_modules[0].buffer.displacements["patch"][
+                            "displacement"
+                        ]
+                    ),
+                    "buffer does not contain the right amount of displacements.",
+                )
+                self.assertSetEqual(
+                    set(exp.model.sensor_modules[0].features),
+                    set(exp.model.learning_modules[0].buffer[-1]["patch"].keys()),
+                    "buffer doesn't contain all features required for matching.",
+                )
+                if step == 3:
+                    break
 
     def test_can_run_eval_episode(self):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
-        for c in [
-            base_config,
-            create_config_with_get_good_view_positioning_procedure(base_config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("eval")
-                pprint("...training...")
-                exp.pre_epoch()
-                exp.run_episode()
+        with MontyObjectRecognitionExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("eval")
+            pprint("...training...")
+            exp.pre_epoch()
+            exp.run_episode()
 
     def test_can_run_eval_episode_with_surface_agent(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.surface_agent_eval_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("eval")
-                pprint("...training...")
-                exp.pre_epoch()
-                exp.run_episode()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("eval")
+            pprint("...training...")
+            exp.pre_epoch()
+            exp.run_episode()
 
     def test_can_run_ppf_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.ppf_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...evaluating...")
+            exp.evaluate()
 
     def test_can_run_disp_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.disp_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...evaluating...")
+            exp.evaluate()
 
     def test_can_run_feature_experiment(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...evaluating...")
+            exp.evaluate()
 
     def test_fixed_actions_disp(self):
         """Runs three test episodes on capsule3DSolid and cubeSolid.
@@ -717,444 +685,382 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_disp)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...loading and checking train statistics...")
-                train_stats = pd.read_csv(
-                    os.path.join(exp.output_dir, "train_stats.csv")
-                )
-                self.check_train_results(train_stats)
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...loading and checking train statistics...")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            self.check_train_results(train_stats)
 
-                pprint("...evaluating...")
-                exp.evaluate()
+            pprint("...evaluating...")
+            exp.evaluate()
 
-            pprint("...loading and checking eval statistics...")
-            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+        pprint("...loading and checking eval statistics...")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
-            self.check_eval_results(eval_stats)
+        self.check_eval_results(eval_stats)
 
     def test_fixed_actions_ppf(self):
         """Like test_fixed_actions_disp but using point pair features for matching."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_ppf)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...loading and checking train statistics...")
-                train_stats = pd.read_csv(
-                    os.path.join(exp.output_dir, "train_stats.csv")
-                )
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...loading and checking train statistics...")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
 
-                self.check_train_results(train_stats)
+            self.check_train_results(train_stats)
 
-                pprint("...evaluating...")
-                exp.evaluate()
+            pprint("...evaluating...")
+            exp.evaluate()
 
-            pprint("...loading and checking eval statistics...")
-            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+        pprint("...loading and checking eval statistics...")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
-            self.check_eval_results(eval_stats)
+        self.check_eval_results(eval_stats)
 
     def test_fixed_actions_feat(self):
         """Like test_fixed_actions_disp but using point pair features for matching."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...loading and checking train statistics...")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...loading and checking train statistics...")
 
-                train_stats = pd.read_csv(
-                    os.path.join(exp.output_dir, "train_stats.csv")
-                )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
 
-                self.check_train_results(train_stats)
+            self.check_train_results(train_stats)
 
-                pprint("...evaluating...")
-                exp.evaluate()
+            pprint("...evaluating...")
+            exp.evaluate()
 
-            pprint("...loading and checking eval statistics...")
-            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+        pprint("...loading and checking eval statistics...")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
-            self.check_eval_results(eval_stats)
+        self.check_eval_results(eval_stats)
 
     def test_reproduce_single_episode(self):
-        for use_get_good_view_positioning_procedure in [False, True]:
-            pprint("...parsing experiment...")
-            config = copy.deepcopy(self.fixed_actions_feat)
-            if use_get_good_view_positioning_procedure:
-                config = create_config_with_get_good_view_positioning_procedure(config)
-            with MontyObjectRecognitionExperiment(config) as exp:
-                pprint("...training...")
-                exp.train()
+        pprint("...parsing experiment...")
+        config = copy.deepcopy(self.fixed_actions_feat)
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
 
-            # Create a separate experiment for evaluation to mimic the us case of re-running  # noqa: E501
-            # eval episodes from a pretrained model
-            eval_cfg_1 = copy.deepcopy(config)
-            eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
-                exp.output_dir,
-                "2",  # latest checkpoint
-            )
-            if use_get_good_view_positioning_procedure:
-                eval_cfg_1 = create_config_with_get_good_view_positioning_procedure(
-                    eval_cfg_1
-                )
-            with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
-                # TODO: update so it only runs one episode
-                pprint("...evaluating (first time) ...")
-                eval_exp_1.evaluate()
+        # Create a separate experiment for evaluation to mimic the us case of re-running
+        # eval episodes from a pretrained model
+        eval_cfg_1 = copy.deepcopy(config)
+        eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
+            exp.output_dir,
+            "2",  # latest checkpoint
+        )
+        with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
+            # TODO: update so it only runs one episode
+            pprint("...evaluating (first time) ...")
+            eval_exp_1.evaluate()
 
-            # Create detailed follow up experiment
-            eval_cfg_2 = create_eval_episode_config(
-                parent_config=eval_exp_1.config,  # already converted to dict in exp
-                parent_config_name="eval_cfg_1",
-                episode=0,
-                update_run_dir=False,  # we are running direct; no run.py
-            )
+        # Create detailed follow up experiment
+        eval_cfg_2 = create_eval_episode_config(
+            parent_config=eval_exp_1.config,  # already converted to dict in exp
+            parent_config_name="eval_cfg_1",
+            episode=0,
+            update_run_dir=False,  # we are running direct; no run.py
+        )
 
-            ###
-            # Check that the arguments for the new experiment are correct
-            ###
+        ###
+        # Check that the arguments for the new experiment are correct
+        ###
 
-            # Detailed wandb logging should be automatically built in, though we will remove  # noqa: E501
-            # it to avoid logging tests to wandb
-            self.assertEqual(
-                eval_cfg_2["logging_config"]["wandb_handlers"][-1],
-                DetailedWandbMarkedObsHandler,
-            )
-            eval_cfg_2["logging_config"]["wandb_handlers"].pop()
+        # Detailed wandb logging should be automatically built in, though we will remove
+        # it to avoid logging tests to wandb
+        self.assertEqual(
+            eval_cfg_2["logging_config"]["wandb_handlers"][-1],
+            DetailedWandbMarkedObsHandler,
+        )
+        eval_cfg_2["logging_config"]["wandb_handlers"].pop()
 
-            # check that the object being used is the same one from original exp
-            self.assertEqual(
-                eval_cfg_1["eval_dataloader_args"].object_names,
-                eval_cfg_2["eval_dataloader_args"]["object_names"],
-            )
+        # check that the object being used is the same one from original exp
+        self.assertEqual(
+            eval_cfg_1["eval_dataloader_args"].object_names,
+            eval_cfg_2["eval_dataloader_args"]["object_names"],
+        )
 
-            # If we made it this far, we have the correct parameters. Now run the experiment  # noqa: E501
-            if use_get_good_view_positioning_procedure:
-                eval_cfg_2 = create_config_with_get_good_view_positioning_procedure(
-                    eval_cfg_2
-                )
-            with MontyObjectRecognitionExperiment(eval_cfg_2) as eval_exp_2:
-                pprint("...evaluating (second time) ...")
-                eval_exp_2.evaluate()
+        # If we made it this far, we have the correct parameters. Now run the experiment
+        with MontyObjectRecognitionExperiment(eval_cfg_2) as eval_exp_2:
+            pprint("...evaluating (second time) ...")
+            eval_exp_2.evaluate()
 
-            ###
-            # Check that basic csv stats are the same
-            ###
-            original_eval_stats_file = os.path.join(
-                eval_exp_1.output_dir, "eval_stats.csv"
-            )
-            new_eval_stats_file = os.path.join(
-                eval_exp_1.output_dir, "eval_episode_0_rerun", "eval_stats.csv"
-            )
+        ###
+        # Check that basic csv stats are the same
+        ###
+        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
+        new_eval_stats_file = os.path.join(
+            eval_exp_1.output_dir, "eval_episode_0_rerun", "eval_stats.csv"
+        )
 
-            original_stats = pd.read_csv(original_eval_stats_file)
-            new_stats = pd.read_csv(new_eval_stats_file)
-            # filter the time column, as both experiments took place at different times
-            original_stats.drop(columns=["time"], inplace=True)
-            new_stats.drop(columns=["time"], inplace=True)
-            # Get only first episode; eval_exp_1 ran for 3 epochs
-            self.assertTrue(original_stats.loc[0].equals(new_stats.loc[0]))
+        original_stats = pd.read_csv(original_eval_stats_file)
+        new_stats = pd.read_csv(new_eval_stats_file)
+        # filter the time column, as both experiments took place at different times
+        original_stats.drop(columns=["time"], inplace=True)
+        new_stats.drop(columns=["time"], inplace=True)
+        # Get only first episode; eval_exp_1 ran for 3 epochs
+        self.assertTrue(original_stats.loc[0].equals(new_stats.loc[0]))
 
-            ###
-            # Just a few simple lines to check that the json logs are correct
-            ###
+        ###
+        # Just a few simple lines to check that the json logs are correct
+        ###
 
-            # TODO: Once json file i/o code has been updated, only load single episode
-            original_json_file = os.path.join(
-                eval_exp_1.output_dir, "detailed_run_stats.json"
-            )
-            new_json_file = os.path.join(
-                eval_exp_1.output_dir,
-                "eval_episode_0_rerun",
-                "detailed_run_stats.json",
-            )
+        # TODO: Once json file i/o code has been updated, only load single episode
+        original_json_file = os.path.join(
+            eval_exp_1.output_dir, "detailed_run_stats.json"
+        )
+        new_json_file = os.path.join(
+            eval_exp_1.output_dir,
+            "eval_episode_0_rerun",
+            "detailed_run_stats.json",
+        )
 
-            original_detailed_stats = deserialize_json_chunks(original_json_file)
-            new_detailed_stats = deserialize_json_chunks(new_json_file)
+        original_detailed_stats = deserialize_json_chunks(original_json_file)
+        new_detailed_stats = deserialize_json_chunks(new_json_file)
 
-            # Check that LM data is the same; absolute nightmare zoo of data formats
-            og_lm_stats = original_detailed_stats["0"]["LM_0"]
-            new_lm_stats = new_detailed_stats["0"]["LM_0"]
+        # Check that LM data is the same; absolute nightmare zoo of data formats
+        og_lm_stats = original_detailed_stats["0"]["LM_0"]
+        new_lm_stats = new_detailed_stats["0"]["LM_0"]
 
-            self.compare_lm_stats(og_lm_stats, new_lm_stats)
+        self.compare_lm_stats(og_lm_stats, new_lm_stats)
 
-            # Check that targets are the same
-            og_lm_targets = original_detailed_stats["0"]["target"]
-            new_lm_targets = new_detailed_stats["0"]["target"]
-            for key, val in og_lm_targets.items():
-                self.assertEqual(val, new_lm_targets[key])
+        # Check that targets are the same
+        og_lm_targets = original_detailed_stats["0"]["target"]
+        new_lm_targets = new_detailed_stats["0"]["target"]
+        for key, val in og_lm_targets.items():
+            self.assertEqual(val, new_lm_targets[key])
 
-            self.compare_sensor_module_logs(original_detailed_stats, new_detailed_stats)
+        self.compare_sensor_module_logs(original_detailed_stats, new_detailed_stats)
 
     def test_reproduce_multiple_episodes(self):
-        for use_get_good_view_positioning_procedure in [False, True]:
-            pprint("...parsing experiment...")
-            config = copy.deepcopy(self.fixed_actions_feat)
-            if use_get_good_view_positioning_procedure:
-                config = create_config_with_get_good_view_positioning_procedure(config)
-            with MontyObjectRecognitionExperiment(config) as exp:
-                pprint("...training...")
-                exp.train()
+        pprint("...parsing experiment...")
+        config = copy.deepcopy(self.fixed_actions_feat)
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
 
-            # Create a separate experiment for evaluation to mimic the us case of re-running  # noqa: E501
-            # eval episodes from a pretrained model
-            eval_cfg_1 = copy.deepcopy(config)
-            eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
-                exp.output_dir,
-                "2",  # latest checkpoint
-            )
-            if use_get_good_view_positioning_procedure:
-                eval_cfg_1 = create_config_with_get_good_view_positioning_procedure(
-                    eval_cfg_1
-                )
-            with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
-                pprint("...evaluating (first time) ...")
-                eval_exp_1.evaluate()
+        # Create a separate experiment for evaluation to mimic the us case of re-running
+        # eval episodes from a pretrained model
+        eval_cfg_1 = copy.deepcopy(config)
+        eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
+            exp.output_dir,
+            "2",  # latest checkpoint
+        )
+        with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
+            pprint("...evaluating (first time) ...")
+            eval_exp_1.evaluate()
 
-            # Create detailed follow up experiment
-            eval_cfg_2 = create_eval_config_multiple_episodes(
-                parent_config=eval_exp_1.config,  # already converted to dict in exp
-                parent_config_name="eval_cfg_1",
-                episodes=[
-                    0,
-                    1,
-                    2,
-                ],  # 3 episodes total, one episode for each of 3 epochs
-                update_run_dir=False,  # we are running direct; no run.py
-            )
+        # Create detailed follow up experiment
+        eval_cfg_2 = create_eval_config_multiple_episodes(
+            parent_config=eval_exp_1.config,  # already converted to dict in exp
+            parent_config_name="eval_cfg_1",
+            episodes=[
+                0,
+                1,
+                2,
+            ],  # 3 episodes total, one episode for each of 3 epochs
+            update_run_dir=False,  # we are running direct; no run.py
+        )
 
-            ###
-            # Check that the arguments for the new experiment are correct
-            ###
+        ###
+        # Check that the arguments for the new experiment are correct
+        ###
 
-            # NOTE: detailed wandb logging is currently removed as default. If the handler  # noqa: E501
-            # is added back, the handler should be removed in unit tests again. (also in the  # noqa: E501
-            # test_reproduce_single_episode_with_multiple_episode_function). For original  # noqa: E501
-            # code see https://github.com/thousandbrainsproject/tbp.monty/pull/208
+        # NOTE: detailed wandb logging is currently removed as default. If the handler
+        # is added back, the handler should be removed in unit tests again. (also in the
+        # test_reproduce_single_episode_with_multiple_episode_function). For original
+        # code see https://github.com/thousandbrainsproject/tbp.monty/pull/208
 
-            # capsule3DSolid is used as the lone eval object; make sure it is listed once  # noqa: E501
-            # per episode
-            self.assertEqual(
-                eval_cfg_2["eval_dataloader_args"]["object_names"],
-                ["capsule3DSolid", "capsule3DSolid", "capsule3DSolid"],
-            )
+        # capsule3DSolid is used as the lone eval object; make sure it is listed once
+        # per episode
+        self.assertEqual(
+            eval_cfg_2["eval_dataloader_args"]["object_names"],
+            ["capsule3DSolid", "capsule3DSolid", "capsule3DSolid"],
+        )
 
-            # Original sampler had just first two rotations, should cycle back to the first  # noqa: E501
-            # on the third episode
-            self.assertEqual(
-                eval_cfg_2["eval_dataloader_args"]["object_init_sampler"].rotations,
-                [[0.0, 0.0, 0.0], [45.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
-            )
+        # Original sampler had just first two rotations, should cycle back to the first
+        # on the third episode
+        self.assertEqual(
+            eval_cfg_2["eval_dataloader_args"]["object_init_sampler"].rotations,
+            [[0.0, 0.0, 0.0], [45.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
+        )
 
-            # If we made it this far, we have the correct parameters. Now run the experiment  # noqa: E501
-            if use_get_good_view_positioning_procedure:
-                eval_cfg_2 = create_config_with_get_good_view_positioning_procedure(
-                    eval_cfg_2
-                )
-            with MontyObjectRecognitionExperiment(eval_cfg_2) as eval_exp_2:
-                pprint("...evaluating (second time) ...")
-                eval_exp_2.evaluate()
+        # If we made it this far, we have the correct parameters. Now run the experiment
+        with MontyObjectRecognitionExperiment(eval_cfg_2) as eval_exp_2:
+            pprint("...evaluating (second time) ...")
+            eval_exp_2.evaluate()
 
-            ###
-            # Check that basic csv stats are the same
-            ###
-            original_eval_stats_file = os.path.join(
-                eval_exp_1.output_dir, "eval_stats.csv"
-            )
-            new_eval_stats_file = os.path.join(
-                eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
-            )
+        ###
+        # Check that basic csv stats are the same
+        ###
+        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
+        new_eval_stats_file = os.path.join(
+            eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
+        )
 
-            original_stats = pd.read_csv(original_eval_stats_file)
-            new_stats = pd.read_csv(new_eval_stats_file)
-            # filter the time column, as both experiments took place at different times
-            original_stats.drop(columns=["time"], inplace=True)
-            new_stats.drop(columns=["time"], inplace=True)
-            # Get only first episode; eval_exp_1 ran for 3 epochs
-            self.assertTrue(original_stats.equals(new_stats))
+        original_stats = pd.read_csv(original_eval_stats_file)
+        new_stats = pd.read_csv(new_eval_stats_file)
+        # filter the time column, as both experiments took place at different times
+        original_stats.drop(columns=["time"], inplace=True)
+        new_stats.drop(columns=["time"], inplace=True)
+        # Get only first episode; eval_exp_1 ran for 3 epochs
+        self.assertTrue(original_stats.equals(new_stats))
 
-            ###
-            # Just a few simple lines to check that the json logs are correct
-            ###
+        ###
+        # Just a few simple lines to check that the json logs are correct
+        ###
 
-            # TODO: Once json file i/o code has been updated, only load single episode
-            original_json_file = os.path.join(
-                eval_exp_1.output_dir, "detailed_run_stats.json"
-            )
-            new_json_file = os.path.join(
-                eval_exp_1.output_dir,
-                "eval_rerun_episodes",
-                "detailed_run_stats.json",
-            )
+        # TODO: Once json file i/o code has been updated, only load single episode
+        original_json_file = os.path.join(
+            eval_exp_1.output_dir, "detailed_run_stats.json"
+        )
+        new_json_file = os.path.join(
+            eval_exp_1.output_dir,
+            "eval_rerun_episodes",
+            "detailed_run_stats.json",
+        )
 
-            original_detailed_stats = deserialize_json_chunks(original_json_file)
-            new_detailed_stats = deserialize_json_chunks(new_json_file)
+        original_detailed_stats = deserialize_json_chunks(original_json_file)
+        new_detailed_stats = deserialize_json_chunks(new_json_file)
 
-            # Check that LM data is the same; absolute nightmare zoo of data formats
-            og_lm_stats = original_detailed_stats["0"]["LM_0"]
-            new_lm_stats = new_detailed_stats["0"]["LM_0"]
+        # Check that LM data is the same; absolute nightmare zoo of data formats
+        og_lm_stats = original_detailed_stats["0"]["LM_0"]
+        new_lm_stats = new_detailed_stats["0"]["LM_0"]
 
-            self.compare_lm_stats(og_lm_stats, new_lm_stats)
+        self.compare_lm_stats(og_lm_stats, new_lm_stats)
 
-            # Check that targets are the same
-            og_lm_targets = original_detailed_stats["0"]["target"]
-            new_lm_targets = new_detailed_stats["0"]["target"]
-            for key, val in og_lm_targets.items():
-                self.assertEqual(val, new_lm_targets[key])
+        # Check that targets are the same
+        og_lm_targets = original_detailed_stats["0"]["target"]
+        new_lm_targets = new_detailed_stats["0"]["target"]
+        for key, val in og_lm_targets.items():
+            self.assertEqual(val, new_lm_targets[key])
 
-            self.compare_sensor_module_logs(original_detailed_stats, new_detailed_stats)
+        self.compare_sensor_module_logs(original_detailed_stats, new_detailed_stats)
 
     def test_reproduce_single_episode_with_multiple_episode_function(self):
         """Verify create_eval_config_multiple_episodes for a single episode."""
-        for use_get_good_view_positioning_procedure in [False, True]:
-            pprint("...parsing experiment...")
-            config = copy.deepcopy(self.fixed_actions_feat)
-            if use_get_good_view_positioning_procedure:
-                config = create_config_with_get_good_view_positioning_procedure(config)
-            with MontyObjectRecognitionExperiment(config) as exp:
-                pprint("...training...")
-                exp.train()
+        pprint("...parsing experiment...")
+        config = copy.deepcopy(self.fixed_actions_feat)
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
 
-            # Create a separate experiment for evaluation to mimic the us case of re-running  # noqa: E501
-            # eval episodes from a pretrained model
-            eval_cfg_1 = copy.deepcopy(config)
-            eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
-                exp.output_dir,
-                "2",  # latest checkpoint
-            )
-            if use_get_good_view_positioning_procedure:
-                eval_cfg_1 = create_config_with_get_good_view_positioning_procedure(
-                    eval_cfg_1
-                )
-            with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
-                pprint("...evaluating (first time) ...")
-                eval_exp_1.evaluate()
+        # Create a separate experiment for evaluation to mimic the us case of re-running
+        # eval episodes from a pretrained model
+        eval_cfg_1 = copy.deepcopy(config)
+        eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
+            exp.output_dir,
+            "2",  # latest checkpoint
+        )
+        with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
+            pprint("...evaluating (first time) ...")
+            eval_exp_1.evaluate()
 
-            # Create detailed follow up experiment
-            eval_cfg_2 = create_eval_config_multiple_episodes(
-                parent_config=eval_exp_1.config,  # already converted to dict in exp
-                parent_config_name="eval_cfg_1",
-                episodes=[0],
-                update_run_dir=False,  # we are running direct; no run.py
-            )
+        # Create detailed follow up experiment
+        eval_cfg_2 = create_eval_config_multiple_episodes(
+            parent_config=eval_exp_1.config,  # already converted to dict in exp
+            parent_config_name="eval_cfg_1",
+            episodes=[0],
+            update_run_dir=False,  # we are running direct; no run.py
+        )
 
-            ###
-            # Check that the arguments for the new experiment are correct
-            ###
+        ###
+        # Check that the arguments for the new experiment are correct
+        ###
 
-            # check that the object being used is the same one from original exp
-            self.assertEqual(
-                eval_cfg_1["eval_dataloader_args"].object_names,
-                eval_cfg_2["eval_dataloader_args"]["object_names"],
-            )
+        # check that the object being used is the same one from original exp
+        self.assertEqual(
+            eval_cfg_1["eval_dataloader_args"].object_names,
+            eval_cfg_2["eval_dataloader_args"]["object_names"],
+        )
 
-            # If we made it this far, we have the correct parameters. Now run the experiment  # noqa: E501
-            if use_get_good_view_positioning_procedure:
-                eval_cfg_2 = create_config_with_get_good_view_positioning_procedure(
-                    eval_cfg_2
-                )
-            with MontyObjectRecognitionExperiment(eval_cfg_2) as eval_exp_2:
-                pprint("...evaluating (second time) ...")
-                eval_exp_2.evaluate()
+        # If we made it this far, we have the correct parameters. Now run the experiment
+        with MontyObjectRecognitionExperiment(eval_cfg_2) as eval_exp_2:
+            pprint("...evaluating (second time) ...")
+            eval_exp_2.evaluate()
 
-            ###
-            # Check that basic csv stats are the same
-            ###
-            original_eval_stats_file = os.path.join(
-                eval_exp_1.output_dir, "eval_stats.csv"
-            )
-            new_eval_stats_file = os.path.join(
-                eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
-            )
+        ###
+        # Check that basic csv stats are the same
+        ###
+        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
+        new_eval_stats_file = os.path.join(
+            eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
+        )
 
-            original_stats = pd.read_csv(original_eval_stats_file)
-            new_stats = pd.read_csv(new_eval_stats_file)
-            # filter the time column, as both experiments took place at different times
-            original_stats.drop(columns=["time"], inplace=True)
-            new_stats.drop(columns=["time"], inplace=True)
-            # Get only first episode; eval_exp_1 ran for 3 epochs
-            self.assertTrue(original_stats.loc[0].equals(new_stats.loc[0]))
+        original_stats = pd.read_csv(original_eval_stats_file)
+        new_stats = pd.read_csv(new_eval_stats_file)
+        # filter the time column, as both experiments took place at different times
+        original_stats.drop(columns=["time"], inplace=True)
+        new_stats.drop(columns=["time"], inplace=True)
+        # Get only first episode; eval_exp_1 ran for 3 epochs
+        self.assertTrue(original_stats.loc[0].equals(new_stats.loc[0]))
 
-            ###
-            # Just a few simple lines to check that the json logs are correct
-            ###
+        ###
+        # Just a few simple lines to check that the json logs are correct
+        ###
 
-            # TODO: Once json file i/o code has been updated, only load single episode
-            original_json_file = os.path.join(
-                eval_exp_1.output_dir, "detailed_run_stats.json"
-            )
-            new_json_file = os.path.join(
-                eval_exp_1.output_dir,
-                "eval_rerun_episodes",
-                "detailed_run_stats.json",
-            )
+        # TODO: Once json file i/o code has been updated, only load single episode
+        original_json_file = os.path.join(
+            eval_exp_1.output_dir, "detailed_run_stats.json"
+        )
+        new_json_file = os.path.join(
+            eval_exp_1.output_dir,
+            "eval_rerun_episodes",
+            "detailed_run_stats.json",
+        )
 
-            original_detailed_stats = deserialize_json_chunks(original_json_file)
-            new_detailed_stats = deserialize_json_chunks(new_json_file)
+        original_detailed_stats = deserialize_json_chunks(original_json_file)
+        new_detailed_stats = deserialize_json_chunks(new_json_file)
 
-            # Check that LM data is the same; absolute nightmare zoo of data formats
-            og_lm_stats = original_detailed_stats["0"]["LM_0"]
-            new_lm_stats = new_detailed_stats["0"]["LM_0"]
+        # Check that LM data is the same; absolute nightmare zoo of data formats
+        og_lm_stats = original_detailed_stats["0"]["LM_0"]
+        new_lm_stats = new_detailed_stats["0"]["LM_0"]
 
-            self.compare_lm_stats(og_lm_stats, new_lm_stats)
+        self.compare_lm_stats(og_lm_stats, new_lm_stats)
 
-            # Check that targets are the same
-            og_lm_targets = original_detailed_stats["0"]["target"]
-            new_lm_targets = new_detailed_stats["0"]["target"]
-            for key, val in og_lm_targets.items():
-                self.assertEqual(val, new_lm_targets[key])
+        # Check that targets are the same
+        og_lm_targets = original_detailed_stats["0"]["target"]
+        new_lm_targets = new_detailed_stats["0"]["target"]
+        for key, val in og_lm_targets.items():
+            self.assertEqual(val, new_lm_targets[key])
 
-            self.compare_sensor_module_logs(original_detailed_stats, new_detailed_stats)
+        self.compare_sensor_module_logs(original_detailed_stats, new_detailed_stats)
 
     def test_save_and_load(self):
         # Move this to graph_building_test.py?
-        for use_get_good_view_positioning_procedure in [False, True]:
-            pprint("...parsing experiment...")
-            config = copy.deepcopy(self.fixed_actions_ppf)
-            if use_get_good_view_positioning_procedure:
-                config = create_config_with_get_good_view_positioning_procedure(config)
-            with MontyObjectRecognitionExperiment(config) as exp:
-                pprint("...training...")
-                exp.train()
+        pprint("...parsing experiment...")
+        config = copy.deepcopy(self.fixed_actions_ppf)
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
 
-            # We are training for 3 epochs by default, load most recent indexing from 0
-            print("Loading a saved checkpoint")
-            cfg2 = copy.deepcopy(self.fixed_actions_feat)
-            cfg2["experiment_args"].model_name_or_path = os.path.join(
-                config["logging_config"].output_dir,
-                "2",  # latest checkpoint
-            )
-            if use_get_good_view_positioning_procedure:
-                cfg2 = create_config_with_get_good_view_positioning_procedure(cfg2)
-            with MontyObjectRecognitionExperiment(cfg2) as exp2:
-                graph_memory_1 = exp.model.learning_modules[
-                    0
-                ].graph_memory.get_all_models_in_memory()
-                graph_memory_2 = exp2.model.learning_modules[
-                    0
-                ].graph_memory.get_all_models_in_memory()
+        # We are training for 3 epochs by default, load most recent indexing from 0
+        print("Loading a saved checkpoint")
+        cfg2 = copy.deepcopy(self.fixed_actions_feat)
+        cfg2["experiment_args"].model_name_or_path = os.path.join(
+            config["logging_config"].output_dir,
+            "2",  # latest checkpoint
+        )
+        with MontyObjectRecognitionExperiment(cfg2) as exp2:
+            graph_memory_1 = exp.model.learning_modules[
+                0
+            ].graph_memory.get_all_models_in_memory()
+            graph_memory_2 = exp2.model.learning_modules[
+                0
+            ].graph_memory.get_all_models_in_memory()
 
-                # Loop over each graph model and check they have the exact same data
-                for obj_name in graph_memory_1.keys():
-                    for input_channel in graph_memory_1[obj_name].keys():
-                        graph_1 = graph_memory_1[obj_name][input_channel]
-                        graph_2 = graph_memory_2[obj_name][input_channel]
-                        self.check_graphs_equal(graph_1, graph_2)
+            # Loop over each graph model and check they have the exact same data
+            for obj_name in graph_memory_1.keys():
+                for input_channel in graph_memory_1[obj_name].keys():
+                    graph_1 = graph_memory_1[obj_name][input_channel]
+                    graph_2 = graph_memory_2[obj_name][input_channel]
+                    self.check_graphs_equal(graph_1, graph_2)
 
     def test_time_out(self):
         """Test time_out and pose_time_out detection and logging.
@@ -1168,271 +1074,248 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_time_out)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("train")
-                pprint("...training...")
-                for e in range(6):
-                    if e % 2 == 0:
-                        exp.pre_epoch()
-                    if e == 2:
-                        # Set max steps low & raise mmd to get pose time outs
-                        exp.max_train_steps = 3
-                        exp.model.learning_modules[0].max_match_distance = 0.1
-                    if e == 4:
-                        # set curvature threshold high to get time outs
-                        exp.model.learning_modules[0].tolerances["patch"][
-                            "principal_curvatures_log"
-                        ] = [10, 10]
-                    exp.run_episode()
-                    if e % 2 == 1:
-                        exp.post_epoch()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            for e in range(6):
+                if e % 2 == 0:
+                    exp.pre_epoch()
+                if e == 2:
+                    # Set max steps low & raise mmd to get pose time outs
+                    exp.max_train_steps = 3
+                    exp.model.learning_modules[0].max_match_distance = 0.1
+                if e == 4:
+                    # set curvature threshold high to get time outs
+                    exp.model.learning_modules[0].tolerances["patch"][
+                        "principal_curvatures_log"
+                    ] = [10, 10]
+                exp.run_episode()
+                if e % 2 == 1:
+                    exp.post_epoch()
 
-            pprint("...check time out logging...")
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+        pprint("...check time out logging...")
+        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+        self.assertEqual(
+            train_stats["primary_performance"][2],
+            "pose_time_out",
+            "pose time out not recognized/logged correctly",
+        )
+        # possible locations are str in .csv with one line per pose
+        # unique rotations may already be one but we don't know
+        # where we are yet.
+        self.assertGreater(
+            train_stats["possible_object_locations"][2].count("\n"),
+            0,  # If there are two possible locations, there will be 1 newline
+            "pose time out episode should have more than one possible pose.",
+        )
+        for episode in [4, 5]:
             self.assertEqual(
-                train_stats["primary_performance"][2],
-                "pose_time_out",
-                "pose time out not recognized/logged correctly",
+                train_stats["primary_performance"][episode],
+                "time_out",
+                "time out not recognized/logged correctly",
             )
-            # possible locations are str in .csv with one line per pose
-            # unique rotations may already be one but we don't know
-            # where we are yet.
+            self.assertEqual(
+                train_stats["primary_performance"][episode],
+                "time_out",
+                "time out not recognized/logged correctly",
+            )
             self.assertGreater(
-                train_stats["possible_object_locations"][2].count("\n"),
-                0,  # If there are two possible locations, there will be 1 newline
-                "pose time out episode should have more than one possible pose.",
+                train_stats["num_possible_matches"][episode],
+                1,
+                "time out episode should have more than one possible match.",
             )
-            for episode in [4, 5]:
-                self.assertEqual(
-                    train_stats["primary_performance"][episode],
-                    "time_out",
-                    "time out not recognized/logged correctly",
-                )
-                self.assertEqual(
-                    train_stats["primary_performance"][episode],
-                    "time_out",
-                    "time out not recognized/logged correctly",
-                )
-                self.assertGreater(
-                    train_stats["num_possible_matches"][episode],
-                    1,
-                    "time out episode should have more than one possible match.",
-                )
-                # possible objects are comma separated string
-                self.assertGreater(
-                    train_stats["result"][episode].count(","),
-                    0,  # If there are two objects, there should be 1 comma
-                    "time out episode should log more than one possible match.",
-                )
+            # possible objects are comma separated string
+            self.assertGreater(
+                train_stats["result"][episode].count(","),
+                0,  # If there are two objects, there should be 1 comma
+                "time out episode should log more than one possible match.",
+            )
 
     def test_confused_logging(self):
         # When the algorithm evolves, this scenario may not lead to confusion
         # anymore. Setting min_steps would also avoid this probably.
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_feat)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("train")
-                pprint("...training...")
-                exp.pre_epoch()
-                # Overwrite target with a false name to test confused logging.
-                for e in range(4):
-                    exp.pre_episode()
-                    exp.model.primary_target = str(e)
-                    for lm in exp.model.learning_modules:
-                        lm.primary_target = str(e)
-                    last_step = exp.run_episode_steps()
-                    exp.post_episode(last_step)
-                exp.post_epoch()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            exp.pre_epoch()
+            # Overwrite target with a false name to test confused logging.
+            for e in range(4):
+                exp.pre_episode()
+                exp.model.primary_target = str(e)
+                for lm in exp.model.learning_modules:
+                    lm.primary_target = str(e)
+                last_step = exp.run_episode_steps()
+                exp.post_episode(last_step)
+            exp.post_epoch()
 
-            pprint("...checking run stats...")
-            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-            for i in [0, 1]:
-                self.assertEqual(
-                    train_stats["primary_performance"][i],
-                    "no_match",
-                    f"episode {i} should be no_match.",
-                )
-                self.assertEqual(
-                    train_stats["TFNP"][i],
-                    "unknown_object_not_matched_(TN)",
-                    f"episode {i} should detect a true negative.",
-                )
-            for i in [2, 3]:
-                self.assertEqual(
-                    train_stats["primary_performance"][i],
-                    "confused",
-                    f"episode {i} should log confused performance.",
-                )
-                self.assertEqual(
-                    train_stats["TFNP"][i],
-                    "unknown_object_in_possible_matches_(FP)",
-                    f"episode {i} should detect a false positive.",
-                )
-                self.assertNotEqual(
-                    train_stats["primary_target_object"][i],
-                    train_stats["result"][i],
-                    "confused object id should not be the same as target.",
-                )
-                self.assertNotEqual(
-                    train_stats["primary_target_object"][i],
-                    train_stats["possible_match_sources"][i],
-                    "confused object id should not be in possible_match_sources.",
-                )
+        pprint("...checking run stats...")
+        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+        for i in [0, 1]:
+            self.assertEqual(
+                train_stats["primary_performance"][i],
+                "no_match",
+                f"episode {i} should be no_match.",
+            )
+            self.assertEqual(
+                train_stats["TFNP"][i],
+                "unknown_object_not_matched_(TN)",
+                f"episode {i} should detect a true negative.",
+            )
+        for i in [2, 3]:
+            self.assertEqual(
+                train_stats["primary_performance"][i],
+                "confused",
+                f"episode {i} should log confused performance.",
+            )
+            self.assertEqual(
+                train_stats["TFNP"][i],
+                "unknown_object_in_possible_matches_(FP)",
+                f"episode {i} should detect a false positive.",
+            )
+            self.assertNotEqual(
+                train_stats["primary_target_object"][i],
+                train_stats["result"][i],
+                "confused object id should not be the same as target.",
+            )
+            self.assertNotEqual(
+                train_stats["primary_target_object"][i],
+                train_stats["possible_match_sources"][i],
+                "confused object id should not be in possible_match_sources.",
+            )
 
     def test_moving_off_object(self):
         # Tests additional elements of logging, in particular in relation
         # to logging of observations when off the object
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_off_object)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                # First episode will be used to learn object (no_match is triggered before  # noqa: E501
-                # min_steps is reached and the sensor moves off the object). In the second  # noqa: E501
-                # episode the sensor moves off the sphere on episode steps 6+
-                # Eventually, we circle round and come back to the object; recognition
-                # does not take place before then because when off the object, matching
-                # steps are no longer incremented, while it is an unfamiliar part of
-                # the object that we return to
-                exp.train()
-                self.assertEqual(
-                    len(
-                        exp.model.learning_modules[
-                            0
-                        ].buffer.get_all_locations_on_object(input_channel="patch")
-                    ),
-                    len(
-                        exp.model.learning_modules[
-                            0
-                        ].buffer.get_all_features_on_object()["patch"]["pose_vectors"]
-                    ),
-                    "Did not retrieve same amount of feature and locations on object.",
-                )
-                self.assertEqual(
-                    sum(
-                        exp.model.learning_modules[
-                            0
-                        ].buffer.get_all_features_on_object()["patch"]["on_object"]
-                    ),
-                    len(
-                        exp.model.learning_modules[
-                            0
-                        ].buffer.get_all_features_on_object()["patch"]["on_object"]
-                    ),
-                    "not all retrieved features were collected on the object.",
-                )
-                # Since we don't add observations to the buffer that are off the object
-                # there should only be 8 observations stored for the 12 matching steps
-                # and all of them should be on the object.
-                num_matching_steps = len(
-                    exp.model.learning_modules[0].buffer.stats["possible_matches"]
-                )
-                self.assertEqual(
-                    num_matching_steps,
-                    sum(
-                        exp.model.learning_modules[0].buffer.features["patch"][
-                            "on_object"
-                        ][:num_matching_steps]
-                    ),
-                    "Number of match steps does not match with stored observations "
-                    "on object",
-                )
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            # First episode will be used to learn object (no_match is triggered before
+            # min_steps is reached and the sensor moves off the object). In the second
+            # episode the sensor moves off the sphere on episode steps 6+
+            # Eventually, we circle round and come back to the object; recognition
+            # does not take place before then because when off the object, matching
+            # steps are no longer incremented, while it is an unfamiliar part of
+            # the object that we return to
+            exp.train()
+            self.assertEqual(
+                len(
+                    exp.model.learning_modules[0].buffer.get_all_locations_on_object(
+                        input_channel="patch"
+                    )
+                ),
+                len(
+                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                        "patch"
+                    ]["pose_vectors"]
+                ),
+                "Did not retrieve same amount of feature and locations on object.",
+            )
+            self.assertEqual(
+                sum(
+                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                        "patch"
+                    ]["on_object"]
+                ),
+                len(
+                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                        "patch"
+                    ]["on_object"]
+                ),
+                "not all retrieved features were collected on the object.",
+            )
+            # Since we don't add observations to the buffer that are off the object
+            # there should only be 8 observations stored for the 12 matching steps
+            # and all of them should be on the object.
+            num_matching_steps = len(
+                exp.model.learning_modules[0].buffer.stats["possible_matches"]
+            )
+            self.assertEqual(
+                num_matching_steps,
+                sum(
+                    exp.model.learning_modules[0].buffer.features["patch"]["on_object"][
+                        :num_matching_steps
+                    ]
+                ),
+                "Number of match steps does not match with stored observations "
+                "on object",
+            )
 
     def test_detailed_logging(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_pred_tests_off_object)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...evaluating...")
+            exp.evaluate()
 
-            pprint("...loading stats files...")
-            train_stats, eval_stats, detailed_stats, lm_models = load_stats(
-                exp.output_dir,
-                load_train=True,
-                load_eval=True,
-                load_detailed=True,
+        pprint("...loading stats files...")
+        train_stats, eval_stats, detailed_stats, lm_models = load_stats(
+            exp.output_dir,
+            load_train=True,
+            load_eval=True,
+            load_detailed=True,
+        )
+        for episode in lm_models.keys():
+            self.assertEqual(
+                list(lm_models[episode]["LM_0"].keys()),
+                ["new_object0"],
+                "should have only learned and saved one object during training.",
             )
-            for episode in lm_models.keys():
-                self.assertEqual(
-                    list(lm_models[episode]["LM_0"].keys()),
-                    ["new_object0"],
-                    "should have only learned and saved one object during training.",
-                )
-            for row in range(train_stats.shape[0]):
-                self.assertEqual(
-                    train_stats.loc[row]["primary_target_object"],
-                    detailed_stats[str(row)]["LM_0"]["target"]["object"],
-                    "targets in train_stats and detailed stats don't match.",
-                )
+        for row in range(train_stats.shape[0]):
+            self.assertEqual(
+                train_stats.loc[row]["primary_target_object"],
+                detailed_stats[str(row)]["LM_0"]["target"]["object"],
+                "targets in train_stats and detailed stats don't match.",
+            )
 
-            for row in range(eval_stats.shape[0]):
-                detailed_id = train_stats.shape[0] + row - 1
-                self.assertEqual(
-                    eval_stats.loc[row]["primary_target_object"],
-                    detailed_stats[str(detailed_id)]["LM_0"]["target"]["object"],
-                    "targets in eval_stats and detailed stats don't match.",
-                )
+        for row in range(eval_stats.shape[0]):
+            detailed_id = train_stats.shape[0] + row - 1
             self.assertEqual(
-                len(detailed_stats["1"]["SM_0"]["processed_observations"]),
-                73,
-                "sensor module observations should contain all observations,"
-                "even those off the object.",
+                eval_stats.loc[row]["primary_target_object"],
+                detailed_stats[str(detailed_id)]["LM_0"]["target"]["object"],
+                "targets in eval_stats and detailed stats don't match.",
             )
-            self.assertEqual(
-                len(detailed_stats["1"]["LM_0"]["possible_matches"]),
-                train_stats.loc[1]["monty_matching_steps"],
-                "matching steps in detailed stats don't match with those in "
-                "train stats.",
-            )
-            self.assertEqual(
-                sum(np.array(detailed_stats["1"]["LM_0"]["patch"]["on_object"])),
-                len(detailed_stats["1"]["LM_0"]["patch"]["on_object"]),
-                "learning module observations should only contain observations"
-                "that were on the object.",
-            )
-            # Could add more tests but not sure how important.
+        self.assertEqual(
+            len(detailed_stats["1"]["SM_0"]["processed_observations"]),
+            73,
+            "sensor module observations should contain all observations,"
+            "even those off the object.",
+        )
+        self.assertEqual(
+            len(detailed_stats["1"]["LM_0"]["possible_matches"]),
+            train_stats.loc[1]["monty_matching_steps"],
+            "matching steps in detailed stats don't match with those in train stats.",
+        )
+        self.assertEqual(
+            sum(np.array(detailed_stats["1"]["LM_0"]["patch"]["on_object"])),
+            len(detailed_stats["1"]["LM_0"]["patch"]["on_object"]),
+            "learning module observations should only contain observations"
+            "that were on the object.",
+        )
+        # Could add more tests but not sure how important.
 
     def test_uniform_initial_poses(self):
         """Test same scenario as test_fixed_actions_feat with uniform poses."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feat_test_uniform_initial_poses)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...loading and checking train statistics...")
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...loading and checking train statistics...")
 
-                train_stats = pd.read_csv(
-                    os.path.join(exp.output_dir, "train_stats.csv")
-                )
-                self.check_train_results(train_stats)
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            self.check_train_results(train_stats)
 
-                pprint("...evaluating...")
-                exp.evaluate()
+            pprint("...evaluating...")
+            exp.evaluate()
 
-            pprint("...loading and checking eval statistics...")
-            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
-            self.check_eval_results(eval_stats)
+        pprint("...loading and checking eval statistics...")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+        self.check_eval_results(eval_stats)
 
     def get_gm_with_fake_object(self):
         graph_lm = FeatureGraphLM(
@@ -1742,59 +1625,112 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Test 5 displacement LMs voting with two evaluation settings."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.ppf_displacement_5lm_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
 
-                train_stats = pd.read_csv(
-                    os.path.join(exp.output_dir, "train_stats.csv")
-                )
-                self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
 
-                pprint("...evaluating...")
-                exp.evaluate()
+            pprint("...evaluating...")
+            exp.evaluate()
 
-            pprint("...loading and checking eval statistics...")
-            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
-            self.check_multilm_eval_results(
-                eval_stats, num_lms=5, min_done=3, num_episodes=1
-            )
+        pprint("...loading and checking eval statistics...")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+        self.check_multilm_eval_results(
+            eval_stats, num_lms=5, min_done=3, num_episodes=1
+        )
 
     def test_5lm_feature_experiment(self):
         """Test 5 feature LMs voting with two evaluation settings."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_5lm_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
 
-                train_stats = pd.read_csv(
-                    os.path.join(exp.output_dir, "train_stats.csv")
-                )
-                # The following check is brittle and depends on sensor arrangement. Leaving  # noqa: E501
-                # the rest of the test intact to detect run failures, but disabling checking  # noqa: E501
-                # of particular results.
-                # self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
+            # The following check is brittle and depends on sensor arrangement. Leaving
+            # the rest of the test intact to detect run failures, but disabling checking
+            # of particular results.
+            # self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
 
-                pprint("...evaluating...")
-                exp.evaluate()
+            pprint("...evaluating...")
+            exp.evaluate()
 
-            pprint("...loading and checking eval statistics...")
-            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
-            # Just testing 1 episode here. Somehow the second rotation doesn't get
-            # recognized. Probably just some parameter setting due to flaws in old
-            # LM but didn't want to dig too deep into that for now.
-            self.check_multilm_eval_results(
-                eval_stats, num_lms=5, min_done=3, num_episodes=1
+        pprint("...loading and checking eval statistics...")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
+        # Just testing 1 episode here. Somehow the second rotation doesn't get
+        # recognized. Probably just some parameter setting due to flaws in old
+        # LM but didn't want to dig too deep into that for now.
+        self.check_multilm_eval_results(
+            eval_stats, num_lms=5, min_done=3, num_episodes=1
+        )
+
+
+class GraphLearningTestWithGetGoodViewPositioningProcedure(GraphLearningTest):
+    def setUp(self):
+        super().setUp()
+        self.base_config = create_config_with_get_good_view_positioning_procedure(
+            self.base_config
+        )
+        self.surface_agent_eval_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.surface_agent_eval_config
             )
+        )
+        self.ppf_config = create_config_with_get_good_view_positioning_procedure(
+            self.ppf_config
+        )
+        self.disp_config = create_config_with_get_good_view_positioning_procedure(
+            self.disp_config
+        )
+        self.feature_config = create_config_with_get_good_view_positioning_procedure(
+            self.feature_config
+        )
+        self.fixed_actions_disp = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.fixed_actions_disp
+            )
+        )
+        self.fixed_actions_ppf = create_config_with_get_good_view_positioning_procedure(
+            self.fixed_actions_ppf
+        )
+        self.fixed_actions_feat = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.fixed_actions_feat
+            )
+        )
+        self.feature_pred_tests_time_out = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.feature_pred_tests_time_out
+            )
+        )
+        self.feature_pred_tests_confused = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.feature_pred_tests_confused
+            )
+        )
+        self.feature_pred_tests_off_object = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.feature_pred_tests_off_object
+            )
+        )
+        self.feat_test_uniform_initial_poses = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.feat_test_uniform_initial_poses
+            )
+        )
+        self.ppf_displacement_5lm_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.ppf_displacement_5lm_config
+            )
+        )
+        self.feature_5lm_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.feature_5lm_config
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -45,10 +45,10 @@ from tbp.monty.frameworks.config_utils.config_args import (
     SurfaceAndViewMontyConfig,
 )
 from tbp.monty.frameworks.config_utils.make_dataset_configs import (
-    EnvironmentDataloaderMultiObjectArgs,
-    EnvironmentDataLoaderPerObjectEvalArgs,
-    EnvironmentDataLoaderPerObjectTrainArgs,
     ExperimentArgs,
+    InformedEnvironmentDataLoaderEvalArgs,
+    InformedEnvironmentDataloaderMultiObjectArgs,
+    InformedEnvironmentDataLoaderTrainArgs,
     PredefinedObjectInitializer,
 )
 from tbp.monty.frameworks.config_utils.policy_setup_utils import (
@@ -84,6 +84,9 @@ from tbp.monty.simulators.habitat.configs import (
     PatchViewFinderMultiObjectMountHabitatDatasetArgs,
     SurfaceViewFinderMountHabitatDatasetArgs,
 )
+from tests.unit.feature_flags import (
+    create_config_with_get_good_view_positioning_procedure,
+)
 
 
 class PolicyTest(unittest.TestCase):
@@ -111,12 +114,12 @@ class PolicyTest(unittest.TestCase):
                 env_init_args=EnvInitArgsPatchViewMount(data_path=None).__dict__,
             ),
             train_dataloader_class=ED.InformedEnvironmentDataLoader,
-            train_dataloader_args=EnvironmentDataLoaderPerObjectTrainArgs(
+            train_dataloader_args=InformedEnvironmentDataLoaderTrainArgs(
                 object_names=["cubeSolid", "capsule3DSolid"],
                 object_init_sampler=PredefinedObjectInitializer(),
             ),
             eval_dataloader_class=ED.InformedEnvironmentDataLoader,
-            eval_dataloader_args=EnvironmentDataLoaderPerObjectEvalArgs(
+            eval_dataloader_args=InformedEnvironmentDataLoaderEvalArgs(
                 object_names=["cubeSolid"],
                 object_init_sampler=PredefinedObjectInitializer(),
             ),
@@ -281,7 +284,7 @@ class PolicyTest(unittest.TestCase):
             self.base_dist_agent_config
         )
         self.poor_initial_view_dist_agent_config.update(
-            train_dataloader_args=EnvironmentDataLoaderPerObjectTrainArgs(
+            train_dataloader_args=InformedEnvironmentDataLoaderTrainArgs(
                 object_names=["cubeSolid"],
                 object_init_sampler=PredefinedObjectInitializer(
                     positions=[[0.0, 1.5, -0.2]]  # Object is farther away than typical
@@ -339,7 +342,7 @@ class PolicyTest(unittest.TestCase):
                     data_path=None
                 ).__dict__,
             ),
-            eval_dataloader_args=EnvironmentDataloaderMultiObjectArgs(
+            eval_dataloader_args=InformedEnvironmentDataloaderMultiObjectArgs(
                 object_names=dict(
                     targets_list=["cubeSolid"],
                     source_object_list=["cubeSolid", "capsule3DSolid"],
@@ -372,7 +375,7 @@ class PolicyTest(unittest.TestCase):
             self.poor_initial_view_dist_agent_config
         )
         self.rotated_cube_view_config.update(
-            train_dataloader_args=EnvironmentDataLoaderPerObjectTrainArgs(
+            train_dataloader_args=InformedEnvironmentDataLoaderTrainArgs(
                 object_names=["cubeSolid"],
                 object_init_sampler=PredefinedObjectInitializer(
                     positions=[[-0.1, 1.5, -0.2]],
@@ -472,72 +475,100 @@ class PolicyTest(unittest.TestCase):
     def test_can_run_informed_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.base_dist_agent_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
-            pprint("...evaluating...")
-            exp.evaluate()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                exp.train()
+                pprint("...evaluating...")
+                exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_spiral_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.spiral_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            # TODO: test that no two locations are the same
-            exp.train()
-            pprint("...evaluating...")
-            exp.evaluate()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                # TODO: test that no two locations are the same
+                exp.train()
+                pprint("...evaluating...")
+                exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_dist_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.dist_agent_hypo_driven_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
-            pprint("...evaluating...")
-            exp.evaluate()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                exp.train()
+                pprint("...evaluating...")
+                exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_surface_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.base_surf_agent_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
-            pprint("...evaluating...")
-            exp.evaluate()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                exp.train()
+                pprint("...evaluating...")
+                exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_curv_informed_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.curv_informed_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
-            pprint("...evaluating...")
-            exp.evaluate()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                exp.train()
+                pprint("...evaluating...")
+                exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_surf_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.surf_agent_hypo_driven_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
-            pprint("...evaluating...")
-            exp.evaluate()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                exp.train()
+                pprint("...evaluating...")
+                exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_multi_lm_dist_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.dist_agent_hypo_driven_multi_lm_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
-            pprint("...evaluating...")
-            exp.evaluate()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                exp.train()
+                pprint("...evaluating...")
+                exp.evaluate()
 
     # ==== MORE INVOLVED TESTS OF ACTION POLICIES ====
 
@@ -603,43 +634,51 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_dist_agent_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            exp.model.set_experiment_mode("train")
-            exp.pre_epoch()
-            exp.pre_episode()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                exp.model.set_experiment_mode("train")
+                exp.pre_epoch()
+                exp.pre_episode()
 
-            pprint("...stepping through observations...")
+                pprint("...stepping through observations...")
 
-            # Check the initial view
-            observation = next(exp.dataloader)
-            # TODO M remove the following train-wreck during refactor
-            view = observation[exp.model.motor_system._policy.agent_id]["view_finder"]
-            semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
-            perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
+                # Check the initial view
+                observation = next(exp.dataloader)
+                # TODO M remove the following train-wreck during refactor
+                view = observation[exp.model.motor_system._policy.agent_id][
+                    "view_finder"
+                ]
+                semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
+                perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
 
-            dict_config = config_to_dict(config)
+                dict_config = config_to_dict(config)
 
-            target_perc_on_target_obj = dict_config["monty_config"][
-                "motor_system_config"
-            ]["motor_system_args"]["policy_args"]["good_view_percentage"]
+                target_perc_on_target_obj = dict_config["monty_config"][
+                    "motor_system_config"
+                ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
-            assert perc_on_target_obj >= target_perc_on_target_obj, (
-                f"Initial view is not good enough, {perc_on_target_obj} "
-                f"vs target of {target_perc_on_target_obj}"
-            )
+                assert perc_on_target_obj >= target_perc_on_target_obj, (
+                    f"Initial view is not good enough, {perc_on_target_obj}\
+                    vs target of {target_perc_on_target_obj}"
+                )
 
-            points_on_target_obj = semantic == 1
-            closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
+                points_on_target_obj = semantic == 1
+                closest_point_on_target_obj = np.min(
+                    view["depth"][points_on_target_obj]
+                )
 
-            target_closest_point = dict_config["monty_config"]["motor_system_config"][
-                "motor_system_args"
-            ]["policy_args"]["desired_object_distance"]
+                target_closest_point = dict_config["monty_config"][
+                    "motor_system_config"
+                ]["motor_system_args"]["policy_args"]["desired_object_distance"]
 
-            # Utility policy should not have moved too close to the object
-            assert closest_point_on_target_obj > target_closest_point, (
-                f"Initial view is too close, {closest_point_on_target_obj} "
-                f"vs target of {target_closest_point}"
-            )
+                # Utility policy should not have moved too close to the object
+                assert closest_point_on_target_obj > target_closest_point, (
+                    f"Initial view is too close, {closest_point_on_target_obj}\
+                    vs target of {target_closest_point}"
+                )
 
     def test_touch_object_basic_surf_agent(self):
         """Test ability to move a surface agent to touch an object.
@@ -652,45 +691,51 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_surf_agent_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            exp.model.set_experiment_mode("train")
-            exp.pre_epoch()
-            exp.pre_episode()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                exp.model.set_experiment_mode("train")
+                exp.pre_epoch()
+                exp.pre_episode()
 
-            pprint("...stepping through observations...")
+                pprint("...stepping through observations...")
 
-            # Get a first step to allow the surface agent to touch the object
-            observation_pre_touch = next(exp.dataloader)
-            exp.model.step(observation_pre_touch)
+                # Get a first step to allow the surface agent to touch the object
+                observation_pre_touch = next(exp.dataloader)
+                exp.model.step(observation_pre_touch)
 
-            # Check initial view post touch-attempt
-            observation_post_touch = next(exp.dataloader)
+                # Check initial view post touch-attempt
+                observation_post_touch = next(exp.dataloader)
 
-            # TODO M remove the following train-wreck during refactor
-            view = observation_post_touch[exp.model.motor_system._policy.agent_id][
-                "view_finder"
-            ]
-            dict_config = config_to_dict(config)
+                # TODO M remove the following train-wreck during refactor
+                view = observation_post_touch[exp.model.motor_system._policy.agent_id][
+                    "view_finder"
+                ]
+                dict_config = config_to_dict(config)
 
-            points_on_target_obj = (
-                view["semantic_3d"][:, 3].reshape(view["depth"].shape) == 1
-            )
-            closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
+                points_on_target_obj = (
+                    view["semantic_3d"][:, 3].reshape(view["depth"].shape) == 1
+                )
+                closest_point_on_target_obj = np.min(
+                    view["depth"][points_on_target_obj]
+                )
 
-            assert closest_point_on_target_obj < 1.0, (
-                f"Should be within a meter of the object, "
-                f"closest point at {closest_point_on_target_obj}"
-            )
+                assert closest_point_on_target_obj < 1.0, (
+                    f"Should be within a meter of the object,\
+                    closest point at {closest_point_on_target_obj}"
+                )
 
-            target_closest_point = dict_config["monty_config"]["motor_system_config"][
-                "motor_system_args"
-            ]["policy_args"]["desired_object_distance"]
+                target_closest_point = dict_config["monty_config"][
+                    "motor_system_config"
+                ]["motor_system_args"]["policy_args"]["desired_object_distance"]
 
-            # Utility policy should not have moved too close to the object
-            assert closest_point_on_target_obj > target_closest_point, (
-                f"Initial position is too close, {closest_point_on_target_obj} "
-                f"vs target of {target_closest_point}"
-            )
+                # Utility policy should not have moved too close to the object
+                assert closest_point_on_target_obj > target_closest_point, (
+                    f"Initial position is too close, {closest_point_on_target_obj}\
+                    vs target of {target_closest_point}"
+                )
 
     def test_get_good_view_multi_object(self):
         """Test ability to move a distant agent to a good view of an object.
@@ -706,56 +751,64 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_multi_object_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            pprint("...training...")
-            exp.train()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                pprint("...training...")
+                exp.train()
 
-            # Manually go through evaluation (i.e. methods in .evaluate()
-            # and run_epoch())
-            exp.model.set_experiment_mode("eval")
-            exp.pre_epoch()
-            exp.pre_episode()
+                # Manually go through evaluation (i.e. methods in .evaluate()
+                # and run_epoch())
+                exp.model.set_experiment_mode("eval")
+                exp.pre_epoch()
+                exp.pre_episode()
 
-            pprint("...stepping through observations...")
-            # Check the initial view
-            observation = next(exp.dataloader)
-            # TODO M remove the following train-wreck during refactor
-            view = observation[exp.model.motor_system._policy.agent_id]["view_finder"]
-            semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
-            perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
+                pprint("...stepping through observations...")
+                # Check the initial view
+                observation = next(exp.dataloader)
+                # TODO M remove the following train-wreck during refactor
+                view = observation[exp.model.motor_system._policy.agent_id][
+                    "view_finder"
+                ]
+                semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
+                perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
 
-            dict_config = config_to_dict(config)
-            target_perc_on_target_obj = dict_config["monty_config"][
-                "motor_system_config"
-            ]["motor_system_args"]["policy_args"]["good_view_percentage"]
+                dict_config = config_to_dict(config)
+                target_perc_on_target_obj = dict_config["monty_config"][
+                    "motor_system_config"
+                ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
-            assert perc_on_target_obj >= target_perc_on_target_obj, (
-                f"Initial view is not good enough, {perc_on_target_obj} "
-                f"vs target of {target_perc_on_target_obj}"
-            )
+                assert perc_on_target_obj >= target_perc_on_target_obj, (
+                    f"Initial view is not good enough, {perc_on_target_obj}\
+                    vs target of {target_perc_on_target_obj}"
+                )
 
-            points_on_target_obj = semantic == 1
-            closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
+                points_on_target_obj = semantic == 1
+                closest_point_on_target_obj = np.min(
+                    view["depth"][points_on_target_obj]
+                )
 
-            target_closest_point = dict_config["monty_config"]["motor_system_config"][
-                "motor_system_args"
-            ]["policy_args"]["desired_object_distance"]
+                target_closest_point = dict_config["monty_config"][
+                    "motor_system_config"
+                ]["motor_system_args"]["policy_args"]["desired_object_distance"]
 
-            # Utility policy should not have moved too close to the object
-            assert closest_point_on_target_obj > target_closest_point, (
-                f"Initial view is too close to target, {closest_point_on_target_obj} "
-                f"vs target of {target_closest_point}"
-            )
+                # Utility policy should not have moved too close to the object
+                assert closest_point_on_target_obj > target_closest_point, (
+                    f"Initial view is too close to target, {closest_point_on_target_obj}"  # noqa: E501
+                    f" vs target of {target_closest_point}"
+                )
 
-            # Also calculate closest point on *any* object so that we don't get
-            # too close and clip into objects; NB that any object will have a
-            # semantic ID > 0
-            points_on_any_obj = view["semantic"] > 0
-            closest_point_on_any_obj = np.min(view["depth"][points_on_any_obj])
-            assert closest_point_on_any_obj > target_closest_point / 6, (
-                f"Initial view too close to other objects, {closest_point_on_any_obj} "
-                f"vs target of {target_closest_point / 6}"
-            )
+                # Also calculate closest point on *any* object so that we don't get
+                # too close and clip into objects; NB that any object will have a
+                # semantic ID > 0
+                points_on_any_obj = view["semantic"] > 0
+                closest_point_on_any_obj = np.min(view["depth"][points_on_any_obj])
+                assert closest_point_on_any_obj > target_closest_point / 6, (
+                    f"Initial view too cloase to other objects, {closest_point_on_any_obj}"  # noqa: E501
+                    f" vs target of {target_closest_point / 6}"
+                )
 
     def test_distant_policy_moves_back_to_object(self):
         """Test ability of distant agent to move back to an object.
@@ -768,104 +821,108 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_action_distant_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            exp.model.set_experiment_mode("train")
-            pprint("...training...")
-            exp.pre_epoch()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                exp.model.set_experiment_mode("train")
+                pprint("...training...")
+                exp.pre_epoch()
 
-            # Only do a single episode
-            exp.pre_episode()
+                # Only do a single episode
+                exp.pre_episode()
 
-            pprint("...stepping through observations...")
-            # Manually step through part of run_episode function
-            for loader_step, observation in enumerate(exp.dataloader):
-                exp.model.step(observation)
+                pprint("...stepping through observations...")
+                # Manually step through part of run_episode function
+                for loader_step, observation in enumerate(exp.dataloader):
+                    exp.model.step(observation)
 
-                last_action = exp.model.motor_system.last_action
+                    last_action = exp.model.motor_system.last_action
 
-                if loader_step == 3:
-                    stored_action = last_action
-                    assert not exp.model.learning_modules[
-                        0
-                    ].buffer.get_last_obs_processed(), "Should be off object"
+                    if loader_step == 3:
+                        stored_action = last_action
+                        assert not exp.model.learning_modules[
+                            0
+                        ].buffer.get_last_obs_processed(), "Should be off object"
 
-                if loader_step == 4:
-                    should_have_moved_back = (
-                        "Should have moved back by reversing last movement"
-                    )
-                    self.assertIsInstance(
-                        last_action, type(stored_action), should_have_moved_back
-                    )
-                    if isinstance(stored_action, (LookDown, LookUp)):
-                        self.assertEqual(
-                            last_action.rotation_degrees,
-                            -stored_action.rotation_degrees,
-                            should_have_moved_back,
+                    if loader_step == 4:
+                        should_have_moved_back = (
+                            "Should have moved back by reversing last movement"
                         )
-                        self.assertEqual(
-                            last_action.constraint_degrees,
-                            stored_action.constraint_degrees,
-                            should_have_moved_back,
+                        self.assertIsInstance(
+                            last_action, type(stored_action), should_have_moved_back
                         )
-                    elif isinstance(stored_action, (TurnLeft, TurnRight)):
-                        self.assertEqual(
-                            last_action.rotation_degrees,
-                            -stored_action.rotation_degrees,
-                            should_have_moved_back,
-                        )
-                    elif isinstance(stored_action, MoveForward):
-                        self.assertEqual(
-                            last_action.distance,
-                            -stored_action.distance,
-                            should_have_moved_back,
-                        )
-                    elif isinstance(stored_action, MoveTangentially):
-                        self.assertEqual(
-                            last_action.distance,
-                            -stored_action.distance,
-                            should_have_moved_back,
-                        )
-                        self.assertEqual(
-                            last_action.direction,
-                            stored_action.direction,
-                            should_have_moved_back,
-                        )
-                    elif isinstance(stored_action, OrientHorizontal):
-                        self.assertEqual(
-                            last_action.rotation_degrees,
-                            -stored_action.rotation_degrees,
-                            should_have_moved_back,
-                        )
-                        self.assertEqual(
-                            last_action.left_distance,
-                            -stored_action.left_distance,
-                            should_have_moved_back,
-                        )
-                        self.assertEqual(
-                            last_action.forward_distance,
-                            -stored_action.forward_distance,
-                            should_have_moved_back,
-                        )
-                    elif isinstance(stored_action, OrientVertical):
-                        self.assertEqual(
-                            last_action.rotation_degrees,
-                            -stored_action.rotation_degrees,
-                            should_have_moved_back,
-                        )
-                        self.assertEqual(
-                            last_action.down_distance,
-                            -stored_action.down_distance,
-                            should_have_moved_back,
-                        )
-                        self.assertEqual(
-                            last_action.forward_distance,
-                            -stored_action.forward_distance,
-                            should_have_moved_back,
-                        )
-                    assert exp.model.learning_modules[
-                        0
-                    ].buffer.get_last_obs_processed(), "Should be back on object"
-                    break  # Don't go into exploratory mode
+                        if isinstance(stored_action, (LookDown, LookUp)):
+                            self.assertEqual(
+                                last_action.rotation_degrees,
+                                -stored_action.rotation_degrees,
+                                should_have_moved_back,
+                            )
+                            self.assertEqual(
+                                last_action.constraint_degrees,
+                                stored_action.constraint_degrees,
+                                should_have_moved_back,
+                            )
+                        elif isinstance(stored_action, (TurnLeft, TurnRight)):
+                            self.assertEqual(
+                                last_action.rotation_degrees,
+                                -stored_action.rotation_degrees,
+                                should_have_moved_back,
+                            )
+                        elif isinstance(stored_action, MoveForward):
+                            self.assertEqual(
+                                last_action.distance,
+                                -stored_action.distance,
+                                should_have_moved_back,
+                            )
+                        elif isinstance(stored_action, MoveTangentially):
+                            self.assertEqual(
+                                last_action.distance,
+                                -stored_action.distance,
+                                should_have_moved_back,
+                            )
+                            self.assertEqual(
+                                last_action.direction,
+                                stored_action.direction,
+                                should_have_moved_back,
+                            )
+                        elif isinstance(stored_action, OrientHorizontal):
+                            self.assertEqual(
+                                last_action.rotation_degrees,
+                                -stored_action.rotation_degrees,
+                                should_have_moved_back,
+                            )
+                            self.assertEqual(
+                                last_action.left_distance,
+                                -stored_action.left_distance,
+                                should_have_moved_back,
+                            )
+                            self.assertEqual(
+                                last_action.forward_distance,
+                                -stored_action.forward_distance,
+                                should_have_moved_back,
+                            )
+                        elif isinstance(stored_action, OrientVertical):
+                            self.assertEqual(
+                                last_action.rotation_degrees,
+                                -stored_action.rotation_degrees,
+                                should_have_moved_back,
+                            )
+                            self.assertEqual(
+                                last_action.down_distance,
+                                -stored_action.down_distance,
+                                should_have_moved_back,
+                            )
+                            self.assertEqual(
+                                last_action.forward_distance,
+                                -stored_action.forward_distance,
+                                should_have_moved_back,
+                            )
+                        assert exp.model.learning_modules[
+                            0
+                        ].buffer.get_last_obs_processed(), "Should be back on object"
+                        break  # Don't go into exploratory mode
 
     def test_surface_policy_moves_back_to_object(self):
         """Test ability of surface agent to move back to an object.
@@ -878,31 +935,37 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_action_surface_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            exp.model.set_experiment_mode("train")
-            pprint("...training...")
-            exp.pre_epoch()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                exp.model.set_experiment_mode("train")
+                pprint("...training...")
+                exp.pre_epoch()
 
-            # Only do a single episode
-            exp.pre_episode()
+                # Only do a single episode
+                exp.pre_episode()
 
-            pprint("...stepping through observations...")
-            # Take several steps in a fixed direction until we fall off the object, then
-            # ensure we get back on to it
-            for loader_step, observation in enumerate(exp.dataloader):
-                exp.model.step(observation)
+                pprint("...stepping through observations...")
+                # Take several steps in a fixed direction until we fall off the object, then  # noqa: E501
+                # ensure we get back on to it
+                for loader_step, observation in enumerate(exp.dataloader):
+                    exp.model.step(observation)
 
-                if loader_step == 24:  # Last step we take before getting back onto the
-                    # object
-                    assert not exp.model.learning_modules[
-                        0
-                    ].buffer.get_last_obs_processed(), "Should be off object"
+                    if (
+                        loader_step == 24
+                    ):  # Last step we take before getting back onto the
+                        # object
+                        assert not exp.model.learning_modules[
+                            0
+                        ].buffer.get_last_obs_processed(), "Should be off object"
 
-                if loader_step == 25:
-                    assert exp.model.learning_modules[
-                        0
-                    ].buffer.get_last_obs_processed(), "Should be back on object"
-                    break  # Don't go into exploratory mode
+                    if loader_step == 25:
+                        assert exp.model.learning_modules[
+                            0
+                        ].buffer.get_last_obs_processed(), "Should be back on object"
+                        break  # Don't go into exploratory mode
 
     def test_surface_policy_orientation(self):
         """Test ability of surface agent to orient to a point-normal.
@@ -915,44 +978,51 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.rotated_cube_view_config)
-        with MontyObjectRecognitionExperiment(config) as exp:
-            exp.model.set_experiment_mode("train")
-            pprint("...training...")
-            exp.pre_epoch()
-            exp.pre_episode()
+        for c in [
+            config,
+            create_config_with_get_good_view_positioning_procedure(config),
+        ]:
+            with MontyObjectRecognitionExperiment(c) as exp:
+                exp.model.set_experiment_mode("train")
+                pprint("...training...")
+                exp.pre_epoch()
+                exp.pre_episode()
 
-            pprint("...stepping through observations...")
-            for loader_step, observation in enumerate(exp.dataloader):
-                exp.model.step(observation)
-                exp.post_step(loader_step, observation)
+                pprint("...stepping through observations...")
+                for loader_step, observation in enumerate(exp.dataloader):
+                    exp.model.step(observation)
+                    exp.post_step(loader_step, observation)
 
-                if loader_step == 3:  # Surface agent should have re-oriented
-                    break
+                    if loader_step == 3:  # Surface agent should have re-oriented
+                        break
 
-            # Most recently observed point-normal sent to the learning module
-            current_pose = exp.model.learning_modules[0].buffer.get_current_pose(
-                input_channel="first"
-            )
-
-            # Rotate vector representing agent's pointing direction by the agent's
-            # current orientation
-            agent_direction = np.array(
-                hab_utils.quat_rotate_vector(
-                    exp.model.motor_system._state["agent_id_0"]["rotation"],
-                    [
-                        0,
-                        0,
-                        -1,
-                    ],  # The initial direction vector corresponding to the agent's
-                    # orientation
+                # Most recently observed point-normal sent to the learning module
+                current_pose = exp.model.learning_modules[0].buffer.get_current_pose(
+                    input_channel="first"
                 )
-            )
 
-            assert np.all(
-                np.isclose(
-                    current_pose[1], agent_direction * (-1), rtol=1.0e-3, atol=1.0e-2
+                # Rotate vector representing agent's pointing direction by the agent's
+                # current orientation
+                agent_direction = np.array(
+                    hab_utils.quat_rotate_vector(
+                        exp.model.motor_system._state["agent_id_0"]["rotation"],
+                        [
+                            0,
+                            0,
+                            -1,
+                        ],  # The initial direction vector corresponding to the agent's
+                        # orientation
+                    )
                 )
-            ), "Agent should be (approximately) looking down on the point-normal"
+
+                assert np.all(
+                    np.isclose(
+                        current_pose[1],
+                        agent_direction * (-1),
+                        rtol=1.0e-3,
+                        atol=1.0e-2,
+                    )
+                ), "Agent should be (approximately) looking down on the point-normal"
 
     def test_core_following_principal_curvature(self):
         """Test ability of surface agent to follow principal curvature.

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -733,8 +733,8 @@ class PolicyTest(unittest.TestCase):
             ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
             assert perc_on_target_obj >= target_perc_on_target_obj, (
-                f"Initial view is not good enough, {perc_on_target_obj}\
-                vs target of {target_perc_on_target_obj}"
+                f"Initial view is not good enough, {perc_on_target_obj} "
+                f"vs target of {target_perc_on_target_obj}"
             )
 
             points_on_target_obj = semantic == 1

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -1049,9 +1049,7 @@ class PolicyTest(unittest.TestCase):
 
         # Step 5: Pass observation *without* a well defined PC direction
         motor_system._policy.processed_observations = self.fake_obs_pc[4]
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(np.isclose(direction, [-0.13745981, 0.99050735, 0])), (
@@ -1125,9 +1123,7 @@ class PolicyTest(unittest.TestCase):
         # done in graph_matching.py normally
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[0].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(np.isclose(direction, [0.98165657, 0.19065773, 0])), (
@@ -1178,9 +1174,7 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.processed_observations = self.fake_obs_advanced_pc[2]
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[2].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(
@@ -1207,9 +1201,7 @@ class PolicyTest(unittest.TestCase):
         # following PC would cause it to visit the observation 1 again (which it is
         # designed to avoid)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction(
-            motor_system._policy.state
-        )
+        direction = motor_system._policy.tangential_direction(motor_system._state)
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(np.isclose(direction, [0.60958557, 0.79272027, 0])), (

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -1049,7 +1049,9 @@ class PolicyTest(unittest.TestCase):
 
         # Step 5: Pass observation *without* a well defined PC direction
         motor_system._policy.processed_observations = self.fake_obs_pc[4]
-        direction = motor_system._policy.tangential_direction(motor_system._state)
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(np.isclose(direction, [-0.13745981, 0.99050735, 0])), (
@@ -1123,7 +1125,9 @@ class PolicyTest(unittest.TestCase):
         # done in graph_matching.py normally
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[0].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction(motor_system._state)
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(np.isclose(direction, [0.98165657, 0.19065773, 0])), (
@@ -1174,7 +1178,9 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.processed_observations = self.fake_obs_advanced_pc[2]
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[2].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction(motor_system._state)
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(
@@ -1201,7 +1207,9 @@ class PolicyTest(unittest.TestCase):
         # following PC would cause it to visit the observation 1 again (which it is
         # designed to avoid)
         motor_system._policy.tangent_norms.append([0, 0, 1])
-        direction = motor_system._policy.tangential_direction(motor_system._state)
+        direction = motor_system._policy.tangential_direction(
+            motor_system._policy.state
+        )
         # Note the following movement is a random direction deterministcally set by the
         # random seed
         assert np.all(np.isclose(direction, [0.60958557, 0.79272027, 0])), (

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -627,8 +627,8 @@ class PolicyTest(unittest.TestCase):
             ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
             assert perc_on_target_obj >= target_perc_on_target_obj, (
-                f"Initial view is not good enough, {perc_on_target_obj}\
-                vs target of {target_perc_on_target_obj}"
+                f"Initial view is not good enough, {perc_on_target_obj} "
+                f"vs target of {target_perc_on_target_obj}"
             )
 
             points_on_target_obj = semantic == 1
@@ -640,8 +640,8 @@ class PolicyTest(unittest.TestCase):
 
             # Utility policy should not have moved too close to the object
             assert closest_point_on_target_obj > target_closest_point, (
-                f"Initial view is too close, {closest_point_on_target_obj}\
-                vs target of {target_closest_point}"
+                f"Initial view is too close, {closest_point_on_target_obj} "
+                f"vs target of {target_closest_point}"
             )
 
     def test_touch_object_basic_surf_agent(self):
@@ -681,8 +681,8 @@ class PolicyTest(unittest.TestCase):
             closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
             assert closest_point_on_target_obj < 1.0, (
-                f"Should be within a meter of the object,\
-                closest point at {closest_point_on_target_obj}"
+                f"Should be within a meter of the object, "
+                f"closest point at {closest_point_on_target_obj}"
             )
 
             target_closest_point = dict_config["monty_config"]["motor_system_config"][
@@ -691,8 +691,8 @@ class PolicyTest(unittest.TestCase):
 
             # Utility policy should not have moved too close to the object
             assert closest_point_on_target_obj > target_closest_point, (
-                f"Initial position is too close, {closest_point_on_target_obj}\
-                vs target of {target_closest_point}"
+                f"Initial position is too close, {closest_point_on_target_obj} "
+                f"vs target of {target_closest_point}"
             )
 
     def test_get_good_view_multi_object(self):
@@ -756,8 +756,8 @@ class PolicyTest(unittest.TestCase):
             points_on_any_obj = view["semantic"] > 0
             closest_point_on_any_obj = np.min(view["depth"][points_on_any_obj])
             assert closest_point_on_any_obj > target_closest_point / 6, (
-                f"Initial view too cloase to other objects, {closest_point_on_any_obj}"
-                f" vs target of {target_closest_point / 6}"
+                f"Initial view too close to other objects, {closest_point_on_any_obj} "
+                f"vs target of {target_closest_point / 6}"
             )
 
     def test_distant_policy_moves_back_to_object(self):
@@ -953,10 +953,7 @@ class PolicyTest(unittest.TestCase):
 
             assert np.all(
                 np.isclose(
-                    current_pose[1],
-                    agent_direction * (-1),
-                    rtol=1.0e-3,
-                    atol=1.0e-2,
+                    current_pose[1], agent_direction * (-1), rtol=1.0e-3, atol=1.0e-2
                 )
             ), "Agent should be (approximately) looking down on the point-normal"
 

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -475,100 +475,72 @@ class PolicyTest(unittest.TestCase):
     def test_can_run_informed_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.base_dist_agent_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...evaluating...")
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_spiral_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.spiral_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                # TODO: test that no two locations are the same
-                exp.train()
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            # TODO: test that no two locations are the same
+            exp.train()
+            pprint("...evaluating...")
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_dist_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.dist_agent_hypo_driven_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...evaluating...")
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_surface_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.base_surf_agent_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...evaluating...")
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_curv_informed_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.curv_informed_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...evaluating...")
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_surf_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.surf_agent_hypo_driven_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...evaluating...")
+            exp.evaluate()
 
     # @unittest.skip("debugging")
     def test_can_run_multi_lm_dist_agent_hypo_driven_policy(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.dist_agent_hypo_driven_multi_lm_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            pprint("...evaluating...")
+            exp.evaluate()
 
     # ==== MORE INVOLVED TESTS OF ACTION POLICIES ====
 
@@ -634,51 +606,43 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_dist_agent_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("train")
-                exp.pre_epoch()
-                exp.pre_episode()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
+            exp.pre_epoch()
+            exp.pre_episode()
 
-                pprint("...stepping through observations...")
+            pprint("...stepping through observations...")
 
-                # Check the initial view
-                observation = next(exp.dataloader)
-                # TODO M remove the following train-wreck during refactor
-                view = observation[exp.model.motor_system._policy.agent_id][
-                    "view_finder"
-                ]
-                semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
-                perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
+            # Check the initial view
+            observation = next(exp.dataloader)
+            # TODO M remove the following train-wreck during refactor
+            view = observation[exp.model.motor_system._policy.agent_id]["view_finder"]
+            semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
+            perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
 
-                dict_config = config_to_dict(config)
+            dict_config = config_to_dict(config)
 
-                target_perc_on_target_obj = dict_config["monty_config"][
-                    "motor_system_config"
-                ]["motor_system_args"]["policy_args"]["good_view_percentage"]
+            target_perc_on_target_obj = dict_config["monty_config"][
+                "motor_system_config"
+            ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
-                assert perc_on_target_obj >= target_perc_on_target_obj, (
-                    f"Initial view is not good enough, {perc_on_target_obj}\
-                    vs target of {target_perc_on_target_obj}"
-                )
+            assert perc_on_target_obj >= target_perc_on_target_obj, (
+                f"Initial view is not good enough, {perc_on_target_obj}\
+                vs target of {target_perc_on_target_obj}"
+            )
 
-                points_on_target_obj = semantic == 1
-                closest_point_on_target_obj = np.min(
-                    view["depth"][points_on_target_obj]
-                )
+            points_on_target_obj = semantic == 1
+            closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
-                target_closest_point = dict_config["monty_config"][
-                    "motor_system_config"
-                ]["motor_system_args"]["policy_args"]["desired_object_distance"]
+            target_closest_point = dict_config["monty_config"]["motor_system_config"][
+                "motor_system_args"
+            ]["policy_args"]["desired_object_distance"]
 
-                # Utility policy should not have moved too close to the object
-                assert closest_point_on_target_obj > target_closest_point, (
-                    f"Initial view is too close, {closest_point_on_target_obj}\
-                    vs target of {target_closest_point}"
-                )
+            # Utility policy should not have moved too close to the object
+            assert closest_point_on_target_obj > target_closest_point, (
+                f"Initial view is too close, {closest_point_on_target_obj}\
+                vs target of {target_closest_point}"
+            )
 
     def test_touch_object_basic_surf_agent(self):
         """Test ability to move a surface agent to touch an object.
@@ -691,51 +655,45 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_surf_agent_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("train")
-                exp.pre_epoch()
-                exp.pre_episode()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
+            exp.pre_epoch()
+            exp.pre_episode()
 
-                pprint("...stepping through observations...")
+            pprint("...stepping through observations...")
 
-                # Get a first step to allow the surface agent to touch the object
-                observation_pre_touch = next(exp.dataloader)
-                exp.model.step(observation_pre_touch)
+            # Get a first step to allow the surface agent to touch the object
+            observation_pre_touch = next(exp.dataloader)
+            exp.model.step(observation_pre_touch)
 
-                # Check initial view post touch-attempt
-                observation_post_touch = next(exp.dataloader)
+            # Check initial view post touch-attempt
+            observation_post_touch = next(exp.dataloader)
 
-                # TODO M remove the following train-wreck during refactor
-                view = observation_post_touch[exp.model.motor_system._policy.agent_id][
-                    "view_finder"
-                ]
-                dict_config = config_to_dict(config)
+            # TODO M remove the following train-wreck during refactor
+            view = observation_post_touch[exp.model.motor_system._policy.agent_id][
+                "view_finder"
+            ]
+            dict_config = config_to_dict(config)
 
-                points_on_target_obj = (
-                    view["semantic_3d"][:, 3].reshape(view["depth"].shape) == 1
-                )
-                closest_point_on_target_obj = np.min(
-                    view["depth"][points_on_target_obj]
-                )
+            points_on_target_obj = (
+                view["semantic_3d"][:, 3].reshape(view["depth"].shape) == 1
+            )
+            closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
-                assert closest_point_on_target_obj < 1.0, (
-                    f"Should be within a meter of the object,\
-                    closest point at {closest_point_on_target_obj}"
-                )
+            assert closest_point_on_target_obj < 1.0, (
+                f"Should be within a meter of the object,\
+                closest point at {closest_point_on_target_obj}"
+            )
 
-                target_closest_point = dict_config["monty_config"][
-                    "motor_system_config"
-                ]["motor_system_args"]["policy_args"]["desired_object_distance"]
+            target_closest_point = dict_config["monty_config"]["motor_system_config"][
+                "motor_system_args"
+            ]["policy_args"]["desired_object_distance"]
 
-                # Utility policy should not have moved too close to the object
-                assert closest_point_on_target_obj > target_closest_point, (
-                    f"Initial position is too close, {closest_point_on_target_obj}\
-                    vs target of {target_closest_point}"
-                )
+            # Utility policy should not have moved too close to the object
+            assert closest_point_on_target_obj > target_closest_point, (
+                f"Initial position is too close, {closest_point_on_target_obj}\
+                vs target of {target_closest_point}"
+            )
 
     def test_get_good_view_multi_object(self):
         """Test ability to move a distant agent to a good view of an object.
@@ -751,64 +709,56 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.poor_initial_view_multi_object_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
 
-                # Manually go through evaluation (i.e. methods in .evaluate()
-                # and run_epoch())
-                exp.model.set_experiment_mode("eval")
-                exp.pre_epoch()
-                exp.pre_episode()
+            # Manually go through evaluation (i.e. methods in .evaluate()
+            # and run_epoch())
+            exp.model.set_experiment_mode("eval")
+            exp.pre_epoch()
+            exp.pre_episode()
 
-                pprint("...stepping through observations...")
-                # Check the initial view
-                observation = next(exp.dataloader)
-                # TODO M remove the following train-wreck during refactor
-                view = observation[exp.model.motor_system._policy.agent_id][
-                    "view_finder"
-                ]
-                semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
-                perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
+            pprint("...stepping through observations...")
+            # Check the initial view
+            observation = next(exp.dataloader)
+            # TODO M remove the following train-wreck during refactor
+            view = observation[exp.model.motor_system._policy.agent_id]["view_finder"]
+            semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
+            perc_on_target_obj = get_perc_on_obj_semantic(semantic, semantic_id=1)
 
-                dict_config = config_to_dict(config)
-                target_perc_on_target_obj = dict_config["monty_config"][
-                    "motor_system_config"
-                ]["motor_system_args"]["policy_args"]["good_view_percentage"]
+            dict_config = config_to_dict(config)
+            target_perc_on_target_obj = dict_config["monty_config"][
+                "motor_system_config"
+            ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
-                assert perc_on_target_obj >= target_perc_on_target_obj, (
-                    f"Initial view is not good enough, {perc_on_target_obj}\
-                    vs target of {target_perc_on_target_obj}"
-                )
+            assert perc_on_target_obj >= target_perc_on_target_obj, (
+                f"Initial view is not good enough, {perc_on_target_obj}\
+                vs target of {target_perc_on_target_obj}"
+            )
 
-                points_on_target_obj = semantic == 1
-                closest_point_on_target_obj = np.min(
-                    view["depth"][points_on_target_obj]
-                )
+            points_on_target_obj = semantic == 1
+            closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
-                target_closest_point = dict_config["monty_config"][
-                    "motor_system_config"
-                ]["motor_system_args"]["policy_args"]["desired_object_distance"]
+            target_closest_point = dict_config["monty_config"]["motor_system_config"][
+                "motor_system_args"
+            ]["policy_args"]["desired_object_distance"]
 
-                # Utility policy should not have moved too close to the object
-                assert closest_point_on_target_obj > target_closest_point, (
-                    f"Initial view is too close to target, {closest_point_on_target_obj}"  # noqa: E501
-                    f" vs target of {target_closest_point}"
-                )
+            # Utility policy should not have moved too close to the object
+            assert closest_point_on_target_obj > target_closest_point, (
+                f"Initial view is too close to target, {closest_point_on_target_obj}"
+                f" vs target of {target_closest_point}"
+            )
 
-                # Also calculate closest point on *any* object so that we don't get
-                # too close and clip into objects; NB that any object will have a
-                # semantic ID > 0
-                points_on_any_obj = view["semantic"] > 0
-                closest_point_on_any_obj = np.min(view["depth"][points_on_any_obj])
-                assert closest_point_on_any_obj > target_closest_point / 6, (
-                    f"Initial view too cloase to other objects, {closest_point_on_any_obj}"  # noqa: E501
-                    f" vs target of {target_closest_point / 6}"
-                )
+            # Also calculate closest point on *any* object so that we don't get
+            # too close and clip into objects; NB that any object will have a
+            # semantic ID > 0
+            points_on_any_obj = view["semantic"] > 0
+            closest_point_on_any_obj = np.min(view["depth"][points_on_any_obj])
+            assert closest_point_on_any_obj > target_closest_point / 6, (
+                f"Initial view too cloase to other objects, {closest_point_on_any_obj}"
+                f" vs target of {target_closest_point / 6}"
+            )
 
     def test_distant_policy_moves_back_to_object(self):
         """Test ability of distant agent to move back to an object.
@@ -821,108 +771,104 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_action_distant_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("train")
-                pprint("...training...")
-                exp.pre_epoch()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            exp.pre_epoch()
 
-                # Only do a single episode
-                exp.pre_episode()
+            # Only do a single episode
+            exp.pre_episode()
 
-                pprint("...stepping through observations...")
-                # Manually step through part of run_episode function
-                for loader_step, observation in enumerate(exp.dataloader):
-                    exp.model.step(observation)
+            pprint("...stepping through observations...")
+            # Manually step through part of run_episode function
+            for loader_step, observation in enumerate(exp.dataloader):
+                exp.model.step(observation)
 
-                    last_action = exp.model.motor_system.last_action
+                last_action = exp.model.motor_system.last_action
 
-                    if loader_step == 3:
-                        stored_action = last_action
-                        assert not exp.model.learning_modules[
-                            0
-                        ].buffer.get_last_obs_processed(), "Should be off object"
+                if loader_step == 3:
+                    stored_action = last_action
+                    assert not exp.model.learning_modules[
+                        0
+                    ].buffer.get_last_obs_processed(), "Should be off object"
 
-                    if loader_step == 4:
-                        should_have_moved_back = (
-                            "Should have moved back by reversing last movement"
+                if loader_step == 4:
+                    should_have_moved_back = (
+                        "Should have moved back by reversing last movement"
+                    )
+                    self.assertIsInstance(
+                        last_action, type(stored_action), should_have_moved_back
+                    )
+                    if isinstance(stored_action, (LookDown, LookUp)):
+                        self.assertEqual(
+                            last_action.rotation_degrees,
+                            -stored_action.rotation_degrees,
+                            should_have_moved_back,
                         )
-                        self.assertIsInstance(
-                            last_action, type(stored_action), should_have_moved_back
+                        self.assertEqual(
+                            last_action.constraint_degrees,
+                            stored_action.constraint_degrees,
+                            should_have_moved_back,
                         )
-                        if isinstance(stored_action, (LookDown, LookUp)):
-                            self.assertEqual(
-                                last_action.rotation_degrees,
-                                -stored_action.rotation_degrees,
-                                should_have_moved_back,
-                            )
-                            self.assertEqual(
-                                last_action.constraint_degrees,
-                                stored_action.constraint_degrees,
-                                should_have_moved_back,
-                            )
-                        elif isinstance(stored_action, (TurnLeft, TurnRight)):
-                            self.assertEqual(
-                                last_action.rotation_degrees,
-                                -stored_action.rotation_degrees,
-                                should_have_moved_back,
-                            )
-                        elif isinstance(stored_action, MoveForward):
-                            self.assertEqual(
-                                last_action.distance,
-                                -stored_action.distance,
-                                should_have_moved_back,
-                            )
-                        elif isinstance(stored_action, MoveTangentially):
-                            self.assertEqual(
-                                last_action.distance,
-                                -stored_action.distance,
-                                should_have_moved_back,
-                            )
-                            self.assertEqual(
-                                last_action.direction,
-                                stored_action.direction,
-                                should_have_moved_back,
-                            )
-                        elif isinstance(stored_action, OrientHorizontal):
-                            self.assertEqual(
-                                last_action.rotation_degrees,
-                                -stored_action.rotation_degrees,
-                                should_have_moved_back,
-                            )
-                            self.assertEqual(
-                                last_action.left_distance,
-                                -stored_action.left_distance,
-                                should_have_moved_back,
-                            )
-                            self.assertEqual(
-                                last_action.forward_distance,
-                                -stored_action.forward_distance,
-                                should_have_moved_back,
-                            )
-                        elif isinstance(stored_action, OrientVertical):
-                            self.assertEqual(
-                                last_action.rotation_degrees,
-                                -stored_action.rotation_degrees,
-                                should_have_moved_back,
-                            )
-                            self.assertEqual(
-                                last_action.down_distance,
-                                -stored_action.down_distance,
-                                should_have_moved_back,
-                            )
-                            self.assertEqual(
-                                last_action.forward_distance,
-                                -stored_action.forward_distance,
-                                should_have_moved_back,
-                            )
-                        assert exp.model.learning_modules[
-                            0
-                        ].buffer.get_last_obs_processed(), "Should be back on object"
-                        break  # Don't go into exploratory mode
+                    elif isinstance(stored_action, (TurnLeft, TurnRight)):
+                        self.assertEqual(
+                            last_action.rotation_degrees,
+                            -stored_action.rotation_degrees,
+                            should_have_moved_back,
+                        )
+                    elif isinstance(stored_action, MoveForward):
+                        self.assertEqual(
+                            last_action.distance,
+                            -stored_action.distance,
+                            should_have_moved_back,
+                        )
+                    elif isinstance(stored_action, MoveTangentially):
+                        self.assertEqual(
+                            last_action.distance,
+                            -stored_action.distance,
+                            should_have_moved_back,
+                        )
+                        self.assertEqual(
+                            last_action.direction,
+                            stored_action.direction,
+                            should_have_moved_back,
+                        )
+                    elif isinstance(stored_action, OrientHorizontal):
+                        self.assertEqual(
+                            last_action.rotation_degrees,
+                            -stored_action.rotation_degrees,
+                            should_have_moved_back,
+                        )
+                        self.assertEqual(
+                            last_action.left_distance,
+                            -stored_action.left_distance,
+                            should_have_moved_back,
+                        )
+                        self.assertEqual(
+                            last_action.forward_distance,
+                            -stored_action.forward_distance,
+                            should_have_moved_back,
+                        )
+                    elif isinstance(stored_action, OrientVertical):
+                        self.assertEqual(
+                            last_action.rotation_degrees,
+                            -stored_action.rotation_degrees,
+                            should_have_moved_back,
+                        )
+                        self.assertEqual(
+                            last_action.down_distance,
+                            -stored_action.down_distance,
+                            should_have_moved_back,
+                        )
+                        self.assertEqual(
+                            last_action.forward_distance,
+                            -stored_action.forward_distance,
+                            should_have_moved_back,
+                        )
+                    assert exp.model.learning_modules[
+                        0
+                    ].buffer.get_last_obs_processed(), "Should be back on object"
+                    break  # Don't go into exploratory mode
 
     def test_surface_policy_moves_back_to_object(self):
         """Test ability of surface agent to move back to an object.
@@ -935,37 +881,31 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_action_surface_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("train")
-                pprint("...training...")
-                exp.pre_epoch()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            exp.pre_epoch()
 
-                # Only do a single episode
-                exp.pre_episode()
+            # Only do a single episode
+            exp.pre_episode()
 
-                pprint("...stepping through observations...")
-                # Take several steps in a fixed direction until we fall off the object, then  # noqa: E501
-                # ensure we get back on to it
-                for loader_step, observation in enumerate(exp.dataloader):
-                    exp.model.step(observation)
+            pprint("...stepping through observations...")
+            # Take several steps in a fixed direction until we fall off the object, then
+            # ensure we get back on to it
+            for loader_step, observation in enumerate(exp.dataloader):
+                exp.model.step(observation)
 
-                    if (
-                        loader_step == 24
-                    ):  # Last step we take before getting back onto the
-                        # object
-                        assert not exp.model.learning_modules[
-                            0
-                        ].buffer.get_last_obs_processed(), "Should be off object"
+                if loader_step == 24:  # Last step we take before getting back onto the
+                    # object
+                    assert not exp.model.learning_modules[
+                        0
+                    ].buffer.get_last_obs_processed(), "Should be off object"
 
-                    if loader_step == 25:
-                        assert exp.model.learning_modules[
-                            0
-                        ].buffer.get_last_obs_processed(), "Should be back on object"
-                        break  # Don't go into exploratory mode
+                if loader_step == 25:
+                    assert exp.model.learning_modules[
+                        0
+                    ].buffer.get_last_obs_processed(), "Should be back on object"
+                    break  # Don't go into exploratory mode
 
     def test_surface_policy_orientation(self):
         """Test ability of surface agent to orient to a point-normal.
@@ -978,51 +918,47 @@ class PolicyTest(unittest.TestCase):
         """
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.rotated_cube_view_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("train")
-                pprint("...training...")
-                exp.pre_epoch()
-                exp.pre_episode()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            exp.pre_epoch()
+            exp.pre_episode()
 
-                pprint("...stepping through observations...")
-                for loader_step, observation in enumerate(exp.dataloader):
-                    exp.model.step(observation)
-                    exp.post_step(loader_step, observation)
+            pprint("...stepping through observations...")
+            for loader_step, observation in enumerate(exp.dataloader):
+                exp.model.step(observation)
+                exp.post_step(loader_step, observation)
 
-                    if loader_step == 3:  # Surface agent should have re-oriented
-                        break
+                if loader_step == 3:  # Surface agent should have re-oriented
+                    break
 
-                # Most recently observed point-normal sent to the learning module
-                current_pose = exp.model.learning_modules[0].buffer.get_current_pose(
-                    input_channel="first"
+            # Most recently observed point-normal sent to the learning module
+            current_pose = exp.model.learning_modules[0].buffer.get_current_pose(
+                input_channel="first"
+            )
+
+            # Rotate vector representing agent's pointing direction by the agent's
+            # current orientation
+            agent_direction = np.array(
+                hab_utils.quat_rotate_vector(
+                    exp.model.motor_system._state["agent_id_0"]["rotation"],
+                    [
+                        0,
+                        0,
+                        -1,
+                    ],  # The initial direction vector corresponding to the agent's
+                    # orientation
                 )
+            )
 
-                # Rotate vector representing agent's pointing direction by the agent's
-                # current orientation
-                agent_direction = np.array(
-                    hab_utils.quat_rotate_vector(
-                        exp.model.motor_system._state["agent_id_0"]["rotation"],
-                        [
-                            0,
-                            0,
-                            -1,
-                        ],  # The initial direction vector corresponding to the agent's
-                        # orientation
-                    )
+            assert np.all(
+                np.isclose(
+                    current_pose[1],
+                    agent_direction * (-1),
+                    rtol=1.0e-3,
+                    atol=1.0e-2,
                 )
-
-                assert np.all(
-                    np.isclose(
-                        current_pose[1],
-                        agent_direction * (-1),
-                        rtol=1.0e-3,
-                        atol=1.0e-2,
-                    )
-                ), "Agent should be (approximately) looking down on the point-normal"
+            ), "Agent should be (approximately) looking down on the point-normal"
 
     def test_core_following_principal_curvature(self):
         """Test ability of surface agent to follow principal curvature.
@@ -1496,6 +1432,74 @@ class PolicyTest(unittest.TestCase):
         assert np.all(
             np.isclose(agent_direction_hab_3, [-0.965738, 0.09413407, -0.24184476])
         ), "Habitat pose is not as expected"
+
+
+class PolicyTestWithGetGoodViewPositioningProcedure(PolicyTest):
+    def setUp(self):
+        super().setUp()
+        self.base_dist_agent_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.base_dist_agent_config
+            )
+        )
+        self.spiral_config = create_config_with_get_good_view_positioning_procedure(
+            self.spiral_config
+        )
+        self.dist_agent_hypo_driven_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.dist_agent_hypo_driven_config
+            )
+        )
+        self.base_surf_agent_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.base_surf_agent_config
+            )
+        )
+        self.curv_informed_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.curv_informed_config
+            )
+        )
+        self.surf_agent_hypo_driven_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.surf_agent_hypo_driven_config
+            )
+        )
+        self.dist_agent_hypo_driven_multi_lm_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.dist_agent_hypo_driven_multi_lm_config
+            )
+        )
+        self.fixed_action_distant_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.fixed_action_distant_config
+            )
+        )
+        self.fixed_action_surface_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.fixed_action_surface_config
+            )
+        )
+        self.poor_initial_view_dist_agent_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.poor_initial_view_dist_agent_config
+            )
+        )
+        self.poor_initial_view_surf_agent_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.poor_initial_view_surf_agent_config
+            )
+        )
+        self.poor_initial_view_multi_object_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.poor_initial_view_multi_object_config
+            )
+        )
+        self.rotated_cube_view_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.rotated_cube_view_config
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/run_parallel_test.py
+++ b/tests/unit/run_parallel_test.py
@@ -244,8 +244,7 @@ class RunParallelTest(unittest.TestCase):
 
         # In serial like normal
         pprint("...Setting up serial experiment...")
-        config = self.eval_config
-        with MontyObjectRecognitionExperiment(config) as eval_exp:
+        with MontyObjectRecognitionExperiment(self.eval_config) as eval_exp:
             pprint("...Evaluating in serial...")
             eval_exp.evaluate()
 
@@ -293,8 +292,7 @@ class RunParallelTest(unittest.TestCase):
 
         # In serial like normal
         pprint("...Setting up serial experiment...")
-        config = self.eval_config_lt
-        with MontyObjectRecognitionExperiment(config) as eval_exp_lt:
+        with MontyObjectRecognitionExperiment(self.eval_config_lt) as eval_exp_lt:
             pprint("...Evaluating in serial...")
             eval_exp_lt.evaluate()
 
@@ -331,8 +329,7 @@ class RunParallelTest(unittest.TestCase):
 
         # In serial like normal
         pprint("...Setting up serial experiment...")
-        config = self.eval_config_gt
-        with MontyObjectRecognitionExperiment(config) as eval_exp_gt:
+        with MontyObjectRecognitionExperiment(self.eval_config_gt) as eval_exp_gt:
             pprint("...Evaluating in serial...")
             eval_exp_gt.evaluate()
 

--- a/tests/unit/sensor_module_test.py
+++ b/tests/unit/sensor_module_test.py
@@ -153,11 +153,7 @@ class SensorModuleTest(unittest.TestCase):
 
                 pprint(exp.model.sensor_module_outputs)
                 for feature in self.tested_features:
-                    if feature in [
-                        "pose_vectors",
-                        "pose_fully_defined",
-                        "on_object",
-                    ]:
+                    if feature in ["pose_vectors", "pose_fully_defined", "on_object"]:
                         self.assertIn(
                             feature,
                             exp.model.sensor_module_outputs[

--- a/tests/unit/sensor_module_test.py
+++ b/tests/unit/sensor_module_test.py
@@ -21,8 +21,6 @@ from tbp.monty.frameworks.config_utils.config_args import (
     PatchAndViewMontyConfig,
 )
 from tbp.monty.frameworks.config_utils.make_dataset_configs import (
-    EnvironmentDataLoaderPerObjectEvalArgs,
-    EnvironmentDataLoaderPerObjectTrainArgs,
     ExperimentArgs,
     InformedEnvironmentDataLoaderEvalArgs,
     InformedEnvironmentDataLoaderTrainArgs,

--- a/tests/unit/sensor_module_test.py
+++ b/tests/unit/sensor_module_test.py
@@ -128,74 +128,78 @@ class SensorModuleTest(unittest.TestCase):
         """Check that correct features are returned by sensor module."""
         print("...parsing experiment...")
         base_config = copy.deepcopy(self.sensor_feature_test)
-        for c in [
-            base_config,
-            create_config_with_get_good_view_positioning_procedure(base_config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("train")
-                pprint("...training...")
-                exp.pre_epoch()
-                exp.pre_episode()
-                for step, observation in enumerate(exp.dataloader):
-                    exp.model.step(observation)
-                    if step == 1:
-                        break
+        with MontyObjectRecognitionExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            exp.pre_epoch()
+            exp.pre_episode()
+            for step, observation in enumerate(exp.dataloader):
+                exp.model.step(observation)
+                if step == 1:
+                    break
 
     # @unittest.skip("debugging")
     def test_features_in_sensor(self):
         """Check that correct features are returned by sensor module."""
         print("...parsing experiment...")
         base_config = copy.deepcopy(self.sensor_feature_test)
-        for c in [
-            base_config,
-            create_config_with_get_good_view_positioning_procedure(base_config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                exp.model.set_experiment_mode("train")
-                pprint("...training...")
-                exp.pre_epoch()
-                exp.pre_episode()
-                for _, observation in enumerate(exp.dataloader):
-                    exp.model.aggregate_sensory_inputs(observation)
+        with MontyObjectRecognitionExperiment(base_config) as exp:
+            exp.model.set_experiment_mode("train")
+            pprint("...training...")
+            exp.pre_epoch()
+            exp.pre_episode()
+            for _, observation in enumerate(exp.dataloader):
+                exp.model.aggregate_sensory_inputs(observation)
 
-                    pprint(exp.model.sensor_module_outputs)
-                    for feature in self.tested_features:
-                        if feature in [
-                            "pose_vectors",
-                            "pose_fully_defined",
-                            "on_object",
-                        ]:
-                            self.assertIn(
-                                feature,
-                                exp.model.sensor_module_outputs[
-                                    0
-                                ].morphological_features.keys(),
-                                f"{feature} not returned by SM",
-                            )
-                        else:
-                            self.assertIn(
-                                feature,
-                                exp.model.sensor_module_outputs[
-                                    0
-                                ].non_morphological_features.keys(),
-                                f"{feature} not returned by SM",
-                            )
-                    break
+                pprint(exp.model.sensor_module_outputs)
+                for feature in self.tested_features:
+                    if feature in [
+                        "pose_vectors",
+                        "pose_fully_defined",
+                        "on_object",
+                    ]:
+                        self.assertIn(
+                            feature,
+                            exp.model.sensor_module_outputs[
+                                0
+                            ].morphological_features.keys(),
+                            f"{feature} not returned by SM",
+                        )
+                    else:
+                        self.assertIn(
+                            feature,
+                            exp.model.sensor_module_outputs[
+                                0
+                            ].non_morphological_features.keys(),
+                            f"{feature} not returned by SM",
+                        )
+                break
 
     def test_feature_change_sm(self):
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.feature_change_sensor_config)
-        for c in [
-            config,
-            create_config_with_get_good_view_positioning_procedure(config),
-        ]:
-            with MontyObjectRecognitionExperiment(c) as exp:
-                pprint("...training...")
-                exp.train()
-                # TODO: test that only new features are given to LM
-                pprint("...evaluating...")
-                exp.evaluate()
+        with MontyObjectRecognitionExperiment(config) as exp:
+            pprint("...training...")
+            exp.train()
+            # TODO: test that only new features are given to LM
+            pprint("...evaluating...")
+            exp.evaluate()
+
+
+class SensorModuleTestWithGetGoodViewPositioningProcedure(SensorModuleTest):
+    def setUp(self):
+        super().setUp()
+        self.base = create_config_with_get_good_view_positioning_procedure(self.base)
+        self.sensor_feature_test = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.sensor_feature_test
+            )
+        )
+        self.feature_change_sensor_config = (
+            create_config_with_get_good_view_positioning_procedure(
+                self.feature_change_sensor_config
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fyi @scottcanoe @hlee9212 @ramyamounir 

> [!NOTE]
> When reviewing, I highly recommend the "hide whitespace" view option for looking through the test changes
> <img width="438" alt="Screenshot 2025-04-23 at 14 45 40" src="https://github.com/user-attachments/assets/b66087ca-8b6f-47fa-afb1-5627d70f3b8b" />


This pull request extracts the `GetGoodView` positioning procedure (as a policy) from the `InformedEnvironmentDataLoader`. 

Note that this PR _only_ extracts the positioning procedure as a policy. It does not separate positioning procedures from policies. This is future work. This requires that `GetGoodView` take in unused arguments on initialization and invoke its `positioning_call` method. This awkwardness will be removed when positioning procedures are made distinct from policies.

This code from updated `InformedEnvironemntDataLoader.get_good_view` demonstrates how dataloaders will use positioning procedures in general:
```python
_configured_policy = self.motor_system._policy

self.motor_system._policy = GetGoodView(...)
result = self.motor_system._policy.positioning_call(
    self._observation, self.motor_system._state
)
while not result.terminated and not result.truncated:
    for action in result.actions:
        self._observation, proprio_state = self.dataset[action]
        self.motor_system._state = (
            MotorSystemState(proprio_state) if proprio_state else None
        )

    result = self.motor_system._policy.positioning_call(
        self._observation, self.motor_system._state
    )

self.motor_system._policy = _configured_policy
```
While the above code works within the current procedures-are-policies constraint, in the future, this will look like:
```python
procedure = GetGoodView(...)
result = procedure(observation, proprioceptive_state)
while not result.terminated and not result.truncated:
  for action in result.actions:
    observation, proprioceptive_state = self.dataset[action]
  result = procedure(observation, proprioceptive_state)
```
The goal is that at the end of any number of positioning procedures, the data loader will return `(observation, proprioceptive_state)`, which will be Monty's initial state.

It is worth highlighting that `positioning_call` takes in different arguments than `dynamic|predefined_call` policy methods. This further reinforces the idea that positioning procedures differ from motor policies.

As another highlight, the essence of `GetGoodView` is now captured in `GetGoodView.positioning_call`:
```python
    def positioning_call(
        self,
        observation: Mapping,
        state: Optional[MotorSystemState] = None,
    ) -> PositioningProcedureResult:
        if self._multiple_objects_present:
            on_target_object = self.is_on_target_object(observation)
            if not on_target_object:
                return PositioningProcedureResult(
                    actions=self.orient_to_object(observation, state)
                )

        if self._allow_translation:
            action = self.move_close_enough(observation)
            if action is not None:
                logging.debug("Moving closer to object.")
                return PositioningProcedureResult(actions=[action])

        on_target_object = self.is_on_target_object(observation)
        if (
            not on_target_object
            and self._num_orientation_attempts < self._max_orientation_attempts
        ):
            self._num_orientation_attempts += 1
            return PositioningProcedureResult(
                actions=self.orient_to_object(observation, state)
            )

        if on_target_object:
            return PositioningProcedureResult(success=True, terminated=True)
        else:
            return PositioningProcedureResult(truncated=True)
```
Notice that we `return` in multiple places. `GetGoodView` effectively functions as a state machine that we call repeatedly until done. This is essentially what data loaders are currently doing, but instead of `return`, the data loaders apply the outputs to the environment, for example:
```python
                actions = self.motor_system._policy.orient_to_object(
                    self._observation,
                    sensor_id,
                    target_semantic_id=self.primary_target["semantic_id"],
                    multiple_objects_present=multiple_objects_present,
                    state=self.motor_system._state,
                )
                for action in actions:
                    self._observation, proprio_state = self.dataset[action]
                    self.motor_system._state = (
                        MotorSystemState(proprio_state) if proprio_state else None
                    )
```
At a high level, both code paths do the same thing, but the action actuation is _outside_ the positioning procedure instead of within it.

## Proving that it works

A feature flag `use_get_good_view_positioning_procedure` is added to the `InformedEnvironmentDataLoader` so that we can run the old and new code paths and verify that there is no difference.

Tests are updated so that they execute both code paths.

> [!NOTE]
> While we have both code paths, tests take twice as long, since we run most of them twice.

We have two paths forward:
1. Merge this PR as is, followed by another PR to remove the feature flag and the old get_good_view code.
2. Remove feature flag and get_good_view code as part of this PR, all at once.

I chose path 1 by default as it allows us to run some benchmarks as long as we want by flipping the feature flag back and forth and ensuring everything works as intended. Path 2 goes all-in without verifying that all benchmarks work as intended.

## Existing bug?

Notice that in `GetGoodView.positioning_call`, we do not limit the number of orientation attempts when we have multiple objects or when we allow translation. This is copied as the current behavior. However, that could go into an infinite loop in a pathological case.