### PR TITLE
style: enable ruff format checking

### DIFF
--- a/.github/workflows/monty.yml
+++ b/.github/workflows/monty.yml
@@ -175,7 +175,8 @@ jobs:
           export PATH="$HOME/miniconda/bin:$PATH"
           source activate tbp.monty
           mkdir -p test_results/ruff
-          ruff check --verbose src tests benchmarks
+          ruff check src tests benchmarks
+          ruff format --check src tests benchmarks
 
   check_types_monty:
     name: check-types-monty

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -100,6 +100,7 @@ jobs:
           export PATH="$HOME/miniconda/bin:$PATH"
           source activate tbp.monty
           ruff check tools
+          ruff format --check tools
       - name: Check types
         if: ${{ steps.should_run.outputs.run_test_tools == 'true' }}
         working-directory: tbp.monty

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -43,13 +43,13 @@ Before submitting a Pull Request, you should set up your development environment
 ## Additional Recommendations for Code Changes
 
 - It is recommended to **add unit tests for any new feature** you implement. This makes sure that your feature continues to function as intended when other people (or you) make future changes to the code. To get a detailed coverage report use `pytest --cov --cov-report html`.
-- **Run `pytest` and `ruff check`** to make sure your changes don't break any existing code and adhere to our [style requirements](style-guide.md). If your code doesn't pass these, it can not be merged.
+- **Run `pytest`, `ruff check`, and `ruff format`** to make sure your changes don't break any existing code and adhere to our [style requirements](style-guide.md). If your code doesn't pass these, it can not be merged.
 - Make sure that your **code is properly documented**. Please refer to our [Style Guide](style-guide.md) for instructions on how to format your comments.
 - If applicable, please also **update or add to the documentation on readme.com**. For instructions on how to do this, see our [guide on contributing documentation](documentation.md).
 - **Use callbacks for logging**, and don’t put control logic into logging functions.
 - Note that the random seed in Monty is handled using a generator object that is passed
   where needed, i.e. by initializing the random number generator with
-  ```
+  ```python
   rng = np.random.RandomState(experiment_args["seed"])
   ```
   This rng is then passed to the various classes, and can be accessed in the sensor

--- a/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
+++ b/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
@@ -413,9 +413,11 @@ def get_omniglot_train_dataloader(num_versions, alphabet_ids, data_path=None):
         alphabet = alphabet_folders[a_idx]
         characters_in_a = list(os.listdir(data_path + "images_background/" + alphabet))
         for c_idx, character in enumerate(characters_in_a):
-            versions_of_char = list(os.listdir(
+            versions_of_char = list(
+                os.listdir(
                     data_path + "images_background/" + alphabet + "/" + character
-                ))
+                )
+            )
             for v_idx in range(len(versions_of_char)):
                 if v_idx < num_versions:
                     all_alphabet_idx.append(a_idx)
@@ -464,9 +466,11 @@ def get_omniglot_eval_dataloader(
         characters_in_a = list(os.listdir(data_path + "images_background/" + alphabet))
         for c_idx, character in enumerate(characters_in_a):
             if num_versions is None:
-                versions_of_char = list(os.listdir(
+                versions_of_char = list(
+                    os.listdir(
                         data_path + "images_background/" + alphabet + "/" + character
-                    ))
+                    )
+                )
                 num_versions = len(versions_of_char) - start_at_version
 
             for v_idx in range(num_versions + start_at_version):

--- a/src/tbp/monty/frameworks/environments/embodied_environment.py
+++ b/src/tbp/monty/frameworks/environments/embodied_environment.py
@@ -19,6 +19,7 @@ __all__ = ["EmbodiedEnvironment", "ActionSpace"]
 VectorXYZ = Tuple[float, float, float]
 QuaternionWXYZ = Tuple[float, float, float, float]
 
+
 class ActionSpace(collections.abc.Container):
     """Represents the environment action space."""
 

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -190,7 +190,7 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
         mlh_id = mlh["graph_id"].split("_")
         for word in mlh_id:
             new_text += r"$\bf{" + word + "}$ "
-        new_text += f"with evidence {np.round(mlh['evidence'],2)}\n\n"
+        new_text += f"with evidence {np.round(mlh['evidence'], 2)}\n\n"
         pms = self.model.learning_modules[0].get_possible_matches()
         graph_ids, evidences = self.model.learning_modules[
             0
@@ -203,12 +203,12 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
             new_text += "2nd MLH: "
             for word in second_id:
                 new_text += r"$\bf{" + word + "}$ "
-            new_text += f"with evidence {np.round(evidences[top_indices[1]],2)}\n\n"
+            new_text += f"with evidence {np.round(evidences[top_indices[1]], 2)}\n\n"
 
         new_text += r"$\bf{Possible}$ $\bf{matches:}$"
         for gid, ev in zip(graph_ids, evidences):
             if gid in pms:
-                new_text += f"\n{gid}: {np.round(ev,1)}"
+                new_text += f"\n{gid}: {np.round(ev, 1)}"
 
         self.text = self.ax[0].text(0, pos + 30, new_text, va="top")
 

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -30,6 +30,7 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
     NOTE: This is not really an experiment, it is more a pretraining step to generate
     models that can then be loaded at the beginning of an experiment.
     """
+
     def __init__(self, config):
         # If we just add "pretrained" to dir at save time, then logs are stored in one
         # place and models in another. Changing the config ensures every reference to

--- a/src/tbp/monty/frameworks/experiments/profile.py
+++ b/src/tbp/monty/frameworks/experiments/profile.py
@@ -65,8 +65,10 @@ class ProfileExperimentMixin:
         if cls.__bases__[0] is not ProfileExperimentMixin:
             raise TypeError("ProfileExperimentMixin must be leftmost base class.")
         if not any(issubclass(b, MontyExperiment) for b in cls.__bases__):
-            raise TypeError("ProfileExperimentMixin must be mixed in with a subclass "
-                            "of MontyExperiment.")
+            raise TypeError(
+                "ProfileExperimentMixin must be mixed in with a subclass "
+                "of MontyExperiment."
+            )
 
     def make_profile_dir(self):
         self.profile_dir = os.path.join(self.output_dir, "profile")

--- a/src/tbp/monty/frameworks/loggers/wandb_handlers.py
+++ b/src/tbp/monty/frameworks/loggers/wandb_handlers.py
@@ -143,6 +143,7 @@ class BasicWandbTableStatsHandler(WandbHandler):
         wandb.log({stats_table: table}, commit=False)
         self.report_count += 1
 
+
 class DetailedWandbTableStatsHandler(BasicWandbTableStatsHandler):
     """Log LM stats and actions to wandb as tables.
 

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -1078,8 +1078,8 @@ class EvidenceGraphLM(GraphLM):
         assert not np.isnan(np.max(self.evidence[graph_id])), "evidence contains NaN."
         logging.debug(
             f"evidence update for {graph_id} took "
-            f"{np.round(end_time - start_time,2)} seconds."
-            f" New max evidence: {np.round(np.max(self.evidence[graph_id]),3)}"
+            f"{np.round(end_time - start_time, 2)} seconds."
+            f" New max evidence: {np.round(np.max(self.evidence[graph_id]), 3)}"
         )
 
     def _update_evidence_with_vote(self, state_votes, graph_id):
@@ -1168,7 +1168,7 @@ class EvidenceGraphLM(GraphLM):
             The location evidence.
         """
         logging.debug(
-            f"Calculating evidence for {graph_id} using input from " f"{input_channel}"
+            f"Calculating evidence for {graph_id} using input from {input_channel}"
         )
 
         pose_transformed_features = rotate_pose_dependent_features(
@@ -1596,7 +1596,7 @@ class EvidenceGraphLM(GraphLM):
         all_possible_locations = np.zeros((1, 3))
         all_possible_rotations = np.zeros((1, 3, 3))
 
-        logging.debug("Determining possible poses using input from " f"{input_channel}")
+        logging.debug(f"Determining possible poses using input from {input_channel}")
         node_directions = self.graph_memory.get_rotation_features_at_all_nodes(
             graph_id, input_channel
         )
@@ -1738,7 +1738,7 @@ class EvidenceGraphLM(GraphLM):
                 mlh["graph_id"] = "new_object0"
             logging.info(
                 f"current most likely hypothesis: {mlh['graph_id']} "
-                f"with evidence {np.round(mlh['evidence'],2)}"
+                f"with evidence {np.round(mlh['evidence'], 2)}"
             )
         return mlh
 
@@ -1763,9 +1763,9 @@ class EvidenceGraphLM(GraphLM):
         ) and self.evidence_update_threshold.endswith("%"):
             percentage_str = self.evidence_update_threshold.strip("%")
             percentage = float(percentage_str)
-            assert (
-                percentage >= 0 and percentage <= 100
-            ), "Percentage must be between 0 and 100"
+            assert percentage >= 0 and percentage <= 100, (
+                "Percentage must be between 0 and 100"
+            )
             max_global_evidence = self.current_mlh["evidence"]
             x_percent_of_max = max_global_evidence * (percentage / 100)
             return max_global_evidence - x_percent_of_max

--- a/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
@@ -108,7 +108,7 @@ class EncoderSDR:
     ):
         if sdr_on_bits >= sdr_length or sdr_on_bits <= 0:
             logging.warning(
-                f"Invalid sparsity: sdr_on_bits set to 2% ({round(sdr_length*0.02)})"
+                f"Invalid sparsity: sdr_on_bits set to 2% ({round(sdr_length * 0.02)})"
             )
             sdr_on_bits = round(sdr_length * 0.02)
 

--- a/src/tbp/monty/frameworks/models/feature_location_matching.py
+++ b/src/tbp/monty/frameworks/models/feature_location_matching.py
@@ -194,7 +194,7 @@ class FeatureGraphLM(GraphLM):
                             self.possible_poses[possible_obj].pop(path_id)
                             removed_locations = np.vstack([removed_locations, location])
                     logging.info(
-                        f"removed {removed_locations.shape[0]-1} locations from "
+                        f"removed {removed_locations.shape[0] - 1} locations from "
                         f"possible matches for {possible_obj}"
                     )
                     # NOTE: could also use votes to add hypotheses -> increase
@@ -424,13 +424,13 @@ class FeatureGraphLM(GraphLM):
             self.possible_poses[graph_id] = new_possible_poses
             if len(self.possible_poses[graph_id]) < 10:
                 logging.info(
-                    f"possible poses after matching for \
-                        {graph_id}: {self.get_possible_poses()[graph_id]}"
+                    f"possible poses after matching for "
+                    f"{graph_id}: {self.get_possible_poses()[graph_id]}"
                 )
         self.possible_paths[graph_id] = new_possible_paths
         logging.debug(
-            f"possible paths after matching for \
-                {graph_id}: {len(self.possible_paths[graph_id])}"
+            f"possible paths after matching for "
+            f"{graph_id}: {len(self.possible_paths[graph_id])}"
         )
         return len(self.possible_paths[graph_id]) > 0
 

--- a/src/tbp/monty/frameworks/models/goal_state_generation.py
+++ b/src/tbp/monty/frameworks/models/goal_state_generation.py
@@ -246,8 +246,8 @@ class GraphGoalStateGenerator(GoalStateGenerator):
                     and state_b.morphological_features is not None
                 ):
                     raise NotImplementedError(
-                        "TODO M implement pose-vector comparisons that handle symmetry\
-                            of objects"
+                        "TODO M implement pose-vector comparisons that handle "
+                        "symmetry of objects"
                     )
                     # TODO M consider using an angular distance instead of Euclidean
                     # when we actually begin making use of this feature; try to ensure
@@ -677,10 +677,10 @@ class EvidenceGoalStateGenerator(GraphGoalStateGenerator):
             second_mlh["rotation"].apply(transformed_current_loc)
             + second_mlh["location"]
         )
-        assert np.all(
-            transformed_current_loc == second_mlh["location"]
-        ), "Graph transformaiton to 2nd object reference frame not returning correct\
-            transformed location"
+        assert np.all(transformed_current_loc == second_mlh["location"]), (
+            "Graph transformation to 2nd object reference frame not returning correct "
+            "transformed location"
+        )
 
         # Perform kdtree search to identify the point with the most distant
         # nearest-neighbor

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -64,8 +64,7 @@ class MontyForGraphMatching(MontyBase):
             sm.pre_episode()
 
         logging.debug(
-            f"Models in memory: \
-            {self.learning_modules[0].get_all_known_object_ids()}"
+            f"Models in memory: {self.learning_modules[0].get_all_known_object_ids()}"
         )
 
     def send_vote_to_lm(self, lm, lm_id, combined_votes):
@@ -1299,7 +1298,7 @@ class GraphMemory(LMMemory):
         else:
             return sum(
                 self.get_num_nodes_in_graph(graph_id, input_channel)
-                    for input_channel in self.get_input_channels_in_graph(graph_id)
+                for input_channel in self.get_input_channels_in_graph(graph_id)
             )
 
     def get_features_at_node(self, graph_id, input_channel, node_id, feature_keys=None):

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -496,9 +496,7 @@ class MontyBase(Monty):
     def switch_to_exploratory_step(self):
         self.step_type = "exploratory_step"
         self.is_seeking_match = False
-        logging.info(
-            "Going into exploratory mode after" f" {self.matching_steps} steps"
-        )
+        logging.info(f"Going into exploratory mode after {self.matching_steps} steps")
 
 
 class LearningModuleBase(LearningModule):

--- a/src/tbp/monty/frameworks/models/object_model.py
+++ b/src/tbp/monty/frameworks/models/object_model.py
@@ -563,7 +563,7 @@ class GridObjectModel(GraphObjectModel):
         if percent_in_bounds < 0.9:
             logging.info(
                 "Too many observations outside of grid "
-                f"({np.round(percent_in_bounds*100,2)}%). Skipping update of grids."
+                f"({np.round(percent_in_bounds * 100, 2)}%). Skipping update of grids."
             )
             raise GridTooSmallError
         voxel_ids_of_new_obs = location_grid_ids[locations_in_bounds]

--- a/src/tbp/monty/frameworks/models/sensor_modules.py
+++ b/src/tbp/monty/frameworks/models/sensor_modules.py
@@ -65,9 +65,9 @@ class DetailedLoggingSM(SensorModuleBase):
     def state_dict(self):
         """Return state_dict."""
         # this is what is saved to detailed stats
-        assert len(self.sm_properties) == len(
-            self.raw_observations
-        ), "Should have a SM value for every set of observations."
+        assert len(self.sm_properties) == len(self.raw_observations), (
+            "Should have a SM value for every set of observations."
+        )
 
         return dict(
             raw_observations=self.raw_observations, sm_properties=self.sm_properties
@@ -242,9 +242,9 @@ class DetailedLoggingSM(SensorModuleBase):
         if "object_coverage" in self.features:
             # Last dimension is semantic ID (integer >0 if on any object)
             features["object_coverage"] = sum(obs_3d[:, 3] > 0) / len(obs_3d[:, 3])
-            assert (
-                features["object_coverage"] <= 1.0
-            ), "Coverage cannot be greater than 100%"
+            assert features["object_coverage"] <= 1.0, (
+                "Coverage cannot be greater than 100%"
+            )
 
         if obs_3d[center_id][3] or (
             not on_object_only and features["object_coverage"] > 0
@@ -483,9 +483,9 @@ class HabitatDistantPatchSM(DetailedLoggingSM, NoiseMixin):
             "coords_for_TM",
         ]
         for feature in features:
-            assert (
-                feature in possible_features
-            ), f"{feature} not part of {possible_features}"
+            assert feature in possible_features, (
+                f"{feature} not part of {possible_features}"
+            )
 
         self.features = features
         self.processed_obs = []
@@ -518,9 +518,9 @@ class HabitatDistantPatchSM(DetailedLoggingSM, NoiseMixin):
 
     def state_dict(self):
         """Return state_dict."""
-        assert len(self.sm_properties) == len(
-            self.raw_observations
-        ), "Should have a SM value for every set of observations."
+        assert len(self.sm_properties) == len(self.raw_observations), (
+            "Should have a SM value for every set of observations."
+        )
 
         return dict(
             raw_observations=self.raw_observations,
@@ -702,7 +702,7 @@ class FeatureChangeSM(HabitatDistantPatchSM, NoiseMixin):
                 delta_change_sv = np.abs(last_feat[1:] - current_feat[1:])
                 for i, dc in enumerate(delta_change_sv):
                     if dc > self.delta_thresholds[feature][i + 1]:
-                        logging.debug(f"new point because of {feature} - {i+1}")
+                        logging.debug(f"new point because of {feature} - {i + 1}")
                         return True
 
             elif feature == "pose_vectors":

--- a/src/tbp/monty/frameworks/models/states.py
+++ b/src/tbp/monty/frameworks/models/states.py
@@ -68,7 +68,7 @@ class State:
         """Return a string representation of the object."""
         repr_string = (
             f"State from {self.sender_id}:\n"
-            f"   Location: {np.round(self.location,3)}.\n"
+            f"   Location: {np.round(self.location, 3)}.\n"
             f"   Morphological Features: \n"
         )
         if self.morphological_features is not None:
@@ -178,9 +178,9 @@ class State:
             return True
 
     def _check_all_attributes(self):
-        assert (
-            "pose_vectors" in self.morphological_features.keys()
-        ), "pose_vectors should be in morphological_features but keys are "
+        assert "pose_vectors" in self.morphological_features.keys(), (
+            "pose_vectors should be in morphological_features but keys are "
+        )
         f"{self.morphological_features.keys()}"
         # TODO S: may want to test length and angle between vectors as well
         assert self.morphological_features["pose_vectors"].shape == (
@@ -193,22 +193,21 @@ class State:
             "pose_fully_defined must be a boolean but type is "
         )
         f"{type(self.morphological_features['pose_fully_defined'])}"
-        assert self.location.shape == (
-            3,
-        ), f"Location must be a 3D vector but shape is {self.location.shape}"
-        assert (
-            self.confidence >= 0 and self.confidence <= 1
-        ), f"Confidence must be in [0,1] but is {self.confidence}"
+        assert self.location.shape == (3,), (
+            f"Location must be a 3D vector but shape is {self.location.shape}"
+        )
+        assert self.confidence >= 0 and self.confidence <= 1, (
+            f"Confidence must be in [0,1] but is {self.confidence}"
+        )
         assert isinstance(self.use_state, bool), (
             f"use_state must be a boolean but is {type(self.use_state)}"
         )
         assert isinstance(self.sender_id, str), (
             f"sender_id must be string but is {type(self.sender_id)}"
         )
-        assert (
-            self.sender_type in self.allowable_sender_types
-        ), f"sender_type must be SM or LM but is\
-            {self.sender_type}"
+        assert self.sender_type in self.allowable_sender_types, (
+            f"sender_type must be SM or LM but is {self.sender_type}"
+        )
 
 
 class GoalState(State):
@@ -288,18 +287,20 @@ class GoalState(State):
     def _check_all_attributes(self):
         """Overwrite base attribute check to also allow for None values."""
         if self.morphological_features is not None:
-            assert (
-                "pose_vectors" in self.morphological_features.keys()
-            ), "pose_vectors should be in morphological_features but keys are "
+            assert "pose_vectors" in self.morphological_features.keys(), (
+                "pose_vectors should be in morphological_features but keys are "
+            )
             f"{self.morphological_features.keys()}"
             assert np.any(
                 self.morphological_features["pose_vectors"] == np.nan
             ) or self.morphological_features["pose_vectors"].shape == (
                 3,
                 3,
-            ), f"pose should be undefined, or defined by three orthonormal unit vectors\
-                but pose_vectors shape is\
-                    {self.morphological_features['pose_vectors'].shape}"
+            ), (
+                "pose should be undefined, or defined by three orthonormal unit "
+                "vectors but pose_vectors shape is "
+                f"{self.morphological_features['pose_vectors'].shape}"
+            )
             assert "pose_fully_defined" in self.morphological_features.keys()
             assert (
                 isinstance(self.morphological_features["pose_fully_defined"], bool)
@@ -308,13 +309,13 @@ class GoalState(State):
             )
             f"{type(self.morphological_features['pose_fully_defined'])}"
         if self.location is not None:
-            assert self.location.shape == (
-                3,
-            ), f"Location must be a 3D vector but shape is {self.location.shape}"
+            assert self.location.shape == (3,), (
+                f"Location must be a 3D vector but shape is {self.location.shape}"
+            )
 
-        assert (
-            self.confidence >= 0 and self.confidence <= 1
-        ), f"Confidence must be in [0,1] but is {self.confidence}"
+        assert self.confidence >= 0 and self.confidence <= 1, (
+            f"Confidence must be in [0,1] but is {self.confidence}"
+        )
         assert isinstance(self.use_state, bool), (
             f"use_state must be a boolean but is {type(self.use_state)}"
         )
@@ -322,9 +323,9 @@ class GoalState(State):
             f"sender_id must be string but is {type(self.sender_id)}"
         )
         # Note *only* GSGs should create GoalState objects
-        assert (
-            self.sender_type in self.allowable_sender_types
-        ), f"sender_type must be GSG but is {self.sender_type}"
+        assert self.sender_type in self.allowable_sender_types, (
+            f"sender_type must be GSG but is {self.sender_type}"
+        )
         # info is optional, but it must be a dictionary.
         assert isinstance(self.info, dict), "info must be a dictionary"
 

--- a/src/tbp/monty/frameworks/utils/logging_utils.py
+++ b/src/tbp/monty/frameworks/utils/logging_utils.py
@@ -453,13 +453,14 @@ def print_overall_stats(stats):
         / len(stats)
         * 100
     )
-    print(f"Detected {np.round(acc,2)}% correctly")
+    print(f"Detected {np.round(acc, 2)}% correctly")
     rt = np.sum(stats["time"])
     rt_per_step = np.mean(stats["time"] / stats["monty_matching_steps"])
     print(
-        f"overall run time: {np.round(rt,2)} seconds ({np.round(rt/60,2)} minutes),"
-        f" {np.round(rt/len(stats),2)} seconds per episode, {np.round(rt_per_step,2)} "
-        "seconds per step."
+        f"overall run time: {np.round(rt, 2)} seconds "
+        f"({np.round(rt / 60, 2)} minutes), "
+        f"{np.round(rt / len(stats), 2)} seconds per episode, "
+        f"{np.round(rt_per_step, 2)} seconds per step."
     )
 
 
@@ -487,10 +488,10 @@ def print_unsupervised_stats(stats, epoch_len):
         * 100
     )
     print(
-        f"Detected {np.round(first_epoch_acc,2)}% correctly as new object"
+        f"Detected {np.round(first_epoch_acc, 2)}% correctly as new object"
         "in first epoch"
     )
-    print(f"Detected {np.round(later_acc,2)}% correctly after first epoch")
+    print(f"Detected {np.round(later_acc, 2)}% correctly after first epoch")
     print(f"Mean objects per graph: {list(stats['mean_objects_per_graph'])[-1]}")
     print(f"Mean graphs per object: {list(stats['mean_graphs_per_object'])[-1]}")
     print("Merged graphs:")
@@ -499,8 +500,8 @@ def print_unsupervised_stats(stats, epoch_len):
             print("     " + string)
     rt = np.sum(stats["time"])
     print(
-        f"overall run time: {np.round(rt,2)} seconds ({np.round(rt/60,2)} minutes),"
-        f" {np.round(rt/len(stats),2)} seconds per episode."
+        f"overall run time: {np.round(rt, 2)} seconds ({np.round(rt / 60, 2)} minutes),"
+        f" {np.round(rt / len(stats), 2)} seconds per episode."
     )
 
 
@@ -920,8 +921,7 @@ def maybe_rename_existing_directory(path, report_count):
     if (report_count == 0) and os.path.exists(path):
         new_path = path + "_old"
         logging.warning(
-            f"Output path {path} already exists. This path will be moved"
-            f"to {new_path}"
+            f"Output path {path} already exists. This path will be movedto {new_path}"
         )
 
         if os.path.exists(new_path):

--- a/src/tbp/monty/frameworks/utils/object_model_utils.py
+++ b/src/tbp/monty/frameworks/utils/object_model_utils.py
@@ -75,9 +75,9 @@ def already_in_list(
         < graph_delta_thresholds["distance"]
     )
 
-    assert (
-        "on_object" not in graph_delta_thresholds.keys()
-    ), "Don't pass feature-change SM delta_thresholds for graph_delta_thresholds"
+    assert "on_object" not in graph_delta_thresholds.keys(), (
+        "Don't pass feature-change SM delta_thresholds for graph_delta_thresholds"
+    )
 
     # Iterate through old graph points that do match distance-wise, performing
     # additional checks
@@ -101,9 +101,9 @@ def already_in_list(
                     match_hue = features[feature][feature_idx][0]
                     current_hue = features[feature][query_id][0]
 
-                    assert np.all(
-                        np.array(graph_delta_thresholds[feature][1:]) == 1
-                    ), "Only considering hue"
+                    assert np.all(np.array(graph_delta_thresholds[feature][1:]) == 1), (
+                        "Only considering hue"
+                    )
 
                     hue_d = min(
                         abs(current_hue - match_hue),

--- a/src/tbp/monty/frameworks/utils/plot_utils.py
+++ b/src/tbp/monty/frameworks/utils/plot_utils.py
@@ -575,11 +575,9 @@ def show_previous_possible_paths_with_nodes(ax, path_stats, step, object_n):
 def update_text(text_ax, num_possible_paths, unique_poses):
     num_unique_poses = unique_poses.shape[0]
     if num_unique_poses > 4:
-        text_ax.set_text(
-            f"# paths: {num_possible_paths}\n" f"# poses: {num_unique_poses}"
-        )
+        text_ax.set_text(f"# paths: {num_possible_paths}\n# poses: {num_unique_poses}")
     else:
-        text = f"# paths: {num_possible_paths}\n" f"# poses: {num_unique_poses}"
+        text = f"# paths: {num_possible_paths}\n# poses: {num_unique_poses}"
         for pose in unique_poses:
             text = text + "\n" + str(pose)
         text_ax.set_text(text)
@@ -1264,8 +1262,8 @@ def plot_evidence_at_step(
         f"target: \n{lm_stats['target']['object']}"
         f" with rotation {mlhr}\n"
         "\ncurrent most likely hypothesis:\n"
-        f"{mlh['graph_id']} with rotation {np.round(mlh['rotation'],1)}"
-        f"\nevidence: {np.round(mlh['evidence'],2)}"
+        f"{mlh['graph_id']} with rotation {np.round(mlh['rotation'], 1)}"
+        f"\nevidence: {np.round(mlh['evidence'], 2)}"
     )
     ax.text(0, 0.5, text)
     plt.axis("off")
@@ -1509,9 +1507,9 @@ class PolicyPlot:
                     "action_details"
                 ]["avoidance_heading"]
             )
-            assert len(self.tangential_locs) == len(
-                self.new_headings
-            ), "Mismatch in number of heading-markers"
+            assert len(self.tangential_locs) == len(self.new_headings), (
+                "Mismatch in number of heading-markers"
+            )
 
         else:
             self.pc_headings = np.zeros(len(self.tangential_locs))

--- a/src/tbp/monty/simulators/habitat/simulator.py
+++ b/src/tbp/monty/simulators/habitat/simulator.py
@@ -255,9 +255,9 @@ class HabitatSim(HabitatActuator):
         obj.rotation = sim_utils.quat_to_magnum(rotation)
 
         if object_to_avoid:
-            assert (
-                self.sim_enable_physics
-            ), "Sim-level physics must be enabled to support collision detection"
+            assert self.sim_enable_physics, (
+                "Sim-level physics must be enabled to support collision detection"
+            )
             # Temporarily enable *object* physics for collision detection
             obj.motion_type = habitat_sim.physics.MotionType.DYNAMIC
             obj = self.find_non_colliding_positions(

--- a/tests/unit/base_config_test.py
+++ b/tests/unit/base_config_test.py
@@ -114,9 +114,7 @@ class BaseConfigTest(unittest.TestCase):
         pprint("...parsing experiment...")
         base_config = copy.deepcopy(self.base_config)
         with MontyExperiment(base_config) as exp:
-            monty_module_sids = {
-                s.sensor_module_id for s in exp.model.sensor_modules
-            }
+            monty_module_sids = {s.sensor_module_id for s in exp.model.sensor_modules}
 
             # Handle the training loop manually for this interim test
             max_count = 5

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -829,9 +829,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
@@ -938,12 +936,11 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         self.assertEqual(
             num_matching_steps,
             sum(
-                exp.model.learning_modules[0].buffer.features["patch"][
-                    "on_object"
-                ][:num_matching_steps]
+                exp.model.learning_modules[0].buffer.features["patch"]["on_object"][
+                    :num_matching_steps
+                ]
             ),
-            "Number of match steps does not match with stored observations"
-            " on object",
+            "Number of match steps does not match with stored observations on object",
         )
         # Since min_train_steps==12 we should have taken 13 steps.
         self.assertEqual(
@@ -961,12 +958,8 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         )
 
         self.assertGreater(
-            exp.model.learning_modules[0].buffer.stats["current_mlh"][-1][
-                "evidence"
-            ],
-            exp.model.learning_modules[0].buffer.stats["current_mlh"][6][
-                "evidence"
-            ],
+            exp.model.learning_modules[0].buffer.stats["current_mlh"][-1]["evidence"],
+            exp.model.learning_modules[0].buffer.stats["current_mlh"][6]["evidence"],
             "evidence should have increased after moving back on the object.",
         )
 
@@ -977,9 +970,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
             pprint("...check time out logging...")
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.assertEqual(
                 train_stats["individual_ts_performance"][0],
                 "no_match",
@@ -990,7 +981,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 self.assertEqual(
                     train_stats["individual_ts_performance"][i + 1],
                     "time_out",
-                    f"time out not recognized/logged correctly in episode {i+1}",
+                    f"time out not recognized/logged correctly in episode {i + 1}",
                 )
             self.assertEqual(
                 train_stats["primary_performance"][2],
@@ -1094,9 +1085,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             print(train_stats)
             self.check_train_results(train_stats)
 
@@ -1117,9 +1106,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             print(train_stats)
             self.check_train_results(train_stats)
 
@@ -1421,9 +1408,9 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         first_input_channel = graph_lm.get_input_channels_in_graph(target_object)[0]
         target_loc = target_graph[first_input_channel].pos[target_loc_id]
 
-        assert np.all(
-            np.isclose(target_loc, self.fake_obs_house[4].location)
-        ), "Should propose testing 5th (indexed from 0) location on object"
+        assert np.all(np.isclose(target_loc, self.fake_obs_house[4].location)), (
+            "Should propose testing 5th (indexed from 0) location on object"
+        )
 
     def test_hypothesis_testing_proposal_for_id(self):
         """Test that the LM correctly predicts a location on a graph to test.
@@ -1697,9 +1684,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
@@ -1718,9 +1703,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             print(train_stats)
             self.check_train_results(train_stats, num_lms=5)
 
@@ -1731,9 +1714,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 exp.run_epoch()
             exp.logger_handler.post_eval(exp.logger_args)
             pprint("...loading and checking eval statistics...")
-            eval_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "eval_stats.csv")
-            )
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
             self.check_eval_results(eval_stats, num_lms=5)
 
             pprint("checking that evaluation also works with larger mmd.")
@@ -1755,9 +1736,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
             # Same as in previous test we make it a bit more difficult during eval
             for lm in exp.model.learning_modules:
@@ -1784,9 +1763,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
 
             exp.train()
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             # Just checking that objects are still recognized correctly when moving off
             # the object.
             self.check_train_results(train_stats, num_lms=5)
@@ -1829,8 +1806,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             self.assertEqual(
                 eval_stats["monty_matching_steps"][row],
                 13,
-                "All eval episodes should have recognized the object "
-                "after 13 steps.",
+                "All eval episodes should have recognized the object after 13 steps.",
             )
         for lm_id in [0, 2, 3, 4]:
             self.assertLess(
@@ -1884,13 +1860,10 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 self.assertNotIn(
                     key,
                     exp.model.learning_modules[0].buffer.stats.keys(),
-                    f"{key} should not be stored in buffer when using "
-                    f"BASIC logging.",
+                    f"{key} should not be stored in buffer when using BASIC logging.",
                 )
             self.assertEqual(
-                len(
-                    exp.model.learning_modules[0].buffer.stats["possible_matches"]
-                ),
+                len(exp.model.learning_modules[0].buffer.stats["possible_matches"]),
                 1,
                 "When using basic logging we don't append stats for every step.",
             )
@@ -1907,9 +1880,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
@@ -1932,9 +1903,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
@@ -1954,9 +1923,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
@@ -1983,9 +1950,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             # NOTE: This might fail if the model becomes more noise robust or
             # better able to deal with few incomplete objects in memory.
             for i in range(6):
@@ -2025,9 +1990,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             # NOTE: This might fail if the model becomes more noise robust or
             # better able to deal with few incomplete objects in memory.
             for i in range(6):
@@ -2093,9 +2056,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
         with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
             exp.train()
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_hierarchical_lm_train_results(train_stats)
 
             models = load_models_from_dir(exp.output_dir)
@@ -2103,9 +2064,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
 
             pprint("...evaluating...")
             exp.evaluate()
-            eval_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "eval_stats.csv")
-            )
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
             self.check_hierarchical_lm_eval_results(eval_stats)
 
 

--- a/tests/unit/graph_building_test.py
+++ b/tests/unit/graph_building_test.py
@@ -287,9 +287,7 @@ class GraphLearningTest(unittest.TestCase):
         config = copy.deepcopy(self.load_habitat_config)
         with MontyObjectRecognitionExperiment(config) as exp:
             pprint("checking loaded graphs")
-            for graph_id in exp.model.learning_modules[
-                0
-            ].get_all_known_object_ids():
+            for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
                 graph = exp.model.learning_modules[0].get_graph(
                     graph_id, input_channel="first"
                 )
@@ -306,9 +304,7 @@ class GraphLearningTest(unittest.TestCase):
         config = copy.deepcopy(self.load_habitat_for_ppf)
         with MontyObjectRecognitionExperiment(config) as exp:
             pprint("checking loaded graphs")
-            for graph_id in exp.model.learning_modules[
-                0
-            ].get_all_known_object_ids():
+            for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
                 graph = exp.model.learning_modules[0].get_graph(
                     graph_id, input_channel="first"
                 )
@@ -330,9 +326,7 @@ class GraphLearningTest(unittest.TestCase):
         config = copy.deepcopy(self.load_habitat_for_feat)
         with MontyObjectRecognitionExperiment(config) as exp:
             pprint("checking loaded graphs")
-            for graph_id in exp.model.learning_modules[
-                0
-            ].get_all_known_object_ids():
+            for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
                 graph = exp.model.learning_modules[0].get_graph(
                     graph_id, input_channel="first"
                 )
@@ -353,9 +347,7 @@ class GraphLearningTest(unittest.TestCase):
         config = copy.deepcopy(self.load_habitat_for_feat)
         with MontyObjectRecognitionExperiment(config) as exp:
             pprint("checking loaded graphs")
-            for graph_id in exp.model.learning_modules[
-                0
-            ].get_all_known_object_ids():
+            for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
                 graph = exp.model.learning_modules[0].get_graph(
                     graph_id, input_channel="first"
                 )

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -594,9 +594,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
                 if step == 0:
                     self.assertListEqual(
                         list(
-                            exp.model.learning_modules[
-                                0
-                            ].buffer.get_nth_displacement(0, input_channel="first")
+                            exp.model.learning_modules[0].buffer.get_nth_displacement(
+                                0, input_channel="first"
+                            )
                         ),
                         [0, 0, 0],
                         "displacement at step 0 should be 0.",
@@ -604,9 +604,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
                 self.assertEqual(
                     step + 1,
                     len(
-                        exp.model.learning_modules[0].buffer.displacements[
-                            "patch"
-                        ]["displacement"]
+                        exp.model.learning_modules[0].buffer.displacements["patch"][
+                            "displacement"
+                        ]
                     ),
                     "buffer does not contain the right amount of displacements.",
                 )
@@ -686,9 +686,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
             pprint("...loading and checking train statistics...")
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
@@ -707,9 +705,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
             pprint("...loading and checking train statistics...")
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
 
             self.check_train_results(train_stats)
 
@@ -730,9 +726,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
 
             self.check_train_results(train_stats)
 
@@ -797,9 +791,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
         # Check that basic csv stats are the same
         ###
-        original_eval_stats_file = os.path.join(
-            eval_exp_1.output_dir, "eval_stats.csv"
-        )
+        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
         new_eval_stats_file = os.path.join(
             eval_exp_1.output_dir, "eval_episode_0_rerun", "eval_stats.csv"
         )
@@ -904,9 +896,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
         # Check that basic csv stats are the same
         ###
-        original_eval_stats_file = os.path.join(
-            eval_exp_1.output_dir, "eval_stats.csv"
-        )
+        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
         new_eval_stats_file = os.path.join(
             eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
         )
@@ -995,9 +985,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
         # Check that basic csv stats are the same
         ###
-        original_eval_stats_file = os.path.join(
-            eval_exp_1.output_dir, "eval_stats.csv"
-        )
+        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
         new_eval_stats_file = os.path.join(
             eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
         )
@@ -1211,27 +1199,27 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             self.assertEqual(
                 len(
-                    exp.model.learning_modules[
-                        0
-                    ].buffer.get_all_locations_on_object(input_channel="patch")
+                    exp.model.learning_modules[0].buffer.get_all_locations_on_object(
+                        input_channel="patch"
+                    )
                 ),
                 len(
-                    exp.model.learning_modules[
-                        0
-                    ].buffer.get_all_features_on_object()["patch"]["pose_vectors"]
+                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                        "patch"
+                    ]["pose_vectors"]
                 ),
                 "Did not retrieve same amount of feature and locations on object.",
             )
             self.assertEqual(
                 sum(
-                    exp.model.learning_modules[
-                        0
-                    ].buffer.get_all_features_on_object()["patch"]["on_object"]
+                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                        "patch"
+                    ]["on_object"]
                 ),
                 len(
-                    exp.model.learning_modules[
-                        0
-                    ].buffer.get_all_features_on_object()["patch"]["on_object"]
+                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                        "patch"
+                    ]["on_object"]
                 ),
                 "not all retrieved features were collected on the object.",
             )
@@ -1244,9 +1232,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             self.assertEqual(
                 num_matching_steps,
                 sum(
-                    exp.model.learning_modules[0].buffer.features["patch"][
-                        "on_object"
-                    ][:num_matching_steps]
+                    exp.model.learning_modules[0].buffer.features["patch"]["on_object"][
+                        :num_matching_steps
+                    ]
                 ),
                 "Number of match steps does not match with stored observations "
                 "on object",
@@ -1297,8 +1285,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         self.assertEqual(
             len(detailed_stats["1"]["LM_0"]["possible_matches"]),
             train_stats.loc[1]["monty_matching_steps"],
-            "matching steps in detailed stats don't match with those in "
-            "train stats.",
+            "matching steps in detailed stats don't match with those in train stats.",
         )
         self.assertEqual(
             sum(np.array(detailed_stats["1"]["LM_0"]["patch"]["on_object"])),
@@ -1317,9 +1304,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
@@ -1641,9 +1626,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
 
             pprint("...evaluating...")
@@ -1663,9 +1646,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(
-                os.path.join(exp.output_dir, "train_stats.csv")
-            )
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             # The following check is brittle and depends on sensor arrangement. Leaving
             # the rest of the test intact to detect run failures, but disabling checking
             # of particular results.

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -623,10 +623,10 @@ class PolicyTest(unittest.TestCase):
                 "motor_system_config"
             ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
-            assert (
-                perc_on_target_obj >= target_perc_on_target_obj
-            ), f"Initial view is not good enough, {perc_on_target_obj}\
-                vs target of {target_perc_on_target_obj}"
+            assert perc_on_target_obj >= target_perc_on_target_obj, (
+                f"Initial view is not good enough, {perc_on_target_obj} "
+                f"vs target of {target_perc_on_target_obj}"
+            )
 
             points_on_target_obj = semantic == 1
             closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
@@ -636,10 +636,10 @@ class PolicyTest(unittest.TestCase):
             ]["policy_args"]["desired_object_distance"]
 
             # Utility policy should not have moved too close to the object
-            assert (
-                closest_point_on_target_obj > target_closest_point
-            ), f"Initial view is too close, {closest_point_on_target_obj}\
-                vs target of {target_closest_point}"
+            assert closest_point_on_target_obj > target_closest_point, (
+                f"Initial view is too close, {closest_point_on_target_obj} "
+                f"vs target of {target_closest_point}"
+            )
 
     def test_touch_object_basic_surf_agent(self):
         """Test ability to move a surface agent to touch an object.
@@ -677,20 +677,20 @@ class PolicyTest(unittest.TestCase):
             )
             closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
 
-            assert (
-                closest_point_on_target_obj < 1.0
-            ), f"Should be within a meter of the object,\
-                closest point at {closest_point_on_target_obj}"
+            assert closest_point_on_target_obj < 1.0, (
+                f"Should be within a meter of the object, "
+                f"closest point at {closest_point_on_target_obj}"
+            )
 
             target_closest_point = dict_config["monty_config"]["motor_system_config"][
                 "motor_system_args"
             ]["policy_args"]["desired_object_distance"]
 
             # Utility policy should not have moved too close to the object
-            assert (
-                closest_point_on_target_obj > target_closest_point
-            ), f"Initial position is too close, {closest_point_on_target_obj}\
-                vs target of {target_closest_point}"
+            assert closest_point_on_target_obj > target_closest_point, (
+                f"Initial position is too close, {closest_point_on_target_obj} "
+                f"vs target of {target_closest_point}"
+            )
 
     def test_get_good_view_multi_object(self):
         """Test ability to move a distant agent to a good view of an object.
@@ -729,10 +729,10 @@ class PolicyTest(unittest.TestCase):
                 "motor_system_config"
             ]["motor_system_args"]["policy_args"]["good_view_percentage"]
 
-            assert (
-                perc_on_target_obj >= target_perc_on_target_obj
-            ), f"Initial view is not good enough, {perc_on_target_obj}\
-                vs target of {target_perc_on_target_obj}"
+            assert perc_on_target_obj >= target_perc_on_target_obj, (
+                f"Initial view is not good enough, {perc_on_target_obj} "
+                f"vs target of {target_perc_on_target_obj}"
+            )
 
             points_on_target_obj = semantic == 1
             closest_point_on_target_obj = np.min(view["depth"][points_on_target_obj])
@@ -742,20 +742,20 @@ class PolicyTest(unittest.TestCase):
             ]["policy_args"]["desired_object_distance"]
 
             # Utility policy should not have moved too close to the object
-            assert (
-                closest_point_on_target_obj > target_closest_point
-            ), f"Initial view is too close to target, {closest_point_on_target_obj}\
-                vs target of {target_closest_point}"
+            assert closest_point_on_target_obj > target_closest_point, (
+                f"Initial view is too close to target, {closest_point_on_target_obj} "
+                f"vs target of {target_closest_point}"
+            )
 
             # Also calculate closest point on *any* object so that we don't get
             # too close and clip into objects; NB that any object will have a
             # semantic ID > 0
             points_on_any_obj = view["semantic"] > 0
             closest_point_on_any_obj = np.min(view["depth"][points_on_any_obj])
-            assert (
-                closest_point_on_any_obj > target_closest_point / 6
-            ), f"Initial view too cloase to other objects, {closest_point_on_any_obj}\
-                vs target of {target_closest_point / 6}"
+            assert closest_point_on_any_obj > target_closest_point / 6, (
+                f"Initial view too close to other objects, {closest_point_on_any_obj} "
+                f"vs target of {target_closest_point / 6}"
+            )
 
     def test_distant_policy_moves_back_to_object(self):
         """Test ability of distant agent to move back to an object.
@@ -997,9 +997,9 @@ class PolicyTest(unittest.TestCase):
         # (i.e. size) of the translation is represented separately.
         motor_system._policy.processed_observations = self.fake_obs_pc[0]
         direction = motor_system._policy.tangential_direction(motor_system._state)
-        assert np.all(
-            np.isclose(direction, [1, 0, 0])
-        ), "Not following correct PC direction"
+        assert np.all(np.isclose(direction, [1, 0, 0])), (
+            "Not following correct PC direction"
+        )
         assert motor_system._policy.following_pc_counter == 1, (
             "Should have followed PC and incremented counter"
         )
@@ -1010,9 +1010,9 @@ class PolicyTest(unittest.TestCase):
         # Step 2
         motor_system._policy.processed_observations = self.fake_obs_pc[1]
         direction = motor_system._policy.tangential_direction(motor_system._state)
-        assert np.all(
-            np.isclose(direction, [1, 0, 0])
-        ), "Not following correct PC direction"
+        assert np.all(np.isclose(direction, [1, 0, 0])), (
+            "Not following correct PC direction"
+        )
         assert motor_system._policy.following_pc_counter == 2, (
             "Should have followed PC and incremented counter"
         )
@@ -1024,9 +1024,9 @@ class PolicyTest(unittest.TestCase):
         # PC
         motor_system._policy.processed_observations = self.fake_obs_pc[2]
         direction = motor_system._policy.tangential_direction(motor_system._state)
-        assert np.all(
-            np.isclose(direction, [0, 1, 0])
-        ), "Not following correct PC direction"
+        assert np.all(np.isclose(direction, [0, 1, 0])), (
+            "Not following correct PC direction"
+        )
         assert motor_system._policy.following_pc_counter == 1, (
             "Should have reset following PC counter due to bias change, and incremented"
         )
@@ -1037,9 +1037,9 @@ class PolicyTest(unittest.TestCase):
         # Step 4
         motor_system._policy.processed_observations = self.fake_obs_pc[3]
         direction = motor_system._policy.tangential_direction(motor_system._state)
-        assert np.all(
-            np.isclose(direction, [0, 1, 0])
-        ), "Not following correct PC direction"
+        assert np.all(np.isclose(direction, [0, 1, 0])), (
+            "Not following correct PC direction"
+        )
         assert motor_system._policy.following_pc_counter == 2, (
             "Should have followed PC and incremented counter"
         )
@@ -1052,9 +1052,9 @@ class PolicyTest(unittest.TestCase):
         direction = motor_system._policy.tangential_direction(motor_system._state)
         # Note the following movement is a random direction deterministcally set by the
         # random seed
-        assert np.all(
-            np.isclose(direction, [-0.13745981, 0.99050735, 0])
-        ), "Not following correct non-PC direction"
+        assert np.all(np.isclose(direction, [-0.13745981, 0.99050735, 0])), (
+            "Not following correct non-PC direction"
+        )
         assert motor_system._policy.ignoring_pc_counter == 1, (
             "Should have reset ignoring_pc_counter, and then incremented"
         )
@@ -1082,9 +1082,9 @@ class PolicyTest(unittest.TestCase):
 
         motor_system._policy.processed_observations = self.fake_obs_pc[5]
         direction = motor_system._policy.tangential_direction(motor_system._state)
-        assert np.all(
-            np.isclose(direction, [1.0, 0.0, 0])
-        ), "Not following correct PC direction"
+        assert np.all(np.isclose(direction, [1.0, 0.0, 0])), (
+            "Not following correct PC direction"
+        )
 
     def test_advanced_following_principal_curvature(self):
         """Test more edge-case elements of the following-PC policy.
@@ -1126,9 +1126,9 @@ class PolicyTest(unittest.TestCase):
         direction = motor_system._policy.tangential_direction(motor_system._state)
         # Note the following movement is a random direction deterministcally set by the
         # random seed
-        assert np.all(
-            np.isclose(direction, [0.98165657, 0.19065773, 0])
-        ), "Not following correct non-PC direction"
+        assert np.all(np.isclose(direction, [0.98165657, 0.19065773, 0])), (
+            "Not following correct non-PC direction"
+        )
         assert motor_system._policy.following_pc_counter == 0, (
             "Should not have followed PC and incremented counter"
         )
@@ -1144,9 +1144,9 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.tangent_locs.append(self.fake_obs_pc[0].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
         direction = motor_system._policy.tangential_direction(motor_system._state)
-        assert np.all(
-            np.isclose(direction, [1, 0, 0])
-        ), "Not following correct PC direction"
+        assert np.all(np.isclose(direction, [1, 0, 0])), (
+            "Not following correct PC direction"
+        )
         assert motor_system._policy.following_pc_counter == 1, (
             "Should have followed PC and incremented counter"
         )
@@ -1160,9 +1160,9 @@ class PolicyTest(unittest.TestCase):
         motor_system._policy.tangent_locs.append(self.fake_obs_advanced_pc[1].location)
         motor_system._policy.tangent_norms.append([0, 0, 1])
         direction = motor_system._policy.tangential_direction(motor_system._state)
-        assert np.all(
-            np.isclose(direction, [1, 0, 0])
-        ), "Not following correct PC direction"
+        assert np.all(np.isclose(direction, [1, 0, 0])), (
+            "Not following correct PC direction"
+        )
         assert motor_system._policy.following_pc_counter == 2, (
             "Should have followed PC and incremented counter"
         )
@@ -1204,9 +1204,9 @@ class PolicyTest(unittest.TestCase):
         direction = motor_system._policy.tangential_direction(motor_system._state)
         # Note the following movement is a random direction deterministcally set by the
         # random seed
-        assert np.all(
-            np.isclose(direction, [0.60958557, 0.79272027, 0])
-        ), "Not following correct non-PC direction"
+        assert np.all(np.isclose(direction, [0.60958557, 0.79272027, 0])), (
+            "Not following correct non-PC direction"
+        )
         assert motor_system._policy.ignoring_pc_counter == 0, (
             "Should have reset ignoring_pc_counter, and not incremented"
         )
@@ -1348,18 +1348,18 @@ class PolicyTest(unittest.TestCase):
         ), "Goal-state location is not as expected"
 
         # Pointing down
-        assert np.all(
-            np.isclose(motor_goal_direction, [0, -1.0, 0])
-        ), "Goal-state pose is not as expected"
+        assert np.all(np.isclose(motor_goal_direction, [0, -1.0, 0])), (
+            "Goal-state pose is not as expected"
+        )
 
         assert np.all(
             np.isclose(target_loc_hab, [0.1, 1.6 + surface_displacement, 0.2])
         ), "Habitat target location is not as expected"
 
         # Pointing down
-        assert np.all(
-            np.isclose(agent_direction_hab, [0, -1.0, 0])
-        ), "Habitat pose is not as expected"
+        assert np.all(np.isclose(agent_direction_hab, [0, -1.0, 0])), (
+            "Habitat pose is not as expected"
+        )
 
         # === Second, harder example ===
 
@@ -1382,9 +1382,9 @@ class PolicyTest(unittest.TestCase):
         ), "Goal-state location is not as expected"
 
         # Pointing up, because object is flipped in y-axis
-        assert np.all(
-            np.isclose(motor_goal_direction_2, [0, 1.0, 0])
-        ), "Goal-state pose is not as expected"
+        assert np.all(np.isclose(motor_goal_direction_2, [0, 1.0, 0])), (
+            "Goal-state pose is not as expected"
+        )
 
         # Surface displacement is negative, because object is flipped in x-axis
         assert np.all(
@@ -1392,9 +1392,9 @@ class PolicyTest(unittest.TestCase):
         ), "Habitat target location is not as expected"
 
         # Pointing up, because object is flipped in y-axis
-        assert np.all(
-            np.isclose(agent_direction_hab_2, [0, 1.0, 0])
-        ), "Habitat pose is not as expected"
+        assert np.all(np.isclose(agent_direction_hab_2, [0, 1.0, 0])), (
+            "Habitat pose is not as expected"
+        )
 
         # === Third, hardest example ===
 

--- a/tests/unit/profile_experiment_mixin_test.py
+++ b/tests/unit/profile_experiment_mixin_test.py
@@ -48,12 +48,14 @@ class InheritanceProfileExperimentMixinTest(TestCase):
     @staticmethod
     def test_non_leftmost_subclassing_raises_error() -> None:
         with pytest.raises(TypeError):
+
             class BadSubclass(MontyExperiment, ProfileExperimentMixin):
                 pass
 
     @staticmethod
     def test_missing_experiment_base_raises_error() -> None:
         with pytest.raises(TypeError):
+
             class BadSubclass(ProfileExperimentMixin):
                 pass
 
@@ -117,12 +119,14 @@ class ProfileExperimentMixinTest(TestCase):
         for file in path.iterdir():
             if not file.is_file():
                 continue
-            self.assertGreater(file.stat().st_size, 0,
-                               "Empty profile file was unexpectedly generated.")
+            self.assertGreater(
+                file.stat().st_size, 0, "Empty profile file was unexpectedly generated."
+            )
             with file.open("r") as f:
                 first_line = f.readline().rstrip("\n")
-                self.assertEqual(first_line,
-                                 ",func,ncalls,ccalls,tottime,cumtime,callers")
+                self.assertEqual(
+                    first_line, ",func,ncalls,ccalls,tottime,cumtime,callers"
+                )
 
     def test_run_episode_is_profiled(self) -> None:
         pprint("...parsing experiment...")
@@ -133,10 +137,13 @@ class ProfileExperimentMixinTest(TestCase):
             exp.dataloader = exp.train_dataloader
             exp.run_episode()
 
-        self.assertSetEqual(self.get_profile_files(), {
-            "profile-setup_experiment.csv",
-            "profile-train_epoch_0_episode_0.csv",
-        })
+        self.assertSetEqual(
+            self.get_profile_files(),
+            {
+                "profile-setup_experiment.csv",
+                "profile-train_epoch_0_episode_0.csv",
+            },
+        )
         self.spot_check_profile_files()
 
     def test_run_train_epoch_is_profiled(self) -> None:
@@ -146,12 +153,15 @@ class ProfileExperimentMixinTest(TestCase):
             exp.model.set_experiment_mode("train")
             exp.run_epoch()
 
-        self.assertSetEqual(self.get_profile_files(), {
-            "profile-setup_experiment.csv",
-            "profile-train_epoch_0_episode_0.csv",
-            "profile-train_epoch_0_episode_1.csv",
-            "profile-train_epoch_0_episode_2.csv",
-        })
+        self.assertSetEqual(
+            self.get_profile_files(),
+            {
+                "profile-setup_experiment.csv",
+                "profile-train_epoch_0_episode_0.csv",
+                "profile-train_epoch_0_episode_1.csv",
+                "profile-train_epoch_0_episode_2.csv",
+            },
+        )
         self.spot_check_profile_files()
 
     def test_run_eval_epoch_is_profiled(self) -> None:
@@ -161,10 +171,13 @@ class ProfileExperimentMixinTest(TestCase):
             exp.model.set_experiment_mode("eval")
             exp.run_epoch()
 
-        self.assertSetEqual(self.get_profile_files(), {
-            "profile-setup_experiment.csv",
-            "profile-eval_epoch_0_episode_0.csv",
-            "profile-eval_epoch_0_episode_1.csv",
-            "profile-eval_epoch_0_episode_2.csv",
-        })
+        self.assertSetEqual(
+            self.get_profile_files(),
+            {
+                "profile-setup_experiment.csv",
+                "profile-eval_epoch_0_episode_0.csv",
+                "profile-eval_epoch_0_episode_1.csv",
+                "profile-eval_epoch_0_episode_2.csv",
+            },
+        )
         self.spot_check_profile_files()

--- a/tests/unit/resources/unit_test_utils.py
+++ b/tests/unit/resources/unit_test_utils.py
@@ -307,7 +307,7 @@ class BaseGraphTestCases:
                     eval_stats["detected_scale"][2 * num_lms + lm_id],
                     eval_stats["primary_target_scale"][2 * num_lms + lm_id],
                     4,
-                    "Scale of capsule3DSolid not detected correctly " f"by lm {lm_id}.",
+                    f"Scale of capsule3DSolid not detected correctly by lm {lm_id}.",
                 )
                 capsule_r = self.string_to_array(
                     eval_stats["detected_rotation"][2 * num_lms + lm_id]
@@ -318,8 +318,7 @@ class BaseGraphTestCases:
                 self.assertLessEqual(
                     eval_stats["rotation_error"][2 * num_lms + lm_id],
                     0.001,
-                    "Rotation of capsule3DSolid not detected correctly "
-                    f"by lm {lm_id}.",
+                    f"Rotation of capsule3DSolid not detected correctly by lm {lm_id}.",
                 )
                 for i in range(3):
                     self.assertEqual(
@@ -441,7 +440,7 @@ class BaseGraphTestCases:
             self.assertNotIn(
                 "learning_module_0",
                 models["0"]["LM_1"]["new_object0"].keys(),
-                "models in LM1 should not store input from LM0 in episode " "0 yet.",
+                "models in LM1 should not store input from LM0 in episode 0 yet.",
             )
             # Check that LM1 extended its graph to add LM0 as a input channel.
             channel_keys = models["2"]["LM_1"]["new_object0"].keys()

--- a/tools/github_readme_sync/req.py
+++ b/tools/github_readme_sync/req.py
@@ -15,6 +15,7 @@ import requests
 
 REQUEST_TIMEOUT_SECONDS = 60
 
+
 def get(url: str, headers=None):
     headers = headers or {}
     headers["Authorization"] = f"Basic {os.getenv('README_API_KEY')}"

--- a/tools/github_readme_sync/tests/file_test.py
+++ b/tools/github_readme_sync/tests/file_test.py
@@ -38,5 +38,6 @@ class TestGetFolders(unittest.TestCase):
         # Assert that the result matches the expected folders
         self.assertEqual(sorted(result), sorted(expected_folders))
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We were under the impression that `ruff check` checked for formatting, but that is under a separate subcommand `ruff format`. This change formats the files that have drifted from the formatting we want, and updates the GH checks to make sure we keep it that way going forward.

After this is merged, we'll add the merge commit hash to the `.git-blame-ignore-revs` file to keep the commit history clear in GH and other tools that support that feature.