### PR TITLE
chore: ignore reformatting in git-blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Ignore reformatting with `ruff format`
+47ad330d0573582e2f807770d1b4e59be0ca67d7


### PR DESCRIPTION
Adding commit 47ad330d0573582e2f807770d1b4e59be0ca67d7 where we reformatted using `ruff format` to the list of commits to ignore in git-blame history.

To have local git use this, run the following:
```shell
git config blame.ignoreRevsFile .git-blame-ignore-revs
```