### PR TITLE
test: use GPU runner for monty tests

### DIFF
--- a/.github/workflows/monty.yml
+++ b/.github/workflows/monty.yml
@@ -305,7 +305,7 @@ jobs:
     name: test-monty
     runs-on:
       group: tbp.monty
-      labels: tbp-linux-x64-ubuntu2204-8core
+      labels: tbp-linux-x64-ubuntu-nvidia-4core-t4gpu
     timeout-minutes: 120
     needs:
       - check_dependencies_monty # Don't run if dependency check fails
@@ -321,24 +321,19 @@ jobs:
           path: |
             ~/miniconda
           key: ${{ needs.install_monty.outputs.conda_env_cache_key_sha }}
+      - name: Install dependencies
+        # Installing before checkout because GitLFS is missing from the image
+        if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
+        run: |
+          sudo apt update -y
+          sudo apt install -y --no-install-recommends xvfb libegl1-mesa-dev git-lfs
       - name: Checkout tbp.monty
         if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
         uses: actions/checkout@v4
         with:
           lfs: true
           path: tbp.monty
-      - name: Install xvfb and mesa
-        # Use X11 framebuffer and mesa opengl libraries for testing.
-        # Not ideal but better than no tests.
-        if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
-        run: |
-          sudo apt update -y
-          sudo apt install -y --no-install-recommends xvfb libegl1-mesa-dev
       - name: Run python tests
-        # Using 8 CPUs corresponding to the large GithHub-hosted runner available in the "tbp" runner group.
-        # See: https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners/about-larger-runners#specifications-for-general-larger-runners
-        #
-        # NOTE: LD_PRELOAD is needed to provide what is discussed in https://stackoverflow.com/questions/71010343/cannot-load-swrast-and-iris-drivers-in-fedora-35/72200748#72200748
         if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
         working-directory: tbp.monty
         run: |
@@ -346,8 +341,7 @@ jobs:
           source activate tbp.monty
           set -e
           mkdir -p test_results/pytest
-          export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6
-          xvfb-run pytest -n 8 --cov --cov-report html --cov-report term --junitxml=test_results/pytest/results.xml --verbose
+          xvfb-run pytest --cov --cov-report html --cov-report term --junitxml=test_results/pytest/results.xml --verbose
       - name: Store test results
         if: ${{ needs.should_run_monty.outputs.should_run_monty == 'true' }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Newer versions of HabitatSim seem to require an actual GPU based on the errors we've seen trying to run without it, so we're switching the tests to run on a GPU instance.