### PR TITLE
fix: GetGoodView positioning procedure matches previous code

### DIFF
--- a/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
+++ b/src/tbp/monty/frameworks/config_utils/make_dataset_configs.py
@@ -312,6 +312,11 @@ class EnvironmentDataloaderPerObjectArgs:
 
 
 @dataclass
+class InformedEnvironmentDataLoaderPerObjectArgs(EnvironmentDataloaderPerObjectArgs):
+    use_get_good_view_positioning_procedure: bool = False
+
+
+@dataclass
 class EnvironmentDataLoaderPerObjectTrainArgs(EnvironmentDataloaderPerObjectArgs):
     object_names: List = field(default_factory=lambda: DefaultTrainObjectList().objects)
     object_init_sampler: Callable = field(default_factory=DefaultObjectInitializer)

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -592,12 +592,10 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             class
         """
         if self._use_get_good_view_positioning_procedure:
-            _configured_policy = self.motor_system._policy
-
-            self.motor_system._policy = GetGoodView(
+            positioning_procedure = GetGoodView(
                 agent_id=self.motor_system._policy.agent_id,
-                desired_object_distance=_configured_policy.desired_object_distance,
-                good_view_percentage=_configured_policy.good_view_percentage,
+                desired_object_distance=self.motor_system._policy.desired_object_distance,
+                good_view_percentage=self.motor_system._policy.good_view_percentage,
                 multiple_objects_present=self.num_distractors > 0,
                 sensor_id=sensor_id,
                 target_semantic_id=self.primary_target["semantic_id"],
@@ -618,7 +616,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 action_sampler_class=UniformlyDistributedSampler,
                 switch_frequency=0.0,
             )
-            result = self.motor_system._policy.positioning_call(
+            result = positioning_procedure.positioning_call(
                 self._observation, self.motor_system._state
             )
             while not result.terminated and not result.truncated:
@@ -628,11 +626,9 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                         MotorSystemState(proprio_state) if proprio_state else None
                     )
 
-                result = self.motor_system._policy.positioning_call(
+                result = positioning_procedure.positioning_call(
                     self._observation, self.motor_system._state
                 )
-
-            self.motor_system._policy = _configured_policy
 
             return result.success
 

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -716,6 +716,8 @@ class GetGoodView(PositioningProcedure):
             self._multiple_objects_present
             and not self._executed_multiple_objects_orientation
         ):
+            # Current implementation only orients to the object once in the case
+            # where there are multiple objects.
             self._executed_multiple_objects_orientation = True
             on_target_object = self.is_on_target_object(observation)
             if not on_target_object:
@@ -729,6 +731,8 @@ class GetGoodView(PositioningProcedure):
                 logging.debug("Moving closer to object.")
                 return PositioningProcedureResult(actions=[action])
 
+        # If we get here, the current implementation will not attempt to move
+        # closer to the object again.
         self._allow_translation = False
 
         on_target_object = self.is_on_target_object(observation)

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -724,6 +724,8 @@ class GetGoodView(PositioningProcedure):
                 logging.debug("Moving closer to object.")
                 return PositioningProcedureResult(actions=[action])
 
+        self._allow_translation = False
+
         on_target_object = self.is_on_target_object(observation)
         if (
             not on_target_object

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -716,6 +716,8 @@ class GetGoodView(PositioningProcedure):
             self._multiple_objects_present
             and not self._executed_multiple_objects_orientation
         ):
+            # Setting this flag to True here ensures that this state machine state is
+            # not revisited.
             self._executed_multiple_objects_orientation = True
             on_target_object = self.is_on_target_object(observation)
             if not on_target_object:
@@ -729,6 +731,8 @@ class GetGoodView(PositioningProcedure):
                 logging.debug("Moving closer to object.")
                 return PositioningProcedureResult(actions=[action])
 
+        # Setting this flag to False here ensures that this state machine state is
+        # not revisited.
         self._allow_translation = False
 
         on_target_object = self.is_on_target_object(observation)

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -716,8 +716,6 @@ class GetGoodView(PositioningProcedure):
             self._multiple_objects_present
             and not self._executed_multiple_objects_orientation
         ):
-            # Current implementation only orients to the object once in the case
-            # where there are multiple objects.
             self._executed_multiple_objects_orientation = True
             on_target_object = self.is_on_target_object(observation)
             if not on_target_object:
@@ -731,8 +729,6 @@ class GetGoodView(PositioningProcedure):
                 logging.debug("Moving closer to object.")
                 return PositioningProcedureResult(actions=[action])
 
-        # If we get here, the current implementation will not attempt to move
-        # closer to the object again.
         self._allow_translation = False
 
         on_target_object = self.is_on_target_object(observation)

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -478,6 +478,7 @@ class GetGoodView(PositioningProcedure):
         self._max_orientation_attempts = max_orientation_attempts
 
         self._num_orientation_attempts = 0
+        self._executed_multiple_objects_orientation = False
 
     def compute_look_amounts(
         self, relative_location: np.ndarray, state: Optional[MotorSystemState] = None
@@ -711,7 +712,11 @@ class GetGoodView(PositioningProcedure):
         observation: Mapping,
         state: Optional[MotorSystemState] = None,
     ) -> PositioningProcedureResult:
-        if self._multiple_objects_present:
+        if (
+            self._multiple_objects_present
+            and not self._executed_multiple_objects_orientation
+        ):
+            self._executed_multiple_objects_orientation = True
             on_target_object = self.is_on_target_object(observation)
             if not on_target_object:
                 return PositioningProcedureResult(


### PR DESCRIPTION
This pull request corrects the GetGoodView positioning procedure to operate exactly like the data loader's current `get_good_view()` code.

## Benchmarks

Here are a few `run_parallel.py` benchmarks from my laptop with old and new code paths. They are for comparison with https://github.com/thousandbrainsproject/tbp.monty/pull/275#issuecomment-2828993390, which had some discrepancies. I now observe no discrepancies.

| GetGoodView | Experiment | Correct (%) | Used MLH (%) | Num Match Steps | Rotation Error | WandB |
|---|---|---|---|---|---|---|
| old | base_config_10distinctobj_dist_agent | 99.28571428571428 | 0 | 35.49285714285714 | 0.30008273381294964 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/l3isif50/overview)
| new | base_config_10distinctobj_dist_agent | 99.28571428571428 | 0 | 35.49285714285714 | 0.30008273381294964 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/thd7ok2b/overview)
| old | randrot_noise_10distinctobj_dist_agent | 100 | 3 | 53.04 | 0.3820000000000001 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/wodxhhmm/overview)
| new | randrot_noise_10distinctobj_dist_agent | 100 | 3 | 53.04 | 0.3820000000000001 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/ypvy54zo/overview)
| old | randrot_noise_10distinctobj_5lms_dist_agent | 100 | 0 | 54.73 | 0.80406485 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/g5cim14p/overview)
| new | randrot_noise_10distinctobj_5lms_dist_agent | 100 | 0 | 54.73 | 0.80406485 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/8iyeat6o/overview)
| old | base_77obj_dist_agent | 93.5064935064935 | 11.255411255411255 | 99.57142857142856 | 0.29177499999999995 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/t105xwl2/overview)
| new | base_77obj_dist_agent | 93.5064935064935 | 11.255411255411255 | 99.57142857142856 | 0.29177499999999995 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/yw56w04a/overview)
| old | base_77obj_surf_agent | 98.7012987012987 | 6.926406926406926 | 53.75757575757576 | 0.17195614035087717 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/iow7d4f7/overview)
| new | base_77obj_surf_agent | 98.7012987012987 | 6.926406926406926 | 53.75757575757576 | 0.17195614035087717 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/v29pgvvc/overview)