### PR TITLE
fix: non-informed Initial possible poses loop order

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -802,8 +802,8 @@ class EvidenceGraphLM(GraphLM):
                 graph_id, input_channel
             )
             # Initialize fixed possible poses (without using pose features)
-            for node_id in range(len(all_channel_locations)):
-                for rotation in self.initial_possible_poses:
+            for rotation in self.initial_possible_poses:
+                for node_id in range(len(all_channel_locations)):
                     initial_possible_channel_locations.append(
                         all_channel_locations[node_id]
                     )


### PR DESCRIPTION
## Problem
While looking into the `_get_initial_hypothesis_space` of `EvidenceGraphLM`, I noticed that the order by which we initialize non-informed hypotheses differs from informed hypotheses. My understanding is that we store the evidence for all locations and then we tile this array for additional rotations. When using uniform (or given) initial poses, we do it the other way around which does not match how we store the initial evidence.

*Note that this looked like a bug to me so I'm labeling it as such, but I could be wrong and there might be something I'm missing here. Either way, I hope to get some feedback here because I'm working on this function for hypotheses resampling.*

![Drawing 2025-05-01 08 03 00 excalidraw](https://github.com/user-attachments/assets/cfade6ea-b768-4f61-b661-29e574a861c4)

## Solution
I just changed the order of the loop so that it would append the node_id first and then stack the rotations. This would match how we store the initial evidence scores.

## Impact
I only ran the benchmark experiment `randrot_noise_10distinctobj_dist_agent` with `uniform` initial poses. The overall accuracy increased from 91 to 96. We rarely use non-informed initial poses so I assume this fix may not have any impact on our workflow or the DMC paper (I hope). Also this is only for the initial evidence set, Monty will overcome this initial setback in subsequent evidence updates anyway.