### PR TITLE
ci: pin python version for monty_publish workflow

### DIFF
--- a/.github/workflows/monty_publish.yml
+++ b/.github/workflows/monty_publish.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           fetch-depth: 2
           path: tbp.monty
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Version updated
         id: version_updated
         if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -78,6 +82,10 @@ jobs:
         with:
           fetch-depth: 2
           path: tbp.monty
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
       - name: Version updated
         id: version_updated
         if: ${{ github.event_name != 'workflow_dispatch' }}


### PR DESCRIPTION
The Monty Publish workflow fails after its default Python version apparently changed to 3.13. 

```
conda install anaconda-client conda-build
...
Channels:
 - defaults
Platform: linux-64
Collecting package metadata (repodata.json): - \ | / - \ | done
Solving environment: - \ | / - \ | failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package conda-build-3.0.22-py27h62b9468_0 requires python >=2.7,<2.8.0a0, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
├─ conda-build =* * is installable with the potential options
│  ├─ conda-build [24.1.0|24.1.1|...|3.28.4] would require
│  │  └─ python >=3.10,<3.11.0a0 *, which can be installed;
│  ├─ conda-build [24.1.0|24.1.1|...|3.28.4] would require
│  │  └─ python >=3.11,<3.12.0a0 *, which can be installed;
│  ├─ conda-build [24.1.0|24.1.1|...|25.4.2] would require
│  │  └─ python >=3.12,<3.13.0a0 *, which can be installed;
│  ├─ conda-build [24.1.0|24.1.1|...|3.28.4] would require
│  │  └─ python >=3.8,<3.9.0a0 *, which can be installed;
│  ├─ conda-build [24.1.0|24.1.1|...|3.28.4] would require
│  │  └─ python >=3.9,<3.10.0a0 *, which can be installed;
│  ├─ conda-build [3.0.22|3.0.23|...|3.9.2] would require
│  │  └─ python >=2.7,<2.8.0a0 *, which can be installed;
│  ├─ conda-build [3.0.22|3.0.23|...|3.9.2] would require
│  │  └─ python >=3.5,<3.6.0a0 *, which can be installed;
│  ├─ conda-build [3.0.22|3.0.23|...|3.9.2] would require
│  │  └─ python >=3.6,<3.7.0a0 *, which can be installed;
│  └─ conda-build [3.10.9|3.11.0|...|3.23.3] would require
│     └─ python >=3.7,<3.8.0a0 *, which can be installed;
└─ pin on python 3.13.* =* * is not installable because it requires
   └─ python =3.13 *, which conflicts with any installable versions previously reported.

Pins seem to be involved in the conflict. Currently pinned specs:
 - python=3.13
```
-- e.g., https://github.com/thousandbrainsproject/tbp.monty/actions/runs/14841400913/job/41668505401

This pull request pins Python version to 3.12 as the highest supported version for `conda-build` per the error.