### PR TITLE
ci: monty_publish workflow installs py312 miniconda

### DIFF
--- a/.github/workflows/monty_publish.yml
+++ b/.github/workflows/monty_publish.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           if [ ! -d ~/miniconda ]
           then
-            wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+            wget https://repo.anaconda.com/miniconda/Miniconda3-py312_25.3.1-1-Linux-x86_64.sh -O ~/miniconda.sh
             bash ~/miniconda.sh -b -p ~/miniconda
             rm ~/miniconda.sh
           fi
@@ -98,7 +98,7 @@ jobs:
         run: |
           if [ ! -d ~/miniconda ]
           then
-            wget https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh -O ~/miniconda.sh
+            wget https://repo.anaconda.com/miniconda/Miniconda3-py312_25.3.1-1-MacOSX-arm64.sh -O ~/miniconda.sh
             bash ~/miniconda.sh -b -p ~/miniconda
             rm ~/miniconda.sh
           fi


### PR DESCRIPTION
Part of the problem with the Monty Publish workflow was using the latest miniconda installation, which pins Python to version 3.13. This pull request pins miniconda to the version that comes with Python 3.12.