### PR TITLE
chore: ignore .envrc files for direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.envrc
 env/
 venv/
 ENV/


### PR DESCRIPTION
I use [direnv](https://direnv.net/) file for defining directory-specific environment variables (e.g., WANDB_DIR) that are only available inside the `tbp.monty` directory, as well as automatically activate and deactivate the conda environment when I `cd` in and out of the `tbp.monty` directory. It's helpful to gitignore the associated dot file `.envrc`.