### PR TITLE
refactor!: remove unused use_get_good_view_positioning_procedure flag

### DIFF
--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -437,18 +437,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
     iv) Supports hypothesis-testing "jump" policy
     """
 
-    def __init__(
-        self, use_get_good_view_positioning_procedure: bool = False, *args, **kwargs
-    ):
+    def __init__(self, *args, **kwargs):
         super(InformedEnvironmentDataLoader, self).__init__(*args, **kwargs)
-        self._use_get_good_view_positioning_procedure = (
-            use_get_good_view_positioning_procedure
-        )
-        """Feature flag to use the GetGoodView positioning procedure.
-
-        This is a temporary feature flag to allow for testing the GetGoodView
-        positioning procedure.
-        """
 
     def __iter__(self):
         # Overwrite original because we don't want to reset agent at this stage


### PR DESCRIPTION
I forgot to remove this flag in #287. It is unused, but as an attribute removal, this is a breaking change `refactor!:`.