### PR TITLE
refactor: remove unused else case

### DIFF
--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -34,7 +34,6 @@ from tbp.monty.frameworks.models.abstract_monty_classes import (
     LearningModule,
     SensorModule,
 )
-from tbp.monty.frameworks.models.monty_base import MontyBase
 from tbp.monty.frameworks.models.motor_policies import MotorPolicy
 from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.frameworks.utils.dataclass_utils import (
@@ -398,23 +397,15 @@ class MontyExperiment:
         # TODO: only defined for MontyForGraphMatching right now, need to add TM later
         # NOTE: later, more levels that Basic or Detailed could be added
 
-        if isinstance(self.model, MontyBase):
-            if self.monty_log_level in self.model.LOGGING_REGISTRY:
-                logger_class = self.model.LOGGING_REGISTRY[self.monty_log_level]
-                self.monty_logger = logger_class(handlers=monty_handlers)
-
-            else:
-                logging.warning(
-                    "Unable to match monty logger to log level"
-                    "An empty logger will be used as a placeholder"
-                )
-                self.monty_logger = BaseMontyLogger(handlers=[])
+        if self.monty_log_level in self.model.LOGGING_REGISTRY:
+            logger_class = self.model.LOGGING_REGISTRY[self.monty_log_level]
+            self.monty_logger = logger_class(handlers=monty_handlers)
         else:
-            raise (
-                NotImplementedError,
-                "Please implement a mapping from monty_log_level to a logger class"
-                f"for models of type {type(self.model)}",
+            logging.warning(
+                "Unable to match monty logger to log level"
+                "An empty logger will be used as a placeholder"
             )
+            self.monty_logger = BaseMontyLogger(handlers=[])
 
         if "log_parallel_wandb" in all_logging_args.keys():
             self.monty_logger.use_parallel_wandb_logging = all_logging_args[


### PR DESCRIPTION
Currently, there is no case where a model is not an instance of `MontyBase`. This pull request removes the else branch that will never be executed.