### PR TITLE
refactor: restructuring of _update_evidence

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -990,7 +990,7 @@ class EvidenceGraphLM(GraphLM):
                     )
                 )
 
-            self._replace_hypotheses_in_hpspace(
+            self._set_hypotheses_in_hpspace(
                 graph_id=graph_id,
                 input_channel=input_channel,
                 new_location_hypotheses=channel_possible_locations,
@@ -1083,7 +1083,7 @@ class EvidenceGraphLM(GraphLM):
             )
         return search_locations, channel_hypotheses_evidence
 
-    def _replace_hypotheses_in_hpspace(
+    def _set_hypotheses_in_hpspace(
         self,
         graph_id: str,
         input_channel: str,

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -1086,11 +1086,11 @@ class EvidenceGraphLM(GraphLM):
             # If past and present weight add up to 1, equivalent to
             # np.average and evidence will be bound to [-1, 2]. Otherwise it
             # keeps growing.
-            evidence = (
+            channel_hypotheses_evidence = (
                 channel_hypotheses_evidence * self.past_weight
                 + evidence_to_add * self.present_weight
             )
-        return search_locations, evidence
+        return search_locations, channel_hypotheses_evidence
 
     def _replace_hypotheses_in_hpspace(
         self,

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -841,37 +841,6 @@ class EvidenceGraphLM(GraphLM):
             evidence,
         )
 
-    def _add_hypotheses_to_hpspace(
-        self,
-        graph_id,
-        input_channel,
-        new_loc_hypotheses,
-        new_rot_hypotheses,
-        new_evidence,
-    ):
-        """Add new hypotheses to hypothesis space."""
-        # Add current mean evidence to give the new hypotheses a fighting
-        # chance. TODO H: Test mean vs. median here.
-        current_mean_evidence = np.mean(self.evidence[graph_id])
-        new_evidence = new_evidence + current_mean_evidence
-        # Add new hypotheses to hypothesis space
-        self.possible_locations[graph_id] = np.vstack(
-            [
-                self.possible_locations[graph_id],
-                new_loc_hypotheses,
-            ]
-        )
-        self.possible_poses[graph_id] = np.vstack(
-            [
-                self.possible_poses[graph_id],
-                new_rot_hypotheses,
-            ]
-        )
-        self.evidence[graph_id] = np.hstack([self.evidence[graph_id], new_evidence])
-        # Update channel hypothesis mapping
-        channel_mapper = self.channel_hypothesis_mapping[graph_id]
-        channel_mapper.add_channel(input_channel, len(new_loc_hypotheses))
-
     def _update_possible_matches(self, query):
         """Update evidence for each hypothesis instead of removing them."""
         thread_list = []

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -988,7 +988,7 @@ class EvidenceGraphLM(GraphLM):
                 # hypotheses should not be affected by the displacement from the last
                 # sensory input.
                 channel_possible_locations, channel_hypotheses_evidence = (
-                    self._displace_hypotheses(
+                    self._displace_hypotheses_and_compute_evidence(
                         features,
                         channel_possible_locations,
                         channel_possible_poses,
@@ -1015,7 +1015,7 @@ class EvidenceGraphLM(GraphLM):
             f" New max evidence: {np.round(np.max(self.evidence[graph_id]), 3)}"
         )
 
-    def _displace_hypotheses(
+    def _displace_hypotheses_and_compute_evidence(
         self,
         features: Dict,
         channel_possible_locations: np.ndarray,

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -1142,10 +1142,8 @@ class EvidenceGraphLM(GraphLM):
             current_mean_evidence = np.mean(self.evidence[graph_id])
             new_evidence = new_evidence + current_mean_evidence
 
-        # This concatenation operation for location, poses and evidence replaces
-        # the existing hypothesis space. The new hypothesis space in inserted
-        # in place of the existing hypothesis space by referencing the channel
-        # start and end indices.
+        # This mapper.update function replaces the hypothesis space with a new one
+        # at the specified input channel range.
         self.possible_locations[graph_id] = mapper.update(
             self.possible_locations[graph_id],
             input_channel,

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -1143,7 +1143,12 @@ class EvidenceGraphLM(GraphLM):
             current_mean_evidence = np.mean(self.evidence[graph_id])
             new_evidence = new_evidence + current_mean_evidence
 
-        # Update the hypothesis space with new locations, poses, and evidence scores
+        # The mapper update function calls below automatically resize the
+        # arrays they update. Afterward, we must update the channel indices
+        # in the mapper via resize_channel_to to stay in sync with
+        # the now resized arrays. We do not resize before array updates
+        # because then, during the update, the indices would not correspond
+        # to the data in the arrays.
         self.possible_locations[graph_id] = mapper.update(
             self.possible_locations[graph_id],
             input_channel,
@@ -1160,7 +1165,6 @@ class EvidenceGraphLM(GraphLM):
             np.array(new_evidence),
         )
 
-        # Resize the hypothesis space for the given input_channel to the new size
         mapper.resize_channel_to(input_channel, len(new_evidence))
 
     def _update_evidence_with_vote(self, state_votes, graph_id):

--- a/src/tbp/monty/frameworks/models/evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching.py
@@ -14,7 +14,7 @@ import copy
 import logging
 import threading
 import time
-from typing import Dict, Tuple
+from typing import Tuple
 
 import numpy as np
 from scipy.spatial import KDTree
@@ -903,8 +903,8 @@ class EvidenceGraphLM(GraphLM):
 
     def _update_evidence(
         self,
-        features: Dict,
-        displacements: Dict | None,
+        features: dict,
+        displacements: dict | None,
         graph_id: str,
     ) -> None:
         """Update evidence based on sensor displacement and sensed features.
@@ -932,8 +932,8 @@ class EvidenceGraphLM(GraphLM):
 
         # Get all usable input channels
         # NOTE: We might also want to check the confidence in the input channel
-        # features. This information is currently not available here. Once we
-        # pull the observation class into the LM we could add this (TODO S).
+        # features. This information is currently not available here.
+        # TODO S: Once we pull the observation class into the LM we could add this.
         input_channels_to_use = [
             ic
             for ic in features.keys()
@@ -1017,11 +1017,11 @@ class EvidenceGraphLM(GraphLM):
 
     def _displace_hypotheses_and_compute_evidence(
         self,
-        features: Dict,
+        features: dict,
         channel_possible_locations: np.ndarray,
         channel_possible_poses: np.ndarray,
         channel_hypotheses_evidence: np.ndarray,
-        displacement: Dict,
+        displacement: dict,
         graph_id: str,
         input_channel: str,
     ) -> Tuple[np.ndarray, np.ndarray]:
@@ -1138,12 +1138,12 @@ class EvidenceGraphLM(GraphLM):
                 return
 
             # Add current mean evidence to give the new hypotheses a fighting
-            # chance. TODO H: Test mean vs. median here.
+            # chance.
+            # TODO H: Test mean vs. median here.
             current_mean_evidence = np.mean(self.evidence[graph_id])
             new_evidence = new_evidence + current_mean_evidence
 
-        # This mapper.update function replaces the hypothesis space with a new one
-        # at the specified input channel range.
+        # Update the hypothesis space with new locations, poses, and evidence scores
         self.possible_locations[graph_id] = mapper.update(
             self.possible_locations[graph_id],
             input_channel,
@@ -1159,6 +1159,8 @@ class EvidenceGraphLM(GraphLM):
             input_channel,
             np.array(new_evidence),
         )
+
+        # Resize the hypothesis space for the given input_channel to the new size
         mapper.resize_channel_to(input_channel, len(new_evidence))
 
     def _update_evidence_with_vote(self, state_votes, graph_id):
@@ -1229,7 +1231,7 @@ class EvidenceGraphLM(GraphLM):
         input_channel: str,
         search_locations: np.ndarray,
         channel_possible_poses: np.ndarray,
-        features: Dict,
+        features: dict,
     ):
         """Use search locations, sensed features and graph model to calculate evidence.
 

--- a/src/tbp/monty/frameworks/utils/evidence_matching.py
+++ b/src/tbp/monty/frameworks/utils/evidence_matching.py
@@ -177,7 +177,14 @@ class ChannelMapper:
         """Inserts data into the original array at the position of the given channel.
 
         This function inserts new data at the index range previously associated with
-        the provided channel.
+        the provided channel. We split the original array around the input channel
+        range, then concatenate the before and after splits with the data to be
+        inserted.
+
+        For example, if original has the shape (20, 3), channel start index is 10,
+        channel end index is 13, and the data has the shape (5, 3). We would concatenate
+        as such: (original[0:10], data, original[13:]). This will result in an array of
+        the shape (22, 3), i.e., we removed 3 rows and added new 5 rows.
 
         Args:
             original (np.ndarray): The original array.

--- a/src/tbp/monty/frameworks/utils/evidence_matching.py
+++ b/src/tbp/monty/frameworks/utils/evidence_matching.py
@@ -54,6 +54,20 @@ class ChannelMapper:
         """
         return sum(self.channel_sizes.values())
 
+    def channel_size(self, channel_name: str) -> int:
+        """Returns the total number of hypotheses for a specific channel.
+
+        Returns:
+            int: Size of channel
+
+        Raises:
+            ValueError: If the channel is not found.
+        """
+        if channel_name not in self.channel_sizes:
+            raise ValueError(f"Channel '{channel_name}' not found.")
+
+        return self.channel_sizes[channel_name]
+
     def channel_range(self, channel_name: str) -> Tuple[int, int]:
         """Returns the start and end indices of the given channel.
 

--- a/src/tbp/monty/frameworks/utils/evidence_matching.py
+++ b/src/tbp/monty/frameworks/utils/evidence_matching.py
@@ -56,20 +56,6 @@ class ChannelMapper:
         """
         return sum(self.channel_sizes.values())
 
-    def channel_size(self, channel_name: str) -> int:
-        """Returns the total number of hypotheses for a specific channel.
-
-        Returns:
-            int: Size of channel
-
-        Raises:
-            ValueError: If the channel is not found.
-        """
-        if channel_name not in self.channel_sizes:
-            raise ValueError(f"Channel '{channel_name}' not found.")
-
-        return self.channel_sizes[channel_name]
-
     def channel_range(self, channel_name: str) -> Tuple[int, int]:
         """Returns the start and end indices of the given channel.
 
@@ -160,7 +146,8 @@ class ChannelMapper:
             channel (str): The name of the channel to extract.
 
         Returns:
-            np.ndarray: The extracted slice of the original array.
+            np.ndarray: The extracted slice of the original array. Returns a view, not
+                a copy of the original array.
 
         Raises:
             ValueError: If the channel is not found.
@@ -179,7 +166,8 @@ class ChannelMapper:
         This function inserts new data at the index range previously associated with
         the provided channel. We split the original array around the input channel
         range, then concatenate the before and after splits with the data to be
-        inserted.
+        inserted. This accommodates 'data' being of a different size than the current
+        channel size.
 
         For example, if original has the shape (20, 3), channel start index is 10,
         channel end index is 13, and the data has the shape (5, 3). We would concatenate
@@ -192,7 +180,8 @@ class ChannelMapper:
             data (np.ndarray): The new data to insert.
 
         Returns:
-            np.ndarray: The resulting array after insertion.
+            np.ndarray: The resulting array after insertion. Returns a new copy not a
+                view.
 
         Raises:
             ValueError: If the channel is not found.

--- a/tests/unit/frameworks/utils/evidence_matching_test.py
+++ b/tests/unit/frameworks/utils/evidence_matching_test.py
@@ -30,6 +30,15 @@ class ChannelMapperTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.mapper.channel_range("D")
 
+    def test_channel_size(self):
+        """Test retrieving total hypotheses for a specific channel."""
+        self.assertEqual(self.mapper.channel_size("A"), 5)
+        self.assertEqual(self.mapper.channel_size("B"), 10)
+        self.assertEqual(self.mapper.channel_size("C"), 15)
+
+        with self.assertRaises(ValueError):
+            self.mapper.channel_size("D")
+
     def test_resize_channel_by_positive(self):
         """Test increasing channel sizes."""
         self.mapper.resize_channel_by("B", 5)

--- a/tests/unit/frameworks/utils/evidence_matching_test.py
+++ b/tests/unit/frameworks/utils/evidence_matching_test.py
@@ -54,6 +54,27 @@ class ChannelMapperTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.mapper.resize_channel_by("A", -10)
 
+    def test_resize_channel_to_valid(self):
+        """Test setting a new size for an existing channel."""
+        self.mapper.resize_channel_to("A", 8)
+        self.assertEqual(self.mapper.channel_size("A"), 8)
+        self.assertEqual(self.mapper.channel_range("A"), (0, 8))
+        self.assertEqual(self.mapper.channel_range("B"), (8, 18))
+        self.assertEqual(self.mapper.channel_range("C"), (18, 33))
+        self.assertEqual(self.mapper.total_size, 33)
+
+    def test_resize_channel_to_invalid_channel(self):
+        """Test resizing a non-existent channel."""
+        with self.assertRaises(ValueError):
+            self.mapper.resize_channel_to("Z", 5)
+
+    def test_resize_channel_to_invalid_size(self):
+        """Test resizing a channel to a non-positive size."""
+        with self.assertRaises(ValueError):
+            self.mapper.resize_channel_to("B", 0)
+        with self.assertRaises(ValueError):
+            self.mapper.resize_channel_to("B", -3)
+
     def test_add_channel(self):
         """Test adding a new channel."""
         self.mapper.add_channel("D", 8)
@@ -73,6 +94,62 @@ class ChannelMapperTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             self.mapper.add_channel("Y", 5, position=10)
+
+    def test_extract_valid_channel(self) -> None:
+        """Test extracting the portion of the array for a valid channel.
+
+        Verifies that the returned data corresponds exactly to the expected slice.
+        """
+        import numpy as np
+
+        original = np.arange(30).reshape(30, 1)
+
+        # Channel "B" occupies indices 5 to 15
+        extracted = self.mapper.extract(original, "B")
+
+        self.assertTrue(np.array_equal(extracted, original[5:15]))
+        self.assertEqual(extracted.shape, (10, 1))
+
+    def test_extract_invalid_channel(self) -> None:
+        """Test that extracting from a non-existent channel raises an error."""
+        import numpy as np
+
+        original = np.arange(30).reshape(30, 1)
+
+        with self.assertRaises(ValueError):
+            self.mapper.extract(original, "Z")
+
+    def test_update_insert_data(self) -> None:
+        """Test inserting new data into a specific channel range.
+
+        Verifies that the new data is inserted at the correct position
+        and that the surrounding data is preserved.
+        """
+        import numpy as np
+
+        original = np.arange(30).reshape(30, 1)
+        new_data = np.array([[100], [101], [102]])
+
+        # Channel "B" originally occupies indices 5 to 15
+        updated = self.mapper.update(original, "B", new_data)
+
+        # original size changed from 30 to 23 (i.e., 30 - (10-3))
+        self.assertEqual(updated.shape[0], 23)
+
+        # The rest of the data stayed the same
+        self.assertTrue(np.array_equal(updated[5:8], new_data))
+        self.assertTrue(np.array_equal(updated[:5], original[:5]))
+        self.assertTrue(np.array_equal(updated[8:], original[15:]))
+
+    def test_update_invalid_channel(self) -> None:
+        """Test that updating a non-existent channel raises an error."""
+        import numpy as np
+
+        original = np.zeros((30, 1))
+        new_data = np.ones((3, 1))
+
+        with self.assertRaises(ValueError):
+            self.mapper.update(original, "Z", new_data)
 
     def test_repr(self):
         """Test string representation of the ChannelMapper."""

--- a/tests/unit/frameworks/utils/evidence_matching_test.py
+++ b/tests/unit/frameworks/utils/evidence_matching_test.py
@@ -30,15 +30,6 @@ class ChannelMapperTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.mapper.channel_range("D")
 
-    def test_channel_size(self):
-        """Test retrieving total hypotheses for a specific channel."""
-        self.assertEqual(self.mapper.channel_size("A"), 5)
-        self.assertEqual(self.mapper.channel_size("B"), 10)
-        self.assertEqual(self.mapper.channel_size("C"), 15)
-
-        with self.assertRaises(ValueError):
-            self.mapper.channel_size("D")
-
     def test_resize_channel_by_positive(self):
         """Test increasing channel sizes."""
         self.mapper.resize_channel_by("B", 5)
@@ -57,7 +48,6 @@ class ChannelMapperTest(unittest.TestCase):
     def test_resize_channel_to_valid(self):
         """Test setting a new size for an existing channel."""
         self.mapper.resize_channel_to("A", 8)
-        self.assertEqual(self.mapper.channel_size("A"), 8)
         self.assertEqual(self.mapper.channel_range("A"), (0, 8))
         self.assertEqual(self.mapper.channel_range("B"), (8, 18))
         self.assertEqual(self.mapper.channel_range("C"), (18, 33))


### PR DESCRIPTION
Based on some discussions with @nielsleadholm [here](https://github.com/thousandbrainsproject/tbp.monty/pull/289#discussion_r2074348453), we agreed to separate out the restructuring of `_update_evidence` in `EvidenceGraphLM` from the resampling logic.

This PR aims to refactor and simplify the `_update_evidence` function. The functionality remains the same but much of the logic has been refactored into other functions (e.g., `_displace_hypotheses`). Some of the refactoring aims to make the functions self-contained. For example instead of passing the range of indices in the hypothesis space and letting the function directly modify the hypothesis space (class variables), I pass the actual hypotheses and return the modified ones. This way these functions can be easily reused, unit-tested, composed, and are less prone to error.

I have tested running the benchmarks `randrot_noise_10distinctobj_dist_agent` and `randrot_noise_10distinctobj_surf_agent`. Both resulted in the exact same performance except for the average time per episode which has increased by 0.0296 seconds for the distant agent and 0.0314 for the surface agent.