### PR TITLE
fix: motor_only_step flag is now always True for motor-only steps

### DIFF
--- a/benchmarks/results/ycb_10objs.csv
+++ b/benchmarks/results/ycb_10objs.csv
@@ -1,13 +1,13 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
 base_config_10distinctobj_dist_agent,100.00,0.00,37,16.04,5,19
-base_config_10distinctobj_surf_agent,100.00,0.00,28,13.18,4,18
+base_config_10distinctobj_surf_agent,100.00,0.00,28,11.66,3,12
 randrot_noise_10distinctobj_dist_agent,100.00,3.00,55,22.35,5,33
 randrot_noise_10distinctobj_dist_on_distm,99.00,1.00,38,12.03,4,28
-randrot_noise_10distinctobj_surf_agent,100.00,0.00,29,22.34,5,33
-randrot_10distinctobj_surf_agent,100.00,1.00,28,18.33,4,21
+randrot_noise_10distinctobj_surf_agent,100.00,0.00,29,21.27,3,19
+randrot_10distinctobj_surf_agent,100.00,1.00,28,18.61,2,11
 randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.26,10,84
-base_10simobj_surf_agent,94.29,10.71,81,13.75,10,50
+base_10simobj_surf_agent,94.29,11.43,84,12.74,6,28
 randrot_noise_10simobj_dist_agent,84.00,40.00,237,34.95,18,147
-randrot_noise_10simobj_surf_agent,93.00,33.00,176,29.79,24,205
-randomrot_rawnoise_10distinctobj_surf_agent,68.00,78.00,16,101.99,17,15
+randrot_noise_10simobj_surf_agent,93.00,34.00,178,30.60,15,134
+randomrot_rawnoise_10distinctobj_surf_agent,68.00,73.00,16,114.56,3,6
 base_10multi_distinctobj_dist_agent,79.29,10.71,31,20.05,43,1

--- a/benchmarks/results/ycb_77objs.csv
+++ b/benchmarks/results/ycb_77objs.csv
@@ -1,6 +1,6 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
 base_77obj_dist_agent,93.51,12.99,108,16.04,62,212
-base_77obj_surf_agent,99.13,6.06,54,10.89,28,82
+base_77obj_surf_agent,99.13,6.06,54,10.74,12,33
 randrot_noise_77obj_dist_agent,89.61,22.51,152,37.24,85,308
-randrot_noise_77obj_surf_agent,92.64,25.11,120,39.53,65,227
+randrot_noise_77obj_surf_agent,91.34,25.11,119,39.21,32,115
 randrot_noise_77obj_5lms_dist_agent,88.31,0.00,70,58.44,32,862

--- a/benchmarks/results/ycb_unsupervised.csv
+++ b/benchmarks/results/ycb_unsupervised.csv
@@ -1,4 +1,4 @@
 Experiment, Correct - 1st Epoch(%)|align right, Correct - >1st Epoch (%)|align right, Mean Objects per Graph|align right, Mean Graphs per Object|align right, Run Time (mins)|align right, Episode Run Time (s)|align right
-surf_agent_unsupervised_10distinctobj,70.00,83.33,1.43,63.60,20,12
-surf_agent_unsupervised_10distinctobj_noise,70.00,67.78,1.19,120.89,25,15
+surf_agent_unsupervised_10distinctobj,70.00,84.44,1.43,1.11,23,14
+surf_agent_unsupervised_10distinctobj_noise,70.00,67.78,1.19,2.11,27,16
 surf_agent_unsupervised_10simobj,40.00,86.67,2.60,74.48,28,17

--- a/benchmarks/results/ycb_unsupervised.csv
+++ b/benchmarks/results/ycb_unsupervised.csv
@@ -1,4 +1,4 @@
 Experiment, Correct - 1st Epoch(%)|align right, Correct - >1st Epoch (%)|align right, Mean Objects per Graph|align right, Mean Graphs per Object|align right, Run Time (mins)|align right, Episode Run Time (s)|align right
 surf_agent_unsupervised_10distinctobj,70.00,84.44,1.43,1.11,23,14
 surf_agent_unsupervised_10distinctobj_noise,70.00,67.78,1.19,2.11,27,16
-surf_agent_unsupervised_10simobj,40.00,86.67,2.60,74.48,28,17
+surf_agent_unsupervised_10simobj,40.00,72.22,2.43,1.7,35,21

--- a/benchmarks/results/ycb_unsupervised_inference.csv
+++ b/benchmarks/results/ycb_unsupervised_inference.csv
@@ -1,3 +1,3 @@
 Experiment,Correct (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
 unsupervised_inference_distinctobj_dist_agent,12.00,100,5,3.0
-unsupervised_inference_distinctobj_surf_agent,4.00,100,11,6.45
+unsupervised_inference_distinctobj_surf_agent,99.00,98,2,16

--- a/benchmarks/results/ycb_unsupervised_inference.csv
+++ b/benchmarks/results/ycb_unsupervised_inference.csv
@@ -1,3 +1,3 @@
 Experiment,Correct (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
 unsupervised_inference_distinctobj_dist_agent,12.00,100,5,3.0
-unsupervised_inference_distinctobj_surf_agent,99.00,98,2,16
+unsupervised_inference_distinctobj_surf_agent,5.00,98,15,9

--- a/docs/overview/benchmark-experiments.md
+++ b/docs/overview/benchmark-experiments.md
@@ -95,11 +95,11 @@ In general, we want to be able to dynamically learn and infer instead of having 
 
 An object is classified as detected correctly if the detected object ID is in the list of objects used for building the graph. This means, if a model was built from multiple objects, there are multiple correct classifications for this model. For example, if we learned a graph from a tomato can and later merge points from a peach can into the same graph, then this graph would be the correct label for tomato and peach cans in the future. This is also why the experiment with similar objects reaches a higher accuracy after the first epoch. Since in the first epoch we build fewer graphs than we saw objects (representing similar objects in the same model) it makes it easier later to recognize these combined models since, for this accuracy measure, we do not need to distinguish the similar objects anymore if they are represented in the same graph. In the most extreme case, if during the first epoch, all objects were merged into a single graph, then the following epochs would get 100% accuracy. As such, future work emphasizing unsupervised learning will also require more fine-grained metrics, such as a dataset with hierarchical labels that appropriately distinguish specific instances (peach-can vs tomato-can), from general ones (cans or even just "cylindrical objects").
 
-## Results
+### Results
 
 !table[../../benchmarks/results/ycb_unsupervised.csv]
 
-To obtain these results use `print_unsupervised_stats(train_stats, epoch_len=10)` (wandb logging is currently not written for unsupervised stats). Unsupervised, continual learning can, by definition, not be parallelized across epochs. Therefore these experiments were run without multiprocessing on the laptop (running on cloud CPUs works as well but since these are slower without parallelization these were run on the laptop).
+To obtain these results use `print_unsupervised_stats(train_stats, epoch_len=10)` (wandb logging is currently not written for unsupervised stats). Unsupervised, continual learning, by definition, cannot be parallelized across epochs. Therefore these experiments were run without multiprocessing (using `run.py`) on the laptop (running on cloud CPUs works as well but since these are slower without parallelization these were run on the laptop).
 
 ## Unsupervised Inference
 
@@ -109,7 +109,7 @@ To simulate such a scenario, we designed an experimental setup that **swaps the 
 
 More specifically, these experiments are run purely in evaluation mode (i.e., pre-trained object graphs are loaded before the experiment begins) with no training or graph updates taking place. Monty stays in the matching phase, continuously updating its internal hypotheses based on sensory observations. For each object, the model performs a fixed number of matching steps before the object is swapped. At the end of each segment, we evaluate whether Monty’s most likely hypothesis correctly identifies the current object. All experiments are performed on 10 distinct objects from the YCB dataset and 10 random rotations for each object. Random noise is added to sensory observations.
 
-## Results
+### Results
 
 !table[../../benchmarks/results/ycb_unsupervised_inference.csv]
 

--- a/docs/overview/benchmark-experiments.md
+++ b/docs/overview/benchmark-experiments.md
@@ -119,6 +119,8 @@ More specifically, these experiments are run purely in evaluation mode (i.e., pr
 > 
 > We do not expect these experiments to have good performance until the RFC is implemented and [issue #214](https://github.com/thousandbrainsproject/tbp.monty/issues/214) is resolved.
 
+These experiments are currently run without multiprocessing (using `run.py`).
+
 # Monty-Meets-World
 
 The following experiments evaluate a Monty model on real-world images derived from the RGBD camera of an iPad/iPhone device. The models that the Monty system leverages are based on photogrammetry scans of the same objects in the real world, and Monty learns on these in the simulated Habitat environment; this approach is taken because currently, we cannot track the movements of the iPad through space, and so Monty cannot leverage its typical sensorimotor learning to build the internal models. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ generate_api_docs_tool = [
     'sphinx-autobuild',
     'myst-parser',
     'pydata_sphinx_theme',
-    'snowballstemmer<3.0.0'
+    'snowballstemmer<3'
 ]
 github_readme_sync_tool = [
     'requests',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,8 @@ generate_api_docs_tool = [
     'sphinx',
     'sphinx-autobuild',
     'myst-parser',
-    'pydata_sphinx_theme'
+    'pydata_sphinx_theme',
+    'snowballstemmer<3.0.0'
 ]
 github_readme_sync_tool = [
     'requests',

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -460,7 +460,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         # NOTE: terminal conditions are now handled in experiment.run_episode loop
         else:
             self._action = self.motor_system()
-            attempting_to_touch_object = False
+            attempting_to_find_object = False
 
             # If entirely off object, use vision (i.e. view-finder)
             # TODO refactor so that this check is done in the motor-policy, and we
@@ -470,7 +470,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 isinstance(self.motor_system._policy, SurfacePolicy)
                 and self._action is None
             ):
-                attempting_to_touch_object = True
+                attempting_to_find_object = True
                 self._action = self.motor_system._policy.touch_object(
                     self._observation,
                     view_sensor_id="view_finder",
@@ -483,17 +483,17 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             # TODO: Refactor this so that all of this is contained within the
             #       SurfacePolicy and/or positioning procedure.
             if isinstance(self.motor_system._policy, SurfacePolicy):
-                # When we are attempting to touch the object, we are always performing
+                # When we are attempting to find the object, we are always performing
                 # a motor-only step.
                 motor_system_state[self.motor_system._policy.agent_id][
                     "motor_only_step"
-                ] = attempting_to_touch_object
+                ] = attempting_to_find_object
 
                 if (
-                    not attempting_to_touch_object
+                    not attempting_to_find_object
                     and self._action.name != OrientVertical.action_name()
                 ):
-                    # We are not attempting to touch the object, which means that we
+                    # We are not attempting to find the object, which means that we
                     # are executing the SurfacePolicy.dynamic_call action cycle.
                     # Out of the four actions in the
                     # MoveForward->OrientHorizontal->OrientVertical->MoveTangentially

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -22,6 +22,7 @@ from tbp.monty.frameworks.actions.actions import (
     Action,
     LookUp,
     MoveTangentially,
+    OrientVertical,
     SetAgentPose,
     SetSensorRotation,
 )
@@ -459,6 +460,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         # NOTE: terminal conditions are now handled in experiment.run_episode loop
         else:
             self._action = self.motor_system()
+            attempting_to_touch_object = False
 
             # If entirely off object, use vision (i.e. view-finder)
             # TODO refactor so that this check is done in the motor-policy, and we
@@ -468,6 +470,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 isinstance(self.motor_system._policy, SurfacePolicy)
                 and self._action is None
             ):
+                attempting_to_touch_object = True
                 self._action = self.motor_system._policy.touch_object(
                     self._observation,
                     view_sensor_id="view_finder",
@@ -477,20 +480,30 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             self._observation, proprioceptive_state = self.dataset[self._action]
             motor_system_state = MotorSystemState(proprioceptive_state)
 
-            # Check whether sensory information is just for feeding back to motor policy
-            # TODO refactor so that the motor policy itself is making this update
-            # when appropriate, not embodied_data
-            if (
-                isinstance(self.motor_system._policy, SurfacePolicy)
-                and self._action.name != "orient_vertical"
-            ):
+            # TODO: Refactor this so that all of this is contained within the
+            #       SurfacePolicy and/or positioning procedure.
+            if isinstance(self.motor_system._policy, SurfacePolicy):
+                # When we are attempting to touch the object, we are always performing
+                # a motor-only step.
                 motor_system_state[self.motor_system._policy.agent_id][
                     "motor_only_step"
-                ] = True
-            else:
-                motor_system_state[self.motor_system._policy.agent_id][
-                    "motor_only_step"
-                ] = False
+                ] = attempting_to_touch_object
+
+                if (
+                    not attempting_to_touch_object
+                    and self._action.name != OrientVertical.action_name()
+                ):
+                    # We are not attempting to touch the object, which means that we
+                    # are executing the SurfacePolicy.dynamic_call action cycle.
+                    # Out of the four actions in the
+                    # MoveForward->OrientHorizontal->OrientVertical->MoveTangentially
+                    # "subroutine" defined in SurfacePolicy.dynamic_call, we only
+                    # want to send data to the learning module after taking the
+                    # OrientVertical action. The other three actions in the cycle
+                    # are motor-only to keep the surface agent on the object.
+                    motor_system_state[self.motor_system._policy.agent_id][
+                        "motor_only_step"
+                    ] = True
 
             self.motor_system._state = motor_system_state
 

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -908,10 +908,10 @@ class PolicyTest(unittest.TestCase):
                 # | 24 | OrientHorizontal | True        | False          | touch_object
                 # | 25 | OrientVertical   | True        | False          | touch_object
                 # | 26 | MoveTangentially | True        | False          | dynamic_call
-                # | 27 | OrientVeritcal   | True        | False          | touch_object
+                # | 27 | OrientVertical   | True        | False          | touch_object
                 # | 28 | MoveForward      | True        | False          | touch_object
                 # | 29 | OrientHorizontal | True        | False          | dynamic_call
-                # | 30 | OrientVeritcal   | True        | True           | dynamic_call
+                # | 30 | OrientVertical   | True        | True           | dynamic_call
                 #
                 # Note that 26 (MoveTangentially) is a bug, in that SurfacePolicy
                 # dynamic_call assumes that it is in the middle of the

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -939,7 +939,7 @@ class PolicyTest(unittest.TestCase):
                         0
                     ].buffer.get_last_obs_processed(), "Should be off object"
 
-                if loader_step == 30:  # MoveForward from SurfacePolicy cycle start
+                if loader_step == 30:  # OrientVertical from SurfacePolicy cycle
                     assert exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), "Should be back on object"

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -892,13 +892,54 @@ class PolicyTest(unittest.TestCase):
             for loader_step, observation in enumerate(exp.dataloader):
                 exp.model.step(observation)
 
-                if loader_step == 24:  # Last step we take before getting back onto the
-                    # object
+                # |Step| Action           | Motor-only? | Obs processed? | Source
+                # |----|------------------|-------------|----------------|-------------
+                # | 13 | OrientHorizontal | True        | False          | touch_object
+                # | 14 | OrientHorizontal | True        | False          | touch_object
+                # | 15 | OrientHorizontal | True        | False          | touch_object
+                # | 16 | OrientHorizontal | True        | False          | touch_object
+                # | 17 | OrientHorizontal | True        | False          | touch_object
+                # | 18 | OrientHorizontal | True        | False          | touch_object
+                # | 19 | OrientHorizontal | True        | False          | touch_object
+                # | 20 | OrientHorizontal | True        | False          | touch_object
+                # | 21 | OrientHorizontal | True        | False          | touch_object
+                # | 22 | OrientHorizontal | True        | False          | touch_object
+                # | 23 | OrientHorizontal | True        | False          | touch_object
+                # | 24 | OrientHorizontal | True        | False          | touch_object
+                # | 25 | OrientVertical   | True        | False          | touch_object
+                # | 26 | MoveTangentially | True        | False          | dynamic_call
+                # | 27 | OrientVeritcal   | True        | False          | touch_object
+                # | 28 | MoveForward      | True        | False          | touch_object
+                # | 29 | OrientHorizontal | True        | False          | dynamic_call
+                # | 30 | OrientVeritcal   | True        | True           | dynamic_call
+                #
+                # Note that 26 (MoveTangentially) is a bug, in that SurfacePolicy
+                # dynamic_call assumes that it is in the middle of the
+                # MoveForward->OrientHorizontal->OrientVertical->MoveTangentially
+                # cycle, but in fact it is not.
+                # As a result, the sensor falls off the object again.
+
+                if 13 <= loader_step <= 25:  # Motor-only touch_object steps
                     assert not exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), "Should be off object"
 
-                if loader_step == 25:
+                if loader_step == 26:  # Incorrect motor-only MoveTangentially
+                    assert not exp.model.learning_modules[
+                        0
+                    ].buffer.get_last_obs_processed(), "Should be off object"
+
+                if 27 <= loader_step <= 28:  # Motor-only touch_object steps
+                    assert not exp.model.learning_modules[
+                        0
+                    ].buffer.get_last_obs_processed(), "Should be off object"
+
+                if loader_step == 29:  # OrientHorizontal from SurfacePolicy cycle start
+                    assert not exp.model.learning_modules[
+                        0
+                    ].buffer.get_last_obs_processed(), "Should be off object"
+
+                if loader_step == 30:  # MoveForward from SurfacePolicy cycle start
                     assert exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), "Should be back on object"


### PR DESCRIPTION
This pull request is best illustrated by showing the trace of actions and their processing results in the `test_surface_policy_moves_back_to_object` test.

Before showing the traces, a quick high-level review of SurfacePolicy's `touch_object` and `dynamic_call`.

The `touch_object` essentially tries to find the object as follows:
- try `OrientHorizontal` repeatedly for up to 360 degrees
- try `OrientVertical` repeatedly for up to 360 degrees (total of 720, it keeps count)
- try random direction
- once object visible, `MoveForward` and success!

The `dynamic_call` is a cycle with three motor-only steps and one where we pass sensor data to the learning module:
- `MoveForward` (motor-only)
- `OrientHorizontal` (motor-only)
- `OrientVertical` (pass to LM)
- `MoveTangentially` (motor-only)

The current data loader code interleaves handling the results of these two methods, and it doesn't get it quite right.

Previous trace of events before this pull request:
```
| Step | Action           | Motor-only? | Obs processed? | Source       | Notes
|------|------------------|-------------|----------------|--------------|------
| 1    | MoveForward      | True        | False          | dynamic_call |
| 2    | OrientHorizontal | True        | False          | dynamic_call |
| 3    | OrientVertical   | False       | True           | dynamic_call |
| 4    | MoveTangentially | True        | False          | dynamic_call |
| 5    | MoveForward      | True        | False          | dynamic_call |
| 6    | OrientHorizontal | True        | False          | dynamic_call |
| 7    | OrientVertical   | False       | True           | dynamic_call |
| 8    | MoveTangentially | True        | False          | dynamic_call |
| 9    | MoveForward      | True        | False          | dynamic_call |
| 10   | OrientHorizontal | True        | False          | dynamic_call |
| 11   | OrientVertical   | False       | True           | dynamic_call |
| 12   | MoveTangentially | True        | False          | dynamic_call | falls off object
| 13   | OrientHorizontal | True        | False          | touch_object |
| 14   | OrientHorizontal | True        | False          | touch_object |
| 15   | OrientHorizontal | True        | False          | touch_object |
| 16   | OrientHorizontal | True        | False          | touch_object |
| 17   | OrientHorizontal | True        | False          | touch_object |
| 18   | OrientHorizontal | True        | False          | touch_object |
| 19   | OrientHorizontal | True        | False          | touch_object |
| 20   | OrientHorizontal | True        | False          | touch_object |
| 21   | OrientHorizontal | True        | False          | touch_object |
| 22   | OrientHorizontal | True        | False          | touch_object |
| 23   | OrientHorizontal | True        | False          | touch_object |
| 24   | OrientHorizontal | True        | False          | touch_object |
| 25   | OrientVertical   | False       | True           | touch_object | Previous test incorrectly asserts that processing observation 25 means "back on object." Also, note that the sensor data is passed to and processed by the LM, even though we are not on the object.
| 26   | MoveTangentially | True        | False          | dynamic_call | We are back on the object, but about to fall off again because of the incorrect assumption that we are in the middle of dynamic_call action cycle.
| 27   | OrientVertical   | False       | False          | touch_object | We are again sending sensor data while not on the object. However, since the sensor did not detect data, the LM did not process the data.
| 28   | MoveForward      | True        | False          | touch_object | Only now we are back on the object. MoveForward is the terminal action of touch_object after it finds the object again.
| 29   | OrientHorizontal | True        | False          | dynamic_call |
| 30   | OrientVertical   | False       | True           | dynamic_call | This is where the previous test should assert we are "back on object" and processed data.
```

The trace of events once this pull request is merged:

```
| Step | Action           | Motor-only? | Obs processed? | Source       | Notes
|------|------------------|-------------|----------------|--------------|------
| 1    | MoveForward      | True        | False          | dynamic_call |
| 2    | OrientHorizontal | True        | False          | dynamic_call |
| 3    | OrientVertical   | False       | True           | dynamic_call |
| 4    | MoveTangentially | True        | False          | dynamic_call |
| 5    | MoveForward      | True        | False          | dynamic_call |
| 6    | OrientHorizontal | True        | False          | dynamic_call |
| 7    | OrientVertical   | False       | True           | dynamic_call |
| 8    | MoveTangentially | True        | False          | dynamic_call |
| 9    | MoveForward      | True        | False          | dynamic_call |
| 10   | OrientHorizontal | True        | False          | dynamic_call |
| 11   | OrientVertical   | False       | True           | dynamic_call |
| 12   | MoveTangentially | True        | False          | dynamic_call | falls off object
| 13   | OrientHorizontal | True        | False          | touch_object |
| 14   | OrientHorizontal | True        | False          | touch_object |
| 15   | OrientHorizontal | True        | False          | touch_object |
| 16   | OrientHorizontal | True        | False          | touch_object |
| 17   | OrientHorizontal | True        | False          | touch_object |
| 18   | OrientHorizontal | True        | False          | touch_object |
| 19   | OrientHorizontal | True        | False          | touch_object |
| 20   | OrientHorizontal | True        | False          | touch_object |
| 21   | OrientHorizontal | True        | False          | touch_object |
| 22   | OrientHorizontal | True        | False          | touch_object |
| 23   | OrientHorizontal | True        | False          | touch_object |
| 24   | OrientHorizontal | True        | False          | touch_object |
| 25   | OrientVertical   | True        | False          | touch_object | This is now a motor-only action and treated as such.
| 26   | MoveTangentially | True        | False          | dynamic_call | We are back on the object, but about to fall off again because of the incorrect assumption that we are in the middle of dynamic_call action cycle.
| 27   | OrientVertical   | True        | False          | touch_object | Again, we are now treating this as a motor-only action.
| 28   | MoveForward      | True        | False          | touch_object | We are back on the object. MoveForward is the terminal action of touch_object after it finds the object again.
| 29   | OrientHorizontal | True        | False          | dynamic_call |
| 30   | OrientVertical   | False       | True           | dynamic_call | We now assert here that we are "back on object" and processed data.
```

The main difference is that we no longer process motor-only steps as non-motor-only steps.

The bug in step 26 where the SurfacePolicy thinks it is in the middle of it's MoveForward->OrientHorizontal->OrientVertical->MoveTangentially cycle is not addressed in this pull request.

## Benchmarks

> [!NOTE]
> There appear to be subtle differences between benchmarks (improvements). See below.

| Code | Experiment | Correct (%) | Used MLH (%) | Num Match Steps | Rotation Error | WandB |
|---|---|---|---|---|---|---|
| old | base_config_10distinctobj_surf_agent | 100 | 0.7142857142857143 | 27.57857142857143 | 0.3179007142857143 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/b80z89c4/overview)
| new | base_config_10distinctobj_surf_agent | 100 | 0.7142857142857143 | 27.514285714285716 | 0.31780785714285714 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/b80z89c4/overview)
| old | base_77obj_surf_agent | 98.7012987012987 | 6.926406926406926 | 53.75757575757576 | 0.17195614035087717 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/iow7d4f7/overview)
| new | base_77obj_surf_agent | 98.7012987012987 | 6.493506493506493 | 53.307359307359306 | 0.1719394736842105 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/y8l9syjb/overview)

FYI @scottcanoe @nielsleadholm @hlee9212. Since you have Monty version pinned this shouldn't matter, but wanted to highlight the issue with SurfacePolicy that I fixed above and the still present subtle bug in the SurfacePolicy (step 26) above. The changes to benchmarks are very subtle, so at first glance it doesn't appear there would be much difference if you were to backport this update to DMC (which is why I wouldn't backport anything).

### Benchmark suite runs

| Benchmark | WandB
|---|---
|base_config_10distinctobj_surf_agent|[overview](https://wandb.ai/thousand-brains-project/Monty/runs/cuyvqizu/overview)
|randrot_noise_10distinctobj_surf_agent|[overview](https://wandb.ai/thousand-brains-project/Monty/runs/gwqeaiwd/overview)
|randrot_10distinctobj_surf_agent|[overview](https://wandb.ai/thousand-brains-project/Monty/runs/t6ch12pr/overview)
|base_10simobj_surf_agent|[overview](https://wandb.ai/thousand-brains-project/Monty/runs/uw4h6n0t/overview)
|randrot_noise_10simobj_surf_agent|[overview](https://wandb.ai/thousand-brains-project/Monty/runs/828xh99q/overview)
|randomrot_rawnoise_10distinctobj_surf_agent|[overview](https://wandb.ai/thousand-brains-project/Monty/runs/efupb36c/overview)
|base_77obj_surf_agent|[overview](https://wandb.ai/thousand-brains-project/Monty/runs/2sf4amy4/overview)
|randrot_noise_77obj_surf_agent|[overview](https://wandb.ai/thousand-brains-project/Monty/runs/3uqnmymx/overview)
|unsupervised_inference_distinctobj_surf_agent|[overview](https://wandb.ai/thousand-brains-project/Monty/runs/u2fzvegt/overview)