### PR TITLE
refactor!: extracted TouchObject positioning procedure from SurfacePolicy

### DIFF
--- a/benchmarks/results/ycb_10objs.csv
+++ b/benchmarks/results/ycb_10objs.csv
@@ -9,5 +9,5 @@ randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.26,10,84
 base_10simobj_surf_agent,95.00,10.71,55,15.49,12,24
 randrot_noise_10simobj_dist_agent,84.00,40.00,237,34.95,18,147
 randrot_noise_10simobj_surf_agent,93.00,36.00,181,31.14,17,146
-randomrot_rawnoise_10distinctobj_surf_agent,69.00,74.00,15,111.45,4,6
+randomrot_rawnoise_10distinctobj_surf_agent,68.00,72.00,15,89.35,6,7
 base_10multi_distinctobj_dist_agent,79.29,10.71,31,20.05,43,1

--- a/benchmarks/results/ycb_10objs.csv
+++ b/benchmarks/results/ycb_10objs.csv
@@ -1,12 +1,12 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
 base_config_10distinctobj_dist_agent,100.00,0.00,37,16.04,5,19
-base_config_10distinctobj_surf_agent,100.00,0.00,28,11.62,2,10
+base_config_10distinctobj_surf_agent,100.00,2.14,27,18.04,5,10
 randrot_noise_10distinctobj_dist_agent,100.00,3.00,55,22.35,5,33
 randrot_noise_10distinctobj_dist_on_distm,99.00,1.00,38,12.03,4,28
-randrot_noise_10distinctobj_surf_agent,100.00,1.00,28,21.53,3,19
-randrot_10distinctobj_surf_agent,100.00,1.00,28,20.17,2,10
+randrot_noise_10distinctobj_surf_agent,100.00,4.00,28,31.12,5,17
+randrot_10distinctobj_surf_agent,100.00,2.00,27,19.11,4,11
 randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.26,10,84
-base_10simobj_surf_agent,94.29,11.43,86,14.08,6,31
+base_10simobj_surf_agent,95.00,10.71,55,15.49,12,24
 randrot_noise_10simobj_dist_agent,84.00,40.00,237,34.95,18,147
 randrot_noise_10simobj_surf_agent,93.00,36.00,181,31.14,17,146
 randomrot_rawnoise_10distinctobj_surf_agent,69.00,74.00,15,111.45,4,6

--- a/benchmarks/results/ycb_77objs.csv
+++ b/benchmarks/results/ycb_77objs.csv
@@ -1,6 +1,6 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
 base_77obj_dist_agent,93.51,12.99,108,16.04,62,212
-base_77obj_surf_agent,99.13,7.36,57,12.82,12,35
+base_77obj_surf_agent,98.27,8.66,42,9.20,17,26
 randrot_noise_77obj_dist_agent,89.61,22.51,152,37.24,85,308
 randrot_noise_77obj_surf_agent,93.51,25.11,123,38.61,35,128
 randrot_noise_77obj_5lms_dist_agent,88.31,0.00,70,58.44,32,862

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ show_contexts = true
 [tool.mypy]
 warn_unused_configs = true
 # TODO: This effectively disables mypy, don't ignore once types are added
-# ignore_errors = true
+ignore_errors = true
 # TODO: Remove global ignore and handle missing type stubs
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ show_contexts = true
 [tool.mypy]
 warn_unused_configs = true
 # TODO: This effectively disables mypy, don't ignore once types are added
-ignore_errors = true
+# ignore_errors = true
 # TODO: Remove global ignore and handle missing type stubs
 ignore_missing_imports = true
 
@@ -227,6 +227,7 @@ ignore = [
     "ISC001", # ISC001: Implicitly concatenated string literals on one line
     "ISC003", # ISC003: Explicitly concatenated string should be implicitly concatenated
     "N804", # N804: First argument of a class method should be named `cls`
+    "N818", # N818: Exception name {exception} should be named with an Error suffix
     "NPY002", # NPY002: Replace legacy `np.random.normal` call with `np.random.Generator`
     "PD002", # PD002: `inplace=True` should be avoided; it has inconsistent behavior
     "PD901", # PD901: Avoid using the generic variable name `df` for DataFrames

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -502,8 +502,6 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 isinstance(self.motor_system._policy, SurfacePolicy)
                 and self._action.name != OrientVertical.action_name()
             ):
-                # We are not attempting to find the object, which means that we
-                # are executing the SurfacePolicy.dynamic_call action cycle.
                 # Out of the four actions in the
                 # MoveForward->OrientHorizontal->OrientVertical->MoveTangentially
                 # "subroutine" defined in SurfacePolicy.dynamic_call, we only
@@ -516,7 +514,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
 
             self.motor_system._state = motor_system_state
 
-            self._counter += 1  # TODO clean up incrementing of counter
+            self._counter += 1
 
             return self._observation
 

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -465,6 +465,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
             try:
                 self._action = self.motor_system()
             except ObjectNotVisible:
+                # Note: Only SurfacePolicy raises ObjectNotVisible.
                 # TODO: Note that a PositioningProcedure is not a MotorPolicy, so
                 #       using it here to keep the agent in touch with the surface is
                 #       questionable. However, in order for the SurfacePolicy to
@@ -476,22 +477,21 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
                 #       the TouchObject positioning procedure instead of raising
                 #       ObjectNotVisible and relying on the dataloader to handle
                 #       this.
-                if isinstance(self.motor_system._policy, SurfacePolicy):
-                    self.touch_object(
-                        sensor_id="view_finder",
-                        desired_object_distance=self.motor_system._policy.desired_object_distance,
-                    )
-                    # TODO: Remove this short-circuit once SurfacePolicy is capable
-                    #       of receiving updated observation via
-                    #       `motor_system(observation)`. For now, we are relying
-                    #       on the experiment to check for motor_only_step and then
-                    #       to `pass_features_directly_to_motor_system(observation)`
-                    #       in order to pass the updated observation to the motor
-                    #       system policy.
-                    self.motor_system._state[self.motor_system._policy.agent_id][
-                        "motor_only_step"
-                    ] = True
-                    return self._observation
+                self.touch_object(
+                    sensor_id="view_finder",
+                    desired_object_distance=self.motor_system._policy.desired_object_distance,
+                )
+                # TODO: Remove this short-circuit once SurfacePolicy is capable
+                #       of receiving updated observation via
+                #       `motor_system(observation)`. For now, we are relying
+                #       on the experiment to check for motor_only_step and then
+                #       to `pass_features_directly_to_motor_system(observation)`
+                #       in order to pass the updated observation to the motor
+                #       system policy.
+                self.motor_system._state[self.motor_system._policy.agent_id][
+                    "motor_only_step"
+                ] = True
+                return self._observation
 
             self._observation, proprioceptive_state = self.dataset[self._action]
             motor_system_state = MotorSystemState(proprioceptive_state)

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -854,6 +854,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         if not result.success:
             raise ObjectNotVisible
 
+
 class OmniglotDataLoader(EnvironmentDataLoaderPerObject):
     """Dataloader for Omniglot dataset."""
 

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1249,7 +1249,7 @@ class SurfacePolicy(InformedPolicy):
     ###
     def dynamic_call(
         self, state: MotorSystemState | None = None
-    ) -> MoveForward | OrientHorizontal | OrientVertical | MoveTangentially | None:
+    ) -> MoveForward | MoveTangentially | OrientHorizontal | OrientVertical:
         """Return the next action to take.
 
         This requires self.processed_observations to be updated at every step
@@ -1261,7 +1261,7 @@ class SurfacePolicy(InformedPolicy):
                 Defaults to None.
 
         Returns:
-            (MoveForward | OrientHorizontal | OrientVertical | MoveTangentially | None):
+            (MoveForward | MoveTangentially | OrientHorizontal | OrientVertical):
                 The action to take.
 
         Raises:
@@ -1378,7 +1378,7 @@ class SurfacePolicy(InformedPolicy):
 
     def get_next_action(
         self, state: MotorSystemState
-    ) -> MoveForward | OrientHorizontal | OrientVertical | MoveTangentially | None:
+    ) -> MoveForward | MoveTangentially | OrientHorizontal | OrientVertical:
         """Retrieve next action from a cycle of four actions.
 
         First move forward to touch the object at the right distance
@@ -1391,13 +1391,9 @@ class SurfacePolicy(InformedPolicy):
             state (MotorSystemState): The current state of the motor system.
 
         Returns:
-            (MoveForward | OrientHorizontal | OrientVertical | MoveTangentially | None):
+            (MoveForward | MoveTangentially | OrientHorizontal | OrientVertical):
                 Next action in the cycle.
         """
-        # TODO: is this check necessary?
-        if not hasattr(self, "processed_observations"):
-            return None
-
         last_action = self.last_action
 
         if isinstance(last_action, MoveForward):

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -394,6 +394,28 @@ class PositioningProcedure(BasePolicy):
     indicates that the procedure has terminated or truncated.
     """
 
+    @classmethod
+    def depth_at_center(
+        cls,
+        agent_id: str,
+        observation: Mapping,
+        sensor_id: str,
+    ) -> float:
+        """Determine the depth of the central pixel for the sensor.
+
+        Args:
+            agent_id (str): The ID of the agent to use.
+            observation (Mapping): The observation to use.
+            sensor_id (str): The ID of the sensor to use.
+
+        Returns:
+            (float): The depth of the central pixel for the sensor.
+        """
+        observation_shape = observation[agent_id][sensor_id]["depth"].shape
+        return observation[agent_id][sensor_id]["depth"][
+            observation_shape[0] // 2, observation_shape[1] // 2
+        ]
+
     @abc.abstractmethod
     def positioning_call(
         self,
@@ -450,7 +472,7 @@ class GetGoodView(PositioningProcedure):
         max_orientation_attempts: int = 1,
         **kwargs,
     ) -> None:
-        """Initialize the GetGoodView policy.
+        """Initialize the GetGoodView positioning procedure.
 
         Args:
             desired_object_distance (float): The desired distance to the object.
@@ -710,7 +732,7 @@ class GetGoodView(PositioningProcedure):
     def positioning_call(
         self,
         observation: Mapping,
-        state: Optional[MotorSystemState] = None,
+        state: MotorSystemState | None = None,
     ) -> PositioningProcedureResult:
         if (
             self._multiple_objects_present
@@ -766,6 +788,157 @@ class GetGoodView(PositioningProcedure):
         sensor_rotation = agent_state["sensors"][f"{self._sensor_id}.depth"]["rotation"]
         # Derive sensor's rotation relative to the world.
         return agent_rotation * sensor_rotation
+
+
+class ObjectNotVisible(RuntimeError):
+    """Error raised when the object is not visible."""
+
+
+class TouchObject(PositioningProcedure):
+    """Positioning procedure to touch an object.
+
+    Called at the beginning of each episode and after "jump" has been initiated
+    by a model-based policy. In addition, it can be called when the surface agent
+    cannot sense the object, e.g. because it has fallen off its surface.
+
+    If we are not on the object, first try systematically orienting left around
+    a point, then orienting down, and finally random orientations along the surface
+    of a fixed sphere.
+    """
+
+    def __init__(
+        self,
+        desired_object_distance: float,
+        sensor_id: str,
+        **kwargs,
+    ) -> None:
+        """Initialize the TouchObject positioning procedure.
+
+        Args:
+            desired_object_distance (float): The desired distance to the object.
+            sensor_id (str): The ID of the sensor to use for positioning.
+            **kwargs: Additional keyword arguments.
+        """
+        super().__init__(**kwargs)
+        self._desired_object_distance = desired_object_distance
+        self._sensor_id = sensor_id
+        self._terminated_and_succeeded = False
+        """Flag to indicate that the procedure has terminated and succeeded.
+
+        Since the PositioningProcedure is a state machine, we first return the last
+        action to take while setting this flag to True, then, on the next invocation,
+        we return a PositioningProcedureResult with success=True, terminated=True.
+        """
+        self._touch_search_rotation_degrees = 0.0
+        """Tracks how many degrees the agent has rotated in search planes.
+
+        Search begins in the horizontal plane. When this reaches 360, attempt searching
+        in the vertical plane. When this reaches 720, perform a random search.
+        """
+
+    def positioning_call(
+        self, observation: Mapping, state: MotorSystemState | None = None
+    ) -> PositioningProcedureResult:
+        if self._terminated_and_succeeded:
+            return PositioningProcedureResult(success=True, terminated=True)
+
+        depth_at_center = PositioningProcedure.depth_at_center(
+            agent_id=self.agent_id, observation=observation, sensor_id=self._sensor_id
+        )
+        # If the viewfinder sees the object within range, then move to it
+        if depth_at_center < 1.0:
+            distance = (
+                depth_at_center
+                - self._desired_object_distance
+                - state["agent_id_0"]["sensors"][f"{self._sensor_id}.depth"][
+                    "position"
+                ][2]
+            )
+            logging.debug(f"Move to touch visible object, forward by {distance}")
+
+            self._terminated_and_succeeded = True
+            return PositioningProcedureResult(
+                actions=[MoveForward(agent_id=self.agent_id, distance=distance)]
+            )
+
+        logging.debug("TouchObject positioning procedure searching for object...")
+
+        # Helpful to conceptualize these movements by considering a unit circle,
+        # scaled by the radius distance_from_center
+        # This image may be useful for intuition:
+        # https://en.wikipedia.org/wiki/Exsecant#/media/File:Circle-trig6.svg
+
+        # Rotate about a circle centered in fron of the agent's current
+        # position; TODO decide how to deal with "coliding with"/entering an
+        # object; ?could just rotate about a point on which the sensor is present
+        # Currently as a heuristic we rotate about a point 4x the desired distance;
+        # as this is typically 2.5cm, this would mean a circle with radius 10cm
+        distance_from_center = self._desired_object_distance * 4
+
+        rotation_degrees = 30  # 30 degrees at a time; note this amount is also used
+        # to eventually re-orient ourselves back to the original central point;
+        # TODO may want to consider trying smaller step-sizes; will
+        # be less efficient, but may be important for smaller/distant objects that
+        # otherwise get missed
+
+        if self._touch_search_rotation_degrees >= 720:
+            # Perform a random upward or downward movement along the surface of a
+            # sphere, with its centre fixed 10 cm in front of the agent
+            logging.debug("Trying random search for object")
+            if self.rng.uniform() < 0.5:
+                orientation = "vertical"
+                logging.debug("Orienting vertically")
+            else:
+                orientation = "horizontal"
+                logging.debug("Orienting horizontally")
+
+            rotation_degrees = self.rng.uniform(-180, 180)
+            logging.debug(f"Random orientation amount is : {rotation_degrees}")
+
+        elif (
+            self._touch_search_rotation_degrees >= 360
+            and self._touch_search_rotation_degrees < 720
+        ):
+            logging.debug("Trying vertical search for object")
+            orientation = "vertical"
+
+        else:
+            logging.debug("Trying horizontal search for object")
+            orientation = "horizontal"
+
+        # Move tangentally to the point we're facing, resulting in the agent's
+        # orienation about the central point changing as specified by rotation_deg,
+        # but now where the agent is no longer on the edge of the circle
+        move_lat_amount = np.tan(np.radians(rotation_degrees)) * distance_from_center
+        # The lateral movement will be down relative to the agent's facing position
+        # in the case of orient vertical, and left in the case of orient horizontal
+
+        # The below calculates the exsecant, which provides the necessary
+        # movement to bring the agent back to the same radius around the central
+        # point
+        move_forward_amount = distance_from_center * (
+            (1 - np.cos(np.radians(rotation_degrees)))
+            / np.cos(np.radians(rotation_degrees))
+        )
+
+        self._touch_search_rotation_degrees += rotation_degrees
+
+        action = (
+            OrientVertical(
+                agent_id=self.agent_id,
+                rotation_degrees=rotation_degrees,
+                down_distance=move_lat_amount,
+                forward_distance=move_forward_amount,
+            )
+            if orientation == "vertical"
+            else OrientHorizontal(
+                agent_id=self.agent_id,
+                rotation_degrees=rotation_degrees,
+                left_distance=move_lat_amount,
+                forward_distance=move_forward_amount,
+            )
+        )
+        return PositioningProcedureResult(actions=[action])
 
 
 class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
@@ -830,40 +1003,6 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
             JumpToGoalStateMixin.pre_episode(self)
 
         return super().pre_episode()
-
-    def get_depth_at_center(self, raw_observation, view_sensor_id, initial_pose=True):
-        """Determine the depth of the central pixel.
-
-        Method primarily used by surface-agent, but also by distant agent after
-        performing a hypothesis-testing jump; determines the depth of the central pixel,
-        to inform whether the object is visible at all
-
-        initial_pose : Whether we are checking depth-at center as part of the first
-            start of an experiment; if using get_depth_at_center to check for
-            the observation after e.g. a hypothesis-testing jump, then we don't
-            want to throw an error if the object is nowhere to be seen; instead, we
-            simply move back
-
-        Returns:
-            Depth at the center of the view sensor.
-        """
-        observation_shape = raw_observation[self.agent_id][view_sensor_id][
-            "depth"
-        ].shape
-        depth_at_center = raw_observation[self.agent_id][view_sensor_id]["depth"][
-            observation_shape[0] // 2, observation_shape[1] // 2
-        ]
-        if initial_pose:
-            assert depth_at_center > 0, (
-                "Object must be initialized such that "
-                "agent can visualize it by moving forward"
-            )
-            # TODO investigate - I think this may have always been passing in the
-            # original surface-agent policy implementation because the surface
-            # sensor clips at 1.0, so even if the object isn't strictly visible (or
-            # we're inside the object))  there's a risk we have initialized without the
-            # object in view
-        return depth_at_center
 
     ###
     # Methods that define behavior of __call__
@@ -1105,129 +1244,12 @@ class SurfacePolicy(InformedPolicy):
 
         return super().pre_episode()
 
-    def touch_object(
-        self, raw_observation, view_sensor_id: str, state: MotorSystemState
-    ) -> MoveForward | OrientHorizontal | OrientVertical:
-        """The surface agent's policy for moving onto an object for sensing it.
-
-        Like the distant agent's get_good_view, this is called at the beginning
-        of every episode, and after a "jump" has been initialized by a
-        model-based policy. In addition, it can be called when the surface agent
-        cannot sense the object, e.g. because it has fallen off its surface.
-
-        Currently uses the raw observations returned from the viewfinder via the
-        dataloader, and not the extracted features from the sensor module.
-        TODO M refactor this so that all sensory processing is done in the sensor
-        module.
-
-        If we aren't on the object, try first systematically orienting left around
-        a point, then orienting down, and finally random orientations along the surface
-        of a fixed sphere.
-
-        Args:
-            raw_observation: The raw observation from the simulator.
-            view_sensor_id (str): The ID of the viewfinder sensor.
-            state (MotorSystemState): The current state of the motor system.
-
-        Returns:
-            (MoveForward | OrientHorizontal | OrientVertical): Action to take.
-        """
-        # If the viewfinder sees the object within range, then move to it
-        depth_at_center = self.get_depth_at_center(raw_observation, view_sensor_id)
-        if depth_at_center < 1.0:
-            distance = (
-                depth_at_center
-                - self.desired_object_distance
-                - state["agent_id_0"]["sensors"][f"{view_sensor_id}.depth"]["position"][
-                    2
-                ]
-            )
-            logging.debug(f"Move to touch visible object, forward by {distance}")
-
-            return MoveForward(agent_id=self.agent_id, distance=distance)
-
-        logging.debug("Surface policy searching for object...")
-
-        # Helpful to conceptualize these movements by considering a unit circle,
-        # scaled by the radius distance_from_center
-        # This image may be useful for intuition:
-        # https://en.wikipedia.org/wiki/Exsecant#/media/File:Circle-trig6.svg
-
-        # Rotate about a circle centered in fron of the agent's current
-        # position; TODO decide how to deal with "coliding with"/entering an
-        # object; ?could just rotate about a point on which the sensor is present
-        # Currently as a heuristic we rotate about a point 4x the desired distance;
-        # as this is typically 2.5cm, this would mean a circle with radius 10cm
-        distance_from_center = self.desired_object_distance * 4
-
-        rotation_degrees = 30  # 30 degrees at a time; note this amount is also used
-        # to eventually re-orient ourselves back to the original central point;
-        # TODO may want to consider trying smaller step-sizes; will
-        # be less efficient, but may be important for smaller/distant objects that
-        # otherwise get missed
-
-        if self.touch_search_amount >= 720:
-            # Perform a random upward or downward movement along the surface of a
-            # sphere, with its centre fixed 10 cm in front of the agent
-            logging.debug("Trying random search for object")
-            if self.rng.uniform() < 0.5:
-                orientation = "vertical"
-                logging.debug("Orienting vertically")
-            else:
-                orientation = "horizontal"
-                logging.debug("Orienting horizontally")
-
-            rotation_degrees = self.rng.uniform(-180, 180)
-            logging.debug(f"Random orientation amount is : {rotation_degrees}")
-
-        elif self.touch_search_amount >= 360 and self.touch_search_amount < 720:
-            logging.debug("Trying vertical search for object")
-            orientation = "vertical"
-
-        else:
-            logging.debug("Trying horizontal search for object")
-            orientation = "horizontal"
-
-        # Move tangentally to the point we're facing, resulting in the agent's
-        # orienation about the central point changing as specified by rotation_deg,
-        # but now where the agent is no longer on the edge of the circle
-        move_lat_amount = np.tan(np.radians(rotation_degrees)) * distance_from_center
-        # The lateral movement will be down relative to the agent's facing position
-        # in the case of orient vertical, and left in the case of orient horizontal
-
-        # The below calculates the exsecant, which provides the necessary
-        # movement to bring the agent back to the same radius around the central
-        # point
-        move_forward_amount = distance_from_center * (
-            (1 - np.cos(np.radians(rotation_degrees)))
-            / np.cos(np.radians(rotation_degrees))
-        )
-
-        self.touch_search_amount += rotation_degrees  # Accumulate total rotations
-        # for touch-search
-
-        return (
-            OrientVertical(
-                agent_id=self.agent_id,
-                rotation_degrees=rotation_degrees,
-                down_distance=move_lat_amount,
-                forward_distance=move_forward_amount,
-            )
-            if orientation == "vertical"
-            else OrientHorizontal(
-                agent_id=self.agent_id,
-                rotation_degrees=rotation_degrees,
-                left_distance=move_lat_amount,
-                forward_distance=move_forward_amount,
-            )
-        )
-
     ###
     # Methods that define behavior of __call__
     ###
     def dynamic_call(
-        self, state: Optional[MotorSystemState] = None
-    ) -> OrientHorizontal | OrientVertical | MoveTangentially | MoveForward | None:
+        self, state: MotorSystemState | None = None
+    ) -> MoveForward | OrientHorizontal | OrientVertical | MoveTangentially | None:
         """Return the next action to take.
 
         This requires self.processed_observations to be updated at every step
@@ -1239,8 +1261,11 @@ class SurfacePolicy(InformedPolicy):
                 Defaults to None.
 
         Returns:
-            (OrientHorizontal | OrientVertical | MoveTangentially | MoveForward | None):
+            (MoveForward | OrientHorizontal | OrientVertical | MoveTangentially | None):
                 The action to take.
+
+        Raises:
+            ObjectNotVisible: If the object is not visible.
         """
         # Check if we have poor visualization of the object
         if self.processed_observations.get_feature_by_name("object_coverage") < 0.1:
@@ -1250,11 +1275,7 @@ class SurfacePolicy(InformedPolicy):
                     self.processed_observations.get_feature_by_name("object_coverage")
                 )
             )
-            logging.debug("Initiating attempts to touch object")
-
-            return None  # Will result in moving to try to find the object
-            # This is determined by some logic in embodied_data.py, in particular
-            # the next method of InformedEnvironmentDataLoader
+            raise ObjectNotVisible
 
         elif self.action is None:
             logging.debug(
@@ -1357,7 +1378,7 @@ class SurfacePolicy(InformedPolicy):
 
     def get_next_action(
         self, state: MotorSystemState
-    ) -> OrientHorizontal | OrientVertical | MoveTangentially | MoveForward | None:
+    ) -> MoveForward | OrientHorizontal | OrientVertical | MoveTangentially | None:
         """Retrieve next action from a cycle of four actions.
 
         First move forward to touch the object at the right distance
@@ -1370,7 +1391,8 @@ class SurfacePolicy(InformedPolicy):
             state (MotorSystemState): The current state of the motor system.
 
         Returns:
-            Next action in the cycle.
+            (MoveForward | OrientHorizontal | OrientVertical | MoveTangentially | None):
+                Next action in the cycle.
         """
         # TODO: is this check necessary?
         if not hasattr(self, "processed_observations"):

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -894,109 +894,80 @@ class PolicyTest(unittest.TestCase):
 
                 #  Step | Action           | Motor-only? | Obs processed? | Source
                 # ------|------------------|-------------|----------------|-------------
-                #  1    | MoveForward      | True        | False          | dynamic_call
+                #  0    | None             | True        | False          | first_step
+                #  1    | MoveForward      | True        | False          | touch_object
                 #  2    | OrientHorizontal | True        | False          | dynamic_call
-                #  3    | OrientVertical   | False       | True           | dynamic_call
+                #  3    | OrientVertical   | KeyError    | True           | dynamic_call
                 #  4    | MoveTangentially | True        | False          | dynamic_call
                 #  5    | MoveForward      | True        | False          | dynamic_call
                 #  6    | OrientHorizontal | True        | False          | dynamic_call
-                #  7    | OrientVertical   | False       | True           | dynamic_call
+                #  7    | OrientVertical   | KeyError    | True           | dynamic_call
                 #  8    | MoveTangentially | True        | False          | dynamic_call
                 #  9    | MoveForward      | True        | False          | dynamic_call
                 #  10   | OrientHorizontal | True        | False          | dynamic_call
-                #  11   | OrientVertical   | False       | True           | dynamic_call
+                #  11   | OrientVertical   | KeyError    | True           | dynamic_call
                 #  12   | MoveTangentially | True        | False          | dynamic_call
                 # falls off object
-                #  13   | OrientHorizontal | True        | False          | touch_object
-                #  14   | OrientHorizontal | True        | False          | touch_object
-                #  15   | OrientHorizontal | True        | False          | touch_object
-                #  16   | OrientHorizontal | True        | False          | touch_object
-                #  17   | OrientHorizontal | True        | False          | touch_object
-                #  18   | OrientHorizontal | True        | False          | touch_object
-                #  19   | OrientHorizontal | True        | False          | touch_object
-                #  20   | OrientHorizontal | True        | False          | touch_object
-                #  21   | OrientHorizontal | True        | False          | touch_object
-                #  22   | OrientHorizontal | True        | False          | touch_object
-                #  23   | OrientHorizontal | True        | False          | touch_object
-                #  24   | OrientHorizontal | True        | False          | touch_object
-                #  25   | OrientVertical   | True        | False          | touch_object
+                # dataloder runs TouchObject positioning procedure in a tight loop only
+                # exposing a new observation at the end of the loop
+                #  13   | MoveForward      | True        | False          | touch_object
                 # back on object
-                #  26   | OrientHorizontal | True        | False          | dynamic_call
-                #  27   | OrientVertical   | False       | True           | dynamic_call
-                #  28   | MoveTangentially | True        | False          | dynamic_call
+                #  14   | MoveForward      | True        | False          | dynamic_call
+                #  15   | OrientHorizontal | True        | False          | dynamic_call
+                #  16   | OrientVertical   | KeyError    | True           | dynamic_call
+                #  17   | MoveTangentially | True        | False          | dynamic_call
                 # falls off object
-                #  29   | OrientHorizontal | True        | False          | touch_object
-                #  30   | OrientHorizontal | True        | False          | touch_object
-                #  31   | OrientHorizontal | True        | False          | touch_object
-                #  32   | OrientHorizontal | True        | False          | touch_object
-                #  33   | OrientHorizontal | True        | False          | touch_object
-                #  34   | OrientHorizontal | True        | False          | touch_object
-                #  35   | OrientHorizontal | True        | False          | touch_object
-                #  36   | OrientHorizontal | True        | False          | touch_object
-                #  37   | OrientHorizontal | True        | False          | touch_object
-                #  38   | OrientHorizontal | True        | False          | touch_object
-                #  39   | OrientHorizontal | True        | False          | touch_object
-                #  40   | OrientHorizontal | True        | False          | touch_object
-                #  41   | OrientVertical   | True        | False          | touch_object
-                #  42   | MoveForward      | True        | False          | touch_object
+                # dataloder runs TouchObject positioning procedure in a tight loop only
+                # exposing a new observation at the end of the loop
+                #  18   | MoveForward      | True        | False          | touch_object
                 # back on object
-                #  43   | OrientHorizontal | True        | False          | dynamic_call
-                #  44   | OrientVertical   | False       | True           | dynamic_call
-                #  45   | MoveTangentially | True        | False          | dynamic_call
+                #  19   | MoveForward      | True        | False          | dynamic_call
+                #  20   | OrientHorizontal | True        | False          | dynamic_call
+                #  21   | OrientVertical   | KeyError    | True           | dynamic_call
+                #  22   | MoveTangentially | True        | False          | dynamic_call
                 # falls off object
-                #  46   | OrientHorizontal | True        | False          | touch_object
-                #  47   | OrientHorizontal | True        | False          | touch_object
-                #  48   | OrientHorizontal | True        | False          | touch_object
-                #  49   | OrientHorizontal | True        | False          | touch_object
-                #  50   | OrientHorizontal | True        | False          | touch_object
-                #  51   | OrientHorizontal | True        | False          | touch_object
-                #  52   | OrientHorizontal | True        | False          | touch_object
-                #  53   | OrientHorizontal | True        | False          | touch_object
-                #  54   | OrientHorizontal | True        | False          | touch_object
-                #  55   | OrientHorizontal | True        | False          | touch_object
-                #  56   | OrientHorizontal | True        | False          | touch_object
-                #  57   | OrientHorizontal | True        | False          | touch_object
-                #  58   | OrientVertical   | True        | False          | touch_object
+                # dataloder runs TouchObject positioning procedure in a tight loop only
+                # exposing a new observation at the end of the loop
+                #  23   | MoveForward      | True        | False          | touch_object
                 # back on object
-                #  59   | OrientHorizontal | True        | False          | dynamic_call
-                #  60   | OrientVertical   | False       | True           | dynamic_call
-                #  61   | MoveTangentially | True        | False          | dynamic_call
+                #  24   | MoveForward      | True        | False          | dynamic_call
+                #  25   | OrientHorizontal | True        | False          | dynamic_call
+                #  26   | OrientVertical   | KeyError    | True           | dynamic_call
+                #  27   | MoveTangentially | True        | False          | dynamic_call
                 # falls off object
-                #  62   | OrientHorizontal | True        | False          | touch_object
+                # dataloder runs TouchObject positioning procedure in a tight loop only
+                # exposing a new observation at the end of the loop
+                #  28   | MoveForward      | True        | False          | touch_object
 
-                # Motor-only touch_object steps
-                if (
-                    13 <= loader_step <= 25
-                    or 29 <= loader_step <= 42
-                    or 46 <= loader_step <= 58
-                    or loader_step == 62
-                ):
+                # Motor-only last step of touch_object positioning procedure
+                if loader_step in [1, 13, 18, 23, 28]:
                     assert not exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), (
                         "Should be off object, motor-only step"
                     )
-                if loader_step == 62:
+                if loader_step == 28:
                     break  # Finish test
 
-                # First on-object steps are always OrientHorizontal motor-only steps
-                if loader_step in [26, 43, 59]:
+                # First two on-object steps after falling off are always MoveForward
+                # followed by OrientHorizontal, which are motor-only steps
+                if loader_step in [14, 15, 19, 20, 24, 25]:
                     assert not exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), (
                         "Should be on object, motor-only step"
                     )
 
-                # Second on-object steps are always OrientVertical that send data to LM
-                if loader_step in [27, 44, 60]:
+                # Third on-object steps are always OrientVertical that send data to LM
+                if loader_step in [16, 21, 26]:
                     assert exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), (
                         "Should be on object, sending data to LM"
                     )
 
-                # Third on-object steps are always MoveTangentially motor-only steps
-                if loader_step in [28, 45, 61]:
+                # Fourth on-object steps are always MoveTangentially motor-only steps
+                if loader_step in [17, 22, 27]:
                     assert not exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), (


### PR DESCRIPTION
This pull request extracts the `touch_object` positioning procedure from `SurfacePolicy` into the `TouchObject` positioning procedure. Now, when `SurfacePolicy.dynamic_call` cannot see the object, it raises `ObjectNotVisible`, and the data loader uses that to invoke the `TouchObject` positioning procedure.

Notably, this doesn't feel right as we use a _privileged_ (due to `"view_finder"` use) positioning procedure to keep a sensor in touch with the object. The future solution here will be to implement a similar touch object logic internally as part of the `SurfacePolicy`. This may be easier after refactoring the main Monty loop between the data loader, model, and the motor system to be more reinforcement-learning-like.

## Benchmark results
Multiple decimal places results here; the table updates are in the benchmark result changeset.

| Code | Experiment | Correct (%) | Used MLH (%) | Num Match Steps | Rotation Error | WandB |
|---|---|---|---|---|---|---|
| new | base_config_10distinctobj_surf_agent | 100 | 2.142857142857143 | 27.314285714285713 | 0.3148828571428572 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/wdnpj6fv/overview)
| recent (#305) | base_config_10distinctobj_surf_agent | 100 | 0 | 27.642857142857142 | 0.20275 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/4d51r1go/overview)
| new | randrot_noise_10distinctobj_surf_agent | 100 | 4 | 27.69 | 0.543061 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/refoixg5/overview)
| recent (#305) | randrot_noise_10distinctobj_surf_agent | 100 | 1 | 28.46 | 0.3758580000000001 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/rhddvorw/overview)
| new | randrot_10distinctobj_surf_agent | 100 | 2 | 27.11 | 0.33348799999999995 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/5jfg1hmz/overview)
| recent (#305) | randrot_10distinctobj_surf_agent | 100 | 1 | 28.08 | 0.352194 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/bn6cwftb/overview)
| new | base_10simobj_surf_agent | 95 | 10.714285714285714 | 54.628571428571426 | 0.2701473684210527 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/hvye109g/overview)
| recent (#305) | base_10simobj_surf_agent | 94.28571428571428 | 11.428571428571429 | 86.30714285714286 | 0.24581287878787875 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/elslasu1/overview)
| new | randrot_noise_10simobj_surf_agent | **gets stuck on step 65**
| recent (#305) | randrot_noise_10simobj_surf_agent | 93 | 36 | 181.35 | 0.5434129032258065 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/8dr5cmeu/overview)
| new | randomrot_rawnoise_10distinctobj_surf_agent | 68 | 72 | 15.35 | 1.5594602941176472 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/xwsio1sx/overview)
| recent (#305) | randomrot_rawnoise_10distinctobj_surf_agent | 69 | 74 | 15.19 | 1.945234782608695 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/rxy360ug/overview)
| new | base_77obj_surf_agent | 98.26839826839829 | 8.658008658008658 | 42.70995670995671 | 0.16050044052863435 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/h0w6zdvu/overview)
| recent (#305) | base_77obj_surf_agent | 99.13419913419914 | 7.35930735930736 | 57.064935064935064 | 0.2236707423580786 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/47nc07bu/overview)
| new | randrot_noise_77obj_surf_agent | _pending_
| recent (#305) | randrot_noise_77obj_surf_agent | 93.5064935064935 | 25.108225108225103 | 122.70995670995671 | 0.6740199074074075 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/t7te0nhh/overview)
| new | unsupervised_inference_distinctobj_surf_agent | _pending_
| recent (#305) | unsupervised_inference_distinctobj_surf_agent | 3.488372093023256 | 40.69767441860465 | 100 | 1.5507666666666668 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/4ffdsqfb/overview)

| Code | Experiment | Correct - 1st Epoch (%) | Correct - >1st Epoch (%) | Mean Objects per Graph | Mean Graphs per Object |
|---|---|---|---|---|---|
| new | surf_agent_unsupervised_10distinctobj | _pending_
| recent (#305) | surf_agent_unsupervised_10distinctobj | 80.00 | 87.78 | 1.22 | 1.1
| new | surf_agent_unsupervised_10distinctobj_noise | _pending_
| recent (#305) | surf_agent_unsupervised_10distinctobj_noise | 70.00 | 72.22 | 1.07 | 1.75
| new | surf_agent_unsupervised_10simobj | _pending_
| recent (#305) | surf_agent_unsupervised_10simobj | 40.00 | 80.00 | 2.33 | 1.4