### PR TITLE
chore: print config by default

### DIFF
--- a/src/tbp/monty/frameworks/run.py
+++ b/src/tbp/monty/frameworks/run.py
@@ -105,7 +105,6 @@ def main(all_configs, experiments=None):
         # Print config without running experiment
         if cmd_args is not None:
             if cmd_args.print_config:
-                print_config(exp_config)
                 continue
 
         os.makedirs(exp_config["logging_config"]["output_dir"], exist_ok=True)

--- a/src/tbp/monty/frameworks/run.py
+++ b/src/tbp/monty/frameworks/run.py
@@ -100,8 +100,9 @@ def main(all_configs, experiments=None):
         )
         # If we are not running in parallel, this should always be False
         exp_config["logging_config"]["log_parallel_wandb"] = False
+        print_config(exp_config)
 
-        # Print config, including udpates to run name
+        # Print config without running experiment
         if cmd_args is not None:
             if cmd_args.print_config:
                 print_config(exp_config)


### PR DESCRIPTION
We used to do this, but it seems like it's no longer done. I'm not sure why it was removed, but I found it useful to have a pprinted version of the experiment config in the logs. I'm happy to be convinced otherwise if this was removed for a specific reason.
Also not sure if chore is the correct label since it technically changes the output of an experiment but didn't feel like it was significant enough for feat.