### PR TITLE
chore: add .rsyncignore to help with infra tooling

### DIFF
--- a/.github/actions/should_run_monty/check_changed_files.sh
+++ b/.github/actions/should_run_monty/check_changed_files.sh
@@ -4,6 +4,7 @@ while IFS= read -r changed_file
 do
   echo $changed_file
   if [[ $changed_file != .github/ISSUE_TEMPLATE/* ]] &&
+     [[ $changed_file != .rsyncignore ]] &&
      [[ $changed_file != .vale/* ]] &&
      [[ $changed_file != .vscode/* ]] &&
      [[ $changed_file != docs/* ]] &&

--- a/.rsyncignore
+++ b/.rsyncignore
@@ -1,6 +1,9 @@
-.git
-.github
-.mypy_cache
-docs
-rfcs
-*.pyc
+- .git
+- .github
+- .mypy_cache
+- .ruff_cache
+- .vale
+- .vscode
+- docs
+- rfcs
+- *.pyc

--- a/.rsyncignore
+++ b/.rsyncignore
@@ -1,0 +1,6 @@
+.git
+.github
+.mypy_cache
+docs
+rfcs
+*.pyc


### PR DESCRIPTION
This pull request adds `.rsyncignore` to help with infrastructure tooling when using `rsync`.