### PR TITLE
refactor!: SurfacePolicy touch_object phase always ends with MoveForward action

### DIFF
--- a/benchmarks/results/ycb_10objs.csv
+++ b/benchmarks/results/ycb_10objs.csv
@@ -5,7 +5,7 @@ randrot_noise_10distinctobj_dist_agent,100.00,3.00,55,22.49,3,20
 randrot_noise_10distinctobj_dist_on_distm,99.00,1.00,38,12.15,3,18
 randrot_noise_10distinctobj_surf_agent,99.00,0.00,29,21.70,3,22
 randrot_10distinctobj_surf_agent,99.00,1.00,28,18.49,2,12
-randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.26,10,84
+randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.48,5,40
 base_10simobj_surf_agent,93.57,7.86,68,12.57,5,25
 randrot_noise_10simobj_dist_agent,84.00,40.00,237,35.01,11,93
 randrot_noise_10simobj_surf_agent,92.00,34.00,175,28.24,16,136

--- a/benchmarks/results/ycb_10objs.csv
+++ b/benchmarks/results/ycb_10objs.csv
@@ -1,13 +1,13 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
 base_config_10distinctobj_dist_agent,100.00,0.00,37,16.20,2,8
-base_config_10distinctobj_surf_agent,100.00,0.00,28,11.62,2,10
+base_config_10distinctobj_surf_agent,100.00,0.00,28,14.01,2,11
 randrot_noise_10distinctobj_dist_agent,100.00,3.00,55,22.49,3,20
 randrot_noise_10distinctobj_dist_on_distm,99.00,1.00,38,12.15,3,18
-randrot_noise_10distinctobj_surf_agent,100.00,1.00,28,21.54,3,19
-randrot_10distinctobj_surf_agent,100.00,1.00,28,20.18,2,10
-randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.48,5,40
-base_10simobj_surf_agent,94.29,11.43,86,14.08,6,32
+randrot_noise_10distinctobj_surf_agent,99.00,0.00,29,21.70,3,22
+randrot_10distinctobj_surf_agent,99.00,1.00,28,18.49,2,12
+randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.26,10,84
+base_10simobj_surf_agent,93.57,7.86,68,12.57,5,25
 randrot_noise_10simobj_dist_agent,84.00,40.00,237,35.01,11,93
-randrot_noise_10simobj_surf_agent,93.00,36.00,181,31.14,16,139
-randomrot_rawnoise_10distinctobj_surf_agent,69.00,74.00,15,111.45,3,5
+randrot_noise_10simobj_surf_agent,92.00,34.00,175,28.24,16,136
+randomrot_rawnoise_10distinctobj_surf_agent,69.00,74.00,15,111.07,4,6
 base_10multi_distinctobj_dist_agent,79.41,9.56,32,19.47,3,1

--- a/benchmarks/results/ycb_77objs.csv
+++ b/benchmarks/results/ycb_77objs.csv
@@ -2,5 +2,5 @@ Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|alig
 base_77obj_dist_agent,93.51,12.99,108,15.86,21,71
 base_77obj_surf_agent,98.70,6.49,54,11.01,13,37
 randrot_noise_77obj_dist_agent,89.61,22.51,152,37.47,31,112
-randrot_noise_77obj_surf_agent,93.51,25.11,123,38.61,35,128
+randrot_noise_77obj_surf_agent,94.81,25.11,123,38.02,38,138
 randrot_noise_77obj_5lms_dist_agent,88.31,0.00,70,58.25,10,99

--- a/benchmarks/results/ycb_77objs.csv
+++ b/benchmarks/results/ycb_77objs.csv
@@ -1,6 +1,6 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
 base_77obj_dist_agent,93.51,12.99,108,15.86,21,71
-base_77obj_surf_agent,99.13,7.36,57,12.82,13,39
+base_77obj_surf_agent,98.70,6.49,54,11.01,13,37
 randrot_noise_77obj_dist_agent,89.61,22.51,152,37.47,31,112
 randrot_noise_77obj_surf_agent,93.51,25.11,123,38.61,35,128
 randrot_noise_77obj_5lms_dist_agent,88.31,0.00,70,58.25,10,99

--- a/benchmarks/results/ycb_unsupervised.csv
+++ b/benchmarks/results/ycb_unsupervised.csv
@@ -1,4 +1,4 @@
 Experiment, Correct - 1st Epoch(%)|align right, Correct - >1st Epoch (%)|align right, Mean Objects per Graph|align right, Mean Graphs per Object|align right, Run Time (mins)|align right, Episode Run Time (s)|align right
-surf_agent_unsupervised_10distinctobj,80.00,87.78,1.22,1.1,16,10
-surf_agent_unsupervised_10distinctobj_noise,70.00,72.22,1.07,1.75,25,15
-surf_agent_unsupervised_10simobj,40.00,80.00,2.33,1.4,35,21
+surf_agent_unsupervised_10distinctobj,70.00,88.89,1.5,1.2,33,19
+surf_agent_unsupervised_10distinctobj_noise,70.00,70.00,1.07,1.88,26,15
+surf_agent_unsupervised_10simobj,50.00,78.89,2.83,1.7,30,18

--- a/benchmarks/results/ycb_unsupervised_inference.csv
+++ b/benchmarks/results/ycb_unsupervised_inference.csv
@@ -1,3 +1,3 @@
 Experiment,Correct (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
 unsupervised_inference_distinctobj_dist_agent,12.00,100,5,3.0
-unsupervised_inference_distinctobj_surf_agent,3.00,100,15,9
+unsupervised_inference_distinctobj_surf_agent,6.00,98,15,9

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1259,6 +1259,9 @@ class SurfacePolicy(InformedPolicy):
                     self.processed_observations.get_feature_by_name("object_coverage")
                 )
             )
+            logging.debug(
+                f"Attempting to find object: {self.attempting_to_find_object}"
+            )
             logging.debug("Initiating attempts to touch object")
 
             return None  # Will result in moving to try to find the object

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1095,6 +1095,8 @@ class SurfacePolicy(InformedPolicy):
         self.tangential_angle = 0
         self.alpha = alpha
 
+        self.attempting_to_find_object = False
+
     def pre_episode(self):
         self.tangential_angle = 0
         self.action = None  # Reset the first action for every episode
@@ -1144,9 +1146,13 @@ class SurfacePolicy(InformedPolicy):
             )
             logging.debug(f"Move to touch visible object, forward by {distance}")
 
+            self.attempting_to_find_object = False
+
             return MoveForward(agent_id=self.agent_id, distance=distance)
 
         logging.debug("Surface policy searching for object...")
+
+        self.attempting_to_find_object = True
 
         # Helpful to conceptualize these movements by considering a unit circle,
         # scaled by the radius distance_from_center
@@ -1243,7 +1249,10 @@ class SurfacePolicy(InformedPolicy):
                 The action to take.
         """
         # Check if we have poor visualization of the object
-        if self.processed_observations.get_feature_by_name("object_coverage") < 0.1:
+        if (
+            self.processed_observations.get_feature_by_name("object_coverage") < 0.1
+            or self.attempting_to_find_object
+        ):
             logging.debug(
                 "Object coverage of only "
                 + str(

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -920,12 +920,12 @@ class PolicyTest(unittest.TestCase):
                 #  23   | OrientHorizontal | True        | False          | touch_object
                 #  24   | OrientHorizontal | True        | False          | touch_object
                 #  25   | OrientVertical   | True        | False          | touch_object
+                #  26   | MoveForward      | True        | False          | touch_object
                 # back on object
-                #  26   | OrientHorizontal | True        | False          | dynamic_call
-                #  27   | OrientVertical   | False       | True           | dynamic_call
-                #  28   | MoveTangentially | True        | False          | dynamic_call
+                #  27   | OrientHorizontal | True        | False          | dynamic_call
+                #  28   | OrientVertical   | False       | True           | dynamic_call
+                #  29   | MoveTangentially | True        | False          | dynamic_call
                 # falls off object
-                #  29   | OrientHorizontal | True        | False          | touch_object
                 #  30   | OrientHorizontal | True        | False          | touch_object
                 #  31   | OrientHorizontal | True        | False          | touch_object
                 #  32   | OrientHorizontal | True        | False          | touch_object
@@ -937,14 +937,14 @@ class PolicyTest(unittest.TestCase):
                 #  38   | OrientHorizontal | True        | False          | touch_object
                 #  39   | OrientHorizontal | True        | False          | touch_object
                 #  40   | OrientHorizontal | True        | False          | touch_object
-                #  41   | OrientVertical   | True        | False          | touch_object
-                #  42   | MoveForward      | True        | False          | touch_object
+                #  41   | OrientHorizontal | True        | False          | touch_object
+                #  42   | OrientVertical   | True        | False          | touch_object
+                #  43   | MoveForward      | True        | False          | touch_object
                 # back on object
-                #  43   | OrientHorizontal | True        | False          | dynamic_call
-                #  44   | OrientVertical   | False       | True           | dynamic_call
-                #  45   | MoveTangentially | True        | False          | dynamic_call
+                #  44   | OrientHorizontal | True        | False          | dynamic_call
+                #  45   | OrientVertical   | False       | True           | dynamic_call
+                #  46   | MoveTangentially | True        | False          | dynamic_call
                 # falls off object
-                #  46   | OrientHorizontal | True        | False          | touch_object
                 #  47   | OrientHorizontal | True        | False          | touch_object
                 #  48   | OrientHorizontal | True        | False          | touch_object
                 #  49   | OrientHorizontal | True        | False          | touch_object
@@ -956,31 +956,33 @@ class PolicyTest(unittest.TestCase):
                 #  55   | OrientHorizontal | True        | False          | touch_object
                 #  56   | OrientHorizontal | True        | False          | touch_object
                 #  57   | OrientHorizontal | True        | False          | touch_object
-                #  58   | OrientVertical   | True        | False          | touch_object
+                #  58   | OrientHorizontal | True        | False          | touch_object
+                #  59   | OrientVertical   | True        | False          | touch_object
+                #  60   | MoveForward      | True        | False          | touch_object
                 # back on object
-                #  59   | OrientHorizontal | True        | False          | dynamic_call
-                #  60   | OrientVertical   | False       | True           | dynamic_call
-                #  61   | MoveTangentially | True        | False          | dynamic_call
+                #  61   | OrientHorizontal | True        | False          | dynamic_call
+                #  62   | OrientVertical   | False       | True           | dynamic_call
+                #  63   | MoveTangentially | True        | False          | dynamic_call
                 # falls off object
-                #  62   | OrientHorizontal | True        | False          | touch_object
+                #  64   | OrientHorizontal | True        | False          | touch_object
 
                 # Motor-only touch_object steps
                 if (
-                    13 <= loader_step <= 25
-                    or 29 <= loader_step <= 42
-                    or 46 <= loader_step <= 58
-                    or loader_step == 62
+                    13 <= loader_step <= 26
+                    or 30 <= loader_step <= 43
+                    or 47 <= loader_step <= 60
+                    or loader_step == 64
                 ):
                     assert not exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), (
                         "Should be off object, motor-only step"
                     )
-                if loader_step == 62:
+                if loader_step == 64:
                     break  # Finish test
 
                 # First on-object steps are always OrientHorizontal motor-only steps
-                if loader_step in [26, 43, 59]:
+                if loader_step in [27, 44, 61]:
                     assert not exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), (
@@ -988,7 +990,7 @@ class PolicyTest(unittest.TestCase):
                     )
 
                 # Second on-object steps are always OrientVertical that send data to LM
-                if loader_step in [27, 44, 60]:
+                if loader_step in [28, 45, 62]:
                     assert exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), (
@@ -996,7 +998,7 @@ class PolicyTest(unittest.TestCase):
                     )
 
                 # Third on-object steps are always MoveTangentially motor-only steps
-                if loader_step in [28, 45, 61]:
+                if loader_step in [29, 46, 63]:
                     assert not exp.model.learning_modules[
                         0
                     ].buffer.get_last_obs_processed(), (


### PR DESCRIPTION
The intended future refactor of `SurfacePolicy` is to separate the `TouchObject` positioning procedure. This was initially attempted in #306. However, after analysis, it turned out that #306 contained three algorithmic changes, and it was difficult to identify and accept the changes.

This pull request isolates and applies only one of the algorithmic changes: TouchObject positioning procedure now always ends with a MoveForward action.

This pull request ensures that the current embedded touch object positioning procedure (in the form of `touch_object` method) always runs until the viewfinder sees the object within range. Then, it executes the MoveForward action. The reason for implementing this change is that once the TouchObject positioning procedure is extracted in the future, it will always run automatically to completion and will always end with the MoveForward action. Before this pull request, `SurfacePolicy` could short-circuit `touch_object` by detecting that it is close enough to the object and begin the main `SurfacePolicy` (in `dynamic_call`) pre-emptively.

## Benchmark results
Multiple decimal places results here; the table updates are in the benchmark result changeset.

| Code | Experiment | Correct (%) | Used MLH (%) | Num Match Steps | Rotation Error | WandB |
|---|---|---|---|---|---|---|
| new | base_config_10distinctobj_surf_agent | 100 | 0 | 27.84285714285714 | 0.24448000000000003 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/86lgqo1w/overview)
| recent (#305) | base_config_10distinctobj_surf_agent | 100 | 0 | 27.642857142857142 | 0.20275 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/4d51r1go/overview)
| new | randrot_noise_10distinctobj_surf_agent | 99 | 0 | 28.81 | 0.3788070707070707 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/1q58zyn6/overview)
| recent (#305) | randrot_noise_10distinctobj_surf_agent | 100 | 1 | 28.46 | 0.3758580000000001 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/rhddvorw/overview)
| new | randrot_10distinctobj_surf_agent | 99 | 1 | 27.94 | 0.32283333333333336 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/tfioufxd/overview)
| recent (#305) | randrot_10distinctobj_surf_agent | 100 | 1 | 28.08 | 0.352194 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/bn6cwftb/overview)
| new | base_10simobj_surf_agent | 93.57142857142856 | 7.857142857142857 | 67.65714285714286 | 0.21942213740458016 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/c8wsevzf/overview)
| recent (#305) | base_10simobj_surf_agent | 94.28571428571428 | 11.428571428571429 | 86.30714285714286 | 0.24581287878787875 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/elslasu1/overview)
| new | randrot_noise_10simobj_surf_agent | 92 | 34 | 175.14 | 0.49290978260869567 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/msyaygde/overview)
| recent (#305) | randrot_noise_10simobj_surf_agent | 93 | 36 | 181.35 | 0.5434129032258065 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/8dr5cmeu/overview)
| new | randomrot_rawnoise_10distinctobj_surf_agent | 69 | 74 | 15.33 | 1.9384666666666663 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/5f5n7cc9/overview)
| recent (#305) | randomrot_rawnoise_10distinctobj_surf_agent | 69 | 74 | 15.19 | 1.945234782608695 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/rxy360ug/overview)
| new | base_77obj_surf_agent | 98.7012987012987 | 6.493506493506493 | 54.277056277056275 | 0.19211228070175443 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/i55rs7u2/overview)
| recent (#305) | base_77obj_surf_agent | 99.13419913419914 | 7.35930735930736 | 57.064935064935064 | 0.2236707423580786 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/47nc07bu/overview)
| new | randrot_noise_77obj_surf_agent | 94.8051948051948 | 25.108225108225103 | 122.73160173160171 | 0.6635575342465753 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/lza8d5ka/overview)
| recent (#305) | randrot_noise_77obj_surf_agent | 93.5064935064935 | 25.108225108225103 | 122.70995670995671 | 0.6740199074074075 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/t7te0nhh/overview)
| new | unsupervised_inference_distinctobj_surf_agent | 6 | 43 | 97.64 | 1.5710833333333334 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/fv181r2j/overview)
| recent (#305) | unsupervised_inference_distinctobj_surf_agent | 3.488372093023256 | 40.69767441860465 | 100 | 1.5507666666666668 | [run](https://wandb.ai/thousand-brains-project/Monty/runs/4ffdsqfb/overview)

| Code | Experiment | Correct - 1st Epoch (%) | Correct - >1st Epoch (%) | Mean Objects per Graph | Mean Graphs per Object |
|---|---|---|---|---|---|
| new | surf_agent_unsupervised_10distinctobj | 70.00 | 88.89 | 1.5 | 1.2
| recent (#305) | surf_agent_unsupervised_10distinctobj | 80.00 | 87.78 | 1.22 | 1.1
| new | surf_agent_unsupervised_10distinctobj_noise | 70.00 | 70.00 | 1.07 | 1.88 
| recent (#305) | surf_agent_unsupervised_10distinctobj_noise | 70.00 | 72.22 | 1.07 | 1.75
| new | surf_agent_unsupervised_10simobj | 50.00 | 78.89 | 2.83 | 1.7
| recent (#305) | surf_agent_unsupervised_10simobj | 40.00 | 80.00 | 2.33 | 1.4