### PR TITLE
refactor!: remove extraneous reset by refactoring reset out of __iter__

### DIFF
--- a/benchmarks/results/ycb_10objs.csv
+++ b/benchmarks/results/ycb_10objs.csv
@@ -10,4 +10,4 @@ base_10simobj_surf_agent,93.57,7.86,68,12.57,5,25
 randrot_noise_10simobj_dist_agent,84.00,40.00,237,35.01,11,93
 randrot_noise_10simobj_surf_agent,92.00,34.00,175,28.24,16,136
 randomrot_rawnoise_10distinctobj_surf_agent,69.00,74.00,15,111.07,4,6
-base_10multi_distinctobj_dist_agent,79.28,10.71,32,19.83,3,1
+base_10multi_distinctobj_dist_agent,79.29,10.71,31,19.84,3,1

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -264,6 +264,17 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
         self.epochs = 0
         self.primary_target = None
 
+    def __iter__(self):
+        """Do not reset the dataset when starting the iterator.
+
+        `self.pre_episode()` already resets the dataset before each episode, therefore,
+        `EnvironmentDataLoader.__iter__()` should not reset the dataset again.
+
+        Returns:
+            EnvironmentDataLoaderPerObject: The iterator.
+        """
+        return self
+
     def pre_episode(self):
         super().pre_episode()
         self.reset_agent()

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -155,13 +155,11 @@ class EnvironmentDataLoader:
         self._counter = 0
 
     def __iter__(self):
-        # Reset the environment before iterating
-        self._observation, proprioceptive_state = self.dataset.reset()
-        self.motor_system._state = (
-            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
-        )
-        self._action = None
-        self._counter = 0
+        """Implement the iterator protocol.
+
+        Returns:
+            EnvironmentDataLoader: The iterator.
+        """
         return self
 
     def __next__(self):
@@ -181,6 +179,14 @@ class EnvironmentDataLoader:
 
     def pre_episode(self):
         self.motor_system.pre_episode()
+
+        # Reset the dataset and the data loader state.
+        self._observation, proprioceptive_state = self.dataset.reset()
+        self.motor_system._state = (
+            MotorSystemState(proprioceptive_state) if proprioceptive_state else None
+        )
+        self._action = None
+        self._counter = 0
 
     def post_episode(self):
         self.motor_system.post_episode()
@@ -264,20 +270,12 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
         self.epochs = 0
         self.primary_target = None
 
-    def __iter__(self):
-        """Do not reset the dataset when starting the iterator.
-
-        `self.pre_episode()` already resets the dataset before each episode, therefore,
-        `EnvironmentDataLoader.__iter__()` should not reset the dataset again.
-
-        Returns:
-            EnvironmentDataLoaderPerObject: The iterator.
-        """
-        return self
-
     def pre_episode(self):
         super().pre_episode()
-        self.reset_agent()
+
+        self.motor_system._state[self.motor_system._policy.agent_id][
+            "motor_only_step"
+        ] = False
 
     def post_episode(self):
         super().post_episode()
@@ -404,23 +402,6 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
                 primary_target_object=primary_target_obj,
             )
 
-    def reset_agent(self):
-        logging.debug("resetting agent------")
-        self._observation, proprioceptive_state = self.dataset.reset()
-        motor_system_state = MotorSystemState(proprioceptive_state)
-        self._counter = 0
-
-        # Make sure to also reset action variables when resetting agent during
-        # pre-episode
-        self._action = None
-        motor_system_state[self.motor_system._policy.agent_id]["motor_only_step"] = (
-            False
-        )
-
-        self.motor_system._state = motor_system_state
-
-        return self._observation
-
 
 class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
     """Dataloader that supports a policy which makes use of previous observation(s).
@@ -445,15 +426,6 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
 
     iv) Supports hypothesis-testing "jump" policy
     """
-
-    def __iter__(self):
-        # Overwrite original because we don't want to reset agent at this stage
-        # (already done in pre-episode)
-
-        # TODO look into refactoring the parent __iter__ method so that we don't need
-        # to use this fix
-
-        return self
 
     def __next__(self):
         if self._counter == 0:
@@ -1011,12 +983,6 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
             "position": np.array([0, 0, 0]),
             "scale": [1.0, 1.0, 1.0],
         }
-
-    def __iter__(self):
-        # Overwrite original because we don't want to reset agent at this stage
-        # (already done in pre-episode)
-
-        return self
 
 
 class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):

--- a/tests/unit/embodied_data_test.py
+++ b/tests/unit/embodied_data_test.py
@@ -250,12 +250,6 @@ class EmbodiedDataTest(unittest.TestCase):
         dataloader_dist = EnvironmentDataLoader(
             dataset_dist, motor_system_dist, rng=rng
         )
-        initial_state = next(dataloader_dist)
-        self.assertTrue(
-            np.all(initial_state[AGENT_ID][SENSOR_ID]["sensor"] == EXPECTED_STATES[0])
-        )
-
-        dataloader_dist.pre_episode()
         for i, item in enumerate(dataloader_dist):
             self.assertTrue(
                 np.all(item[AGENT_ID][SENSOR_ID]["sensor"] == EXPECTED_STATES[i])
@@ -281,12 +275,6 @@ class EmbodiedDataTest(unittest.TestCase):
         )
 
         dataloader_abs = EnvironmentDataLoader(dataset_abs, motor_system_abs, rng)
-        initial_state = next(dataloader_abs)
-        self.assertTrue(
-            np.all(initial_state[AGENT_ID][SENSOR_ID]["sensor"] == EXPECTED_STATES[0])
-        )
-
-        dataloader_abs.pre_episode()
         for i, item in enumerate(dataloader_abs):
             self.assertTrue(
                 np.all(item[AGENT_ID][SENSOR_ID]["sensor"] == EXPECTED_STATES[i])

--- a/tests/unit/embodied_data_test.py
+++ b/tests/unit/embodied_data_test.py
@@ -255,6 +255,7 @@ class EmbodiedDataTest(unittest.TestCase):
             np.all(initial_state[AGENT_ID][SENSOR_ID]["sensor"] == EXPECTED_STATES[0])
         )
 
+        dataloader_dist.pre_episode()
         for i, item in enumerate(dataloader_dist):
             self.assertTrue(
                 np.all(item[AGENT_ID][SENSOR_ID]["sensor"] == EXPECTED_STATES[i])
@@ -285,6 +286,7 @@ class EmbodiedDataTest(unittest.TestCase):
             np.all(initial_state[AGENT_ID][SENSOR_ID]["sensor"] == EXPECTED_STATES[0])
         )
 
+        dataloader_abs.pre_episode()
         for i, item in enumerate(dataloader_abs):
             self.assertTrue(
                 np.all(item[AGENT_ID][SENSOR_ID]["sensor"] == EXPECTED_STATES[i])

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -56,6 +56,7 @@ from tbp.monty.frameworks.models.goal_state_generation import (
     GraphGoalStateGenerator,
 )
 from tbp.monty.frameworks.models.motor_system import MotorSystem
+from tbp.monty.frameworks.models.motor_system_state import MotorSystemState
 from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     HabitatDistantPatchSM,
@@ -874,33 +875,21 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             "When using detailed logging we should store matches at every steps.",
         )
 
-    def test_patch_off_object_logging(self):
-        """Test that patch_off_object is logged when no object is present.
-
-        Test that if there is no object in the scene to begin with,
-        we log patch_off_object.
-        """
+    def test_pre_episode_raises_error_when_no_object_is_present(self):
+        """Test that pre_episode raises an error when no object is present."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.fixed_actions_evidence)
         with MontyObjectRecognitionExperiment(config) as exp:
             exp.model.set_experiment_mode("train")
             exp.pre_epoch()
-            exp.pre_episode()
             pprint("...removing all objects...")
             exp.dataset.env._env.remove_all_objects()
-            exp.dataloader.reset_agent()
-            pprint("...training...")
-            last_step = exp.run_episode_steps()
-            exp.post_episode(last_step)
-            exp.post_epoch()
-
-        pprint("...checking run stats...")
-        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-        self.assertEqual(
-            train_stats["primary_performance"][0],
-            "patch_off_object",
-            "episode should log patch_off_object performance.",
-        )
+            with self.assertRaises(ValueError) as error:
+                exp.pre_episode()
+            self.assertEqual(
+                "May be initializing experiment with no visible target object",
+                str(error.exception),
+            )
 
     def test_moving_off_object(self):
         """Test logging when moving off the object for some steps during an episode."""
@@ -1832,33 +1821,21 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 f" since it was off the object for longer than other LMs.",
             )
 
-    def test_starting_off_object_5lms(self):
-        """Test that patch_off_object is logged when no object is present.
-
-        Test that if there is no object in the scene to begin with,
-        we log patch_off_object with 5lms and voting.
-        """
+    def test_5lms_pre_episode_raises_error_when_no_object_is_present(self):
+        """Test that pre_episode raises an error when no object is present."""
         pprint("...parsing experiment...")
         config = copy.deepcopy(self.evidence_5lm_config)
         with MontyObjectRecognitionExperiment(config) as exp:
             exp.model.set_experiment_mode("train")
             exp.pre_epoch()
-            exp.pre_episode()
             pprint("...removing all objects...")
             exp.dataset.env._env.remove_all_objects()
-            exp.dataloader.reset_agent()
-            pprint("...training...")
-            last_step = exp.run_episode_steps()
-            exp.post_episode(last_step)
-            exp.post_epoch()
-
-        pprint("...checking run stats...")
-        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
-        self.assertEqual(
-            train_stats["primary_performance"][0],
-            "patch_off_object",
-            "episode should log patch_off_object performance.",
-        )
+            with self.assertRaises(ValueError) as error:
+                exp.pre_episode()
+            self.assertEqual(
+                "May be initializing experiment with no visible target object",
+                str(error.exception),
+            )
 
     def test_5lm_basic_logging(self):
         """Test that 5LM setup works with BASIC logging and stores correct data."""

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -56,7 +56,6 @@ from tbp.monty.frameworks.models.goal_state_generation import (
     GraphGoalStateGenerator,
 )
 from tbp.monty.frameworks.models.motor_system import MotorSystem
-from tbp.monty.frameworks.models.motor_system_state import MotorSystemState
 from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     HabitatDistantPatchSM,

--- a/tests/unit/habitat_data_test.py
+++ b/tests/unit/habitat_data_test.py
@@ -333,11 +333,6 @@ class HabitatDataTest(unittest.TestCase):
         )
 
         dataloader_dist = EnvironmentDataLoader(dataset_dist, motor_system_dist, rng)
-        initial_obs_dist = next(dataloader_dist)
-        camera_obs_dist = initial_obs_dist[AGENT_ID][SENSOR_ID]
-        self.assertTrue(np.all(camera_obs_dist[SENSORS[0]] == EXPECTED_STATES[0]))
-
-        dataloader_dist.pre_episode()
         for i, item in enumerate(dataloader_dist):
             camera_obs_dist = item[AGENT_ID][SENSOR_ID]
             self.assertTrue(np.all(camera_obs_dist[SENSORS[0]] == EXPECTED_STATES[i]))
@@ -379,11 +374,6 @@ class HabitatDataTest(unittest.TestCase):
         )
 
         dataloader_abs = EnvironmentDataLoader(dataset_abs, motor_system_abs, rng)
-        initial_obs_abs = next(dataloader_abs)
-        camera_obs_abs = initial_obs_abs[AGENT_ID][SENSOR_ID]
-        self.assertTrue(np.all(camera_obs_abs[SENSORS[0]] == EXPECTED_STATES[0]))
-
-        dataloader_abs.pre_episode()
         for i, item in enumerate(dataloader_abs):
             camera_obs_abs = item[AGENT_ID][SENSOR_ID]
             self.assertTrue(np.all(camera_obs_abs[SENSORS[0]] == EXPECTED_STATES[i]))
@@ -427,11 +417,6 @@ class HabitatDataTest(unittest.TestCase):
         )
 
         dataloader_surf = EnvironmentDataLoader(dataset_surf, motor_system_surf, rng)
-        initial_obs_surf = next(dataloader_surf)
-        camera_obs_surf = initial_obs_surf[AGENT_ID][SENSOR_ID]
-        self.assertTrue(np.all(camera_obs_surf[SENSORS[0]] == EXPECTED_STATES[0]))
-
-        dataloader_surf.pre_episode()
         for i, item in enumerate(dataloader_surf):
             camera_obs_surf = item[AGENT_ID][SENSOR_ID]
             self.assertTrue(np.all(camera_obs_surf[SENSORS[0]] == EXPECTED_STATES[i]))

--- a/tests/unit/habitat_data_test.py
+++ b/tests/unit/habitat_data_test.py
@@ -337,6 +337,7 @@ class HabitatDataTest(unittest.TestCase):
         camera_obs_dist = initial_obs_dist[AGENT_ID][SENSOR_ID]
         self.assertTrue(np.all(camera_obs_dist[SENSORS[0]] == EXPECTED_STATES[0]))
 
+        dataloader_dist.pre_episode()
         for i, item in enumerate(dataloader_dist):
             camera_obs_dist = item[AGENT_ID][SENSOR_ID]
             self.assertTrue(np.all(camera_obs_dist[SENSORS[0]] == EXPECTED_STATES[i]))
@@ -382,6 +383,7 @@ class HabitatDataTest(unittest.TestCase):
         camera_obs_abs = initial_obs_abs[AGENT_ID][SENSOR_ID]
         self.assertTrue(np.all(camera_obs_abs[SENSORS[0]] == EXPECTED_STATES[0]))
 
+        dataloader_abs.pre_episode()
         for i, item in enumerate(dataloader_abs):
             camera_obs_abs = item[AGENT_ID][SENSOR_ID]
             self.assertTrue(np.all(camera_obs_abs[SENSORS[0]] == EXPECTED_STATES[i]))
@@ -429,6 +431,7 @@ class HabitatDataTest(unittest.TestCase):
         camera_obs_surf = initial_obs_surf[AGENT_ID][SENSOR_ID]
         self.assertTrue(np.all(camera_obs_surf[SENSORS[0]] == EXPECTED_STATES[0]))
 
+        dataloader_surf.pre_episode()
         for i, item in enumerate(dataloader_surf):
             camera_obs_surf = item[AGENT_ID][SENSOR_ID]
             self.assertTrue(np.all(camera_obs_surf[SENSORS[0]] == EXPECTED_STATES[i]))


### PR DESCRIPTION
This turned out to be more complicated than I expected.

This pull request removes an extraneous reset coded in `__iter__` and ensures all data loaders do the reset logic inside `pre_episode` instead.

Since the reset logic now always happens in `pre_episode`, two previous tests that were testing for logging `patch_off_object` now throw a `ValueError`, since the experiment is being initialized off the object. If those original tests intended to ensure that we know that an experiment started off object, the new tests maintain that intent. However, if those original tests intended to test `patch_off_object` logging functionality specifically, we'll need a different test. Based on the original docstrings, I believe the intent was the former.

The three Habitat tests and two embodied data tests were shortened. They implicitly relied on the reset in `__iter__` but didn't seem to do anything other than test that each observation is returned as intended.

## Benchmarks

_compared with d126aa160de8a1813b48aaf6b2788881a93bf644_

base_config_10distinctobj_dist_agent ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/tuintpm2/overview
base_config_10distinctobj_surf_agent ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/v92grbhv/overview
randrot_noise_10distinctobj_dist_agent ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/lqgb599s/overview
randrot_noise_10distinctobj_dist_on_distm ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/1vswvcpe/overview
randrot_noise_10distinctobj_surf_agent ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/829ix3w6/overview
randrot_10distinctobj_surf_agent,99.00,1.00,28,18.50,2,11 😐 (same as #317) - https://wandb.ai/thousand-brains-project/Monty/runs/giu1vcd4/overview
```diff
-randrot_10distinctobj_surf_agent,99.00,1.00,28,18.49,2,12
+randrot_10distinctobj_surf_agent,99.00,1.00,28,18.50,2,11
```
randrot_noise_10distinctobj_5lms_dist_agent ✅  - https://wandb.ai/thousand-brains-project/Monty/runs/2bek9su9/overview
base_10simobj_surf_agent ✅  - https://wandb.ai/thousand-brains-project/Monty/runs/qblu9uh4/overview
randrot_noise_10simobj_dist_agent ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/g6dqq4wd/overview
randrot_noise_10simobj_surf_agent ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/7kvn6lha/overview
randomrot_rawnoise_10distinctobj_surf_agent ✅  - https://wandb.ai/thousand-brains-project/Monty/runs/k2hbjtda/overview
base_10multi_distinctobj_dist_agent,79.29,10.71,31,19.84,3,1 ❌ (degraded, same as in #317 although there's a typo there, percent correct should have been 79.29 from 79.28571428571428)  - https://wandb.ai/thousand-brains-project/Monty/runs/97fa80wg/overview
```diff
-base_10multi_distinctobj_dist_agent,79.41,9.56,32,19.47,3,1
+base_10multi_distinctobj_dist_agent,79.29,10.71,31,19.84,3,1
```
base_77obj_dist_agent ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/2qhi4wj8/overview
base_77obj_surf_agent ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/e3gwcyx4/overview
randrot_noise_77obj_dist_agent ✅  - https://wandb.ai/thousand-brains-project/Monty/runs/qgk2upco/overview
randrot_noise_77obj_surf_agent ✅  - https://wandb.ai/thousand-brains-project/Monty/runs/ngndnv2e/overview
randrot_noise_77obj_5lms_dist_agent ✅  - https://wandb.ai/thousand-brains-project/Monty/runs/zg82di9b/overview