### PR TITLE
docs: benchmark updates for current code

### DIFF
--- a/benchmarks/results/ycb_10objs.csv
+++ b/benchmarks/results/ycb_10objs.csv
@@ -1,13 +1,13 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
-base_config_10distinctobj_dist_agent,100.00,0.00,37,16.04,5,19
+base_config_10distinctobj_dist_agent,100.00,0.00,37,16.20,2,8
 base_config_10distinctobj_surf_agent,100.00,0.00,28,11.62,2,10
-randrot_noise_10distinctobj_dist_agent,100.00,3.00,55,22.35,5,33
-randrot_noise_10distinctobj_dist_on_distm,99.00,1.00,38,12.03,4,28
-randrot_noise_10distinctobj_surf_agent,100.00,1.00,28,21.53,3,19
-randrot_10distinctobj_surf_agent,100.00,1.00,28,20.17,2,10
-randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.26,10,84
-base_10simobj_surf_agent,94.29,11.43,86,14.08,6,31
-randrot_noise_10simobj_dist_agent,84.00,40.00,237,34.95,18,147
-randrot_noise_10simobj_surf_agent,93.00,36.00,181,31.14,17,146
-randomrot_rawnoise_10distinctobj_surf_agent,69.00,74.00,15,111.45,4,6
-base_10multi_distinctobj_dist_agent,79.29,10.71,31,20.05,43,1
+randrot_noise_10distinctobj_dist_agent,100.00,3.00,55,22.49,3,20
+randrot_noise_10distinctobj_dist_on_distm,99.00,1.00,38,12.15,3,18
+randrot_noise_10distinctobj_surf_agent,100.00,1.00,28,21.54,3,19
+randrot_10distinctobj_surf_agent,100.00,1.00,28,20.18,2,10
+randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.48,5,40
+base_10simobj_surf_agent,94.29,11.43,86,14.08,6,32
+randrot_noise_10simobj_dist_agent,84.00,40.00,237,35.01,11,93
+randrot_noise_10simobj_surf_agent,93.00,36.00,181,31.14,16,139
+randomrot_rawnoise_10distinctobj_surf_agent,69.00,74.00,15,111.45,3,5
+base_10multi_distinctobj_dist_agent,79.41,9.56,32,19.47,3,1

--- a/benchmarks/results/ycb_77objs.csv
+++ b/benchmarks/results/ycb_77objs.csv
@@ -1,6 +1,6 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
-base_77obj_dist_agent,93.51,12.99,108,16.04,62,212
-base_77obj_surf_agent,99.13,7.36,57,12.82,12,35
-randrot_noise_77obj_dist_agent,89.61,22.51,152,37.24,85,308
+base_77obj_dist_agent,93.51,12.99,108,15.86,21,71
+base_77obj_surf_agent,99.13,7.36,57,12.82,13,39
+randrot_noise_77obj_dist_agent,89.61,22.51,152,37.47,31,112
 randrot_noise_77obj_surf_agent,93.51,25.11,123,38.61,35,128
-randrot_noise_77obj_5lms_dist_agent,88.31,0.00,70,58.44,32,862
+randrot_noise_77obj_5lms_dist_agent,88.31,0.00,70,58.25,10,99


### PR DESCRIPTION
When working on other pull requests, I noticed that the documented benchmark values no longer reflect the `main` branch code benchmarks. It appears that the reason for the discrepancy is the use of _2-decimal point rounded_ radian values when converting from radians to degrees for the initial benchmark CSV (see below for details).

This pull request updates the benchmarks as of commit 451ba5f576cfdf3eb1b14250d85125429b93d1e4 (the HEAD of `main` branch as of the writing of this pull request).

I rearranged the diff below for easier reading:

`benchmarks/results/ycb_10objs.csv`
```diff
-base_config_10distinctobj_dist_agent,100.00,0.00,37,16.04,5,19
+base_config_10distinctobj_dist_agent,100.00,0.00,37,16.20,2,8
base_config_10distinctobj_surf_agent,100.00,0.00,28,11.62,2,10
-randrot_noise_10distinctobj_dist_agent,100.00,3.00,55,22.35,5,33
+randrot_noise_10distinctobj_dist_agent,100.00,3.00,55,22.49,3,20
-randrot_noise_10distinctobj_dist_on_distm,99.00,1.00,38,12.03,4,28
+randrot_noise_10distinctobj_dist_on_distm,99.00,1.00,38,12.15,3,18
-randrot_noise_10distinctobj_surf_agent,100.00,1.00,28,21.53,3,19
+randrot_noise_10distinctobj_surf_agent,100.00,1.00,28,21.54,3,19
-randrot_10distinctobj_surf_agent,100.00,1.00,28,20.17,2,10
+randrot_10distinctobj_surf_agent,100.00,1.00,28,20.18,2,10
-randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.26,10,84
+randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.48,5,40
-base_10simobj_surf_agent,94.29,11.43,86,14.08,6,31
+base_10simobj_surf_agent,94.29,11.43,86,14.08,6,32
-randrot_noise_10simobj_dist_agent,84.00,40.00,237,34.95,18,147
+randrot_noise_10simobj_dist_agent,84.00,40.00,237,35.01,11,93
-randrot_noise_10simobj_surf_agent,93.00,36.00,181,31.14,17,146
+randrot_noise_10simobj_surf_agent,93.00,36.00,181,31.14,16,139
-randomrot_rawnoise_10distinctobj_surf_agent,69.00,74.00,15,111.45,4,6
+randomrot_rawnoise_10distinctobj_surf_agent,69.00,74.00,15,111.45,3,5
-base_10multi_distinctobj_dist_agent,79.29,10.71,31,20.05,43,1
+base_10multi_distinctobj_dist_agent,79.41,9.56,32,19.47,3,1
```

`benchmarks/results/ycb_77objs.csv`
```diff
-base_77obj_dist_agent,93.51,12.99,108,16.04,62,212
+base_77obj_dist_agent,93.51,12.99,108,15.86,21,71
-base_77obj_surf_agent,99.13,7.36,57,12.82,12,35
+base_77obj_surf_agent,99.13,7.36,57,12.82,13,39
-randrot_noise_77obj_dist_agent,89.61,22.51,152,37.24,85,308
+randrot_noise_77obj_dist_agent,89.61,22.51,152,37.47,31,112
randrot_noise_77obj_surf_agent,93.51,25.11,123,38.61,35,128
-randrot_noise_77obj_5lms_dist_agent,88.31,0.00,70,58.44,32,862
+randrot_noise_77obj_5lms_dist_agent,88.31,0.00,70,58.25,10,99
```

~The `dist` benchmarks have not been updated for the past five months. Since the changes are minor, I propose to forego investigating why they changed and instead accept the current numbers.~

The difference in the case of `base_config_10distinctobj_dist_agent` rotation error was that the benchmark table was originally in radian units. It truncated the true radians value from 0.2826742857142857 to 0.28, then, later on, when this was converted into the CSV, it turns out that 0.28 radians = 16.04 degrees, whereas 0.2826742857142857 = 16.20 degrees.

![Screenshot 2025-06-05 at 08 10 24](https://github.com/user-attachments/assets/cdf46426-763a-4fbe-829f-8aa44d906c35)

Latest runs:
base_config_10distinctobj_dist_agent - https://wandb.ai/thousand-brains-project/Monty/runs/46pussy2/overview
base_config_10distinctobj_surf_agent - https://wandb.ai/thousand-brains-project/Monty/runs/7zx4nokz/overview
randrot_noise_10distinctobj_dist_agent - https://wandb.ai/thousand-brains-project/Monty/runs/suck3hfz/overview
randrot_noise_10distinctobj_dist_on_distm - https://wandb.ai/thousand-brains-project/Monty/runs/ozwpzfx1/overview
randrot_noise_10distinctobj_surf_agent - https://wandb.ai/thousand-brains-project/Monty/runs/r0nd5rih/overview
randrot_10distinctobj_surf_agent - https://wandb.ai/thousand-brains-project/Monty/runs/xohsk38z/overview
randrot_noise_10distinctobj_5lms_dist_agent - https://wandb.ai/thousand-brains-project/Monty/runs/dt5k62m6/overview
base_10simobj_surf_agent - https://wandb.ai/thousand-brains-project/Monty/runs/fku73ux9/overview
randrot_noise_10simobj_dist_agent - https://wandb.ai/thousand-brains-project/Monty/runs/mhixi6k3/overview
randrot_noise_10simobj_surf_agent - https://wandb.ai/thousand-brains-project/Monty/runs/i99n6qnr/overview
randomrot_rawnoise_10distinctobj_surf_agent - https://wandb.ai/thousand-brains-project/Monty/runs/ac1ka9ur/overview
base_10multi_distinctobj_dist_agent - https://wandb.ai/thousand-brains-project/Monty/runs/jtqkdg22/overview

base_77obj_dist_agent - https://wandb.ai/thousand-brains-project/Monty/runs/hk3b1k8a/overview
base_77obj_surf_agent - https://wandb.ai/thousand-brains-project/Monty/runs/8knlpv1q/overview
randrot_noise_77obj_dist_agent - https://wandb.ai/thousand-brains-project/Monty/runs/h0trwstc/overview
randrot_noise_77obj_surf_agent - https://wandb.ai/thousand-brains-project/Monty/runs/y2utajj8/overview
randrot_noise_77obj_5lms_dist_agent - https://wandb.ai/thousand-brains-project/Monty/runs/mw1lbp6n/overview

## Investigation

Using `base_config_10distinctobj_dist_agent` as the test benchmark to see when change was introduced and the rotation error as the data point to test.

451ba5f576cfdf3eb1b14250d85125429b93d1e4 (Jun 2, 2025) -> 16.20
264a150a9e4357b02c1e3a26e5c635667a2f241d (Apr 23, 2025) -> 16.20
89edbcd1d2fd51673bfd0e704d06a4519d1c90a2 (Mar 3, 2025) -> 16.20
0e5b9beaec8d72ef437d67bcb0f094fcae828cea (Jan 27, 2025) -> 16.20
caf2ef4805120ba73b786d614332717bb99c3f24 (Jan 23, 2025) -> 16.20 (table value 16.04)
^ The benchmark table was in radian units and truncated the true radians value from 0.2826742857142857 to 0.28, then, later on, when this was converted into the CSV, it turns out that 0.28 radians = 16.04 degrees, whereas 0.2826742857142857 = 16.20 degrees.
4cdbd2a5cbc4e8b2cedfd1cf782e4d1c00fc06bd (Jan 22, 2025) -> 16.74
2d843e134fc3cf8d946d572f2479c8e4bd53fc36 (Jan 15, 2025) -> 16.74
af4bf3d38828b00973f2ae6879be0005fea0f3a0 (Dec 13, 2024) -> 14.82
6176ba5508ab1932c7f5c00a5b28662d522ad9e0 (Nov 13, 2024; first commit) -> failed