### PR TITLE
refactor: extract `_get_evidence_update_threshold` into a bare function

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
@@ -192,6 +192,7 @@ class DefaultHypothesesUpdater:
         displacements: dict | None,
         graph_id: str,
         mapper: ChannelMapper,
+        max_global_evidence: float,
     ) -> list[ChannelHypotheses]:
         """Update hypotheses based on sensor displacement and sensed features.
 
@@ -254,6 +255,7 @@ class DefaultHypothesesUpdater:
                 evidence_update_threshold = get_evidence_update_threshold(
                     self.evidence_update_threshold,
                     self.x_percent_threshold,
+                    max_global_evidence,
                     hypotheses.evidence,
                 )
 
@@ -422,6 +424,7 @@ def all_usable_input_channels(
 def get_evidence_update_threshold(
     evidence_update_threshold: int,
     x_percent_threshold: float | str,
+    max_global_evidence: float,
     evidence_all_channels: np.ndarray,
 ):
     """Determine how much evidence a hypothesis should have to be updated.
@@ -430,6 +433,7 @@ def get_evidence_update_threshold(
         evidence_update_threshold (float | str): update threshold type.
         x_percent_threshold (int): x_percent threshold used in the calculation of
             evidence threshold.
+        max_global_evidence (float): highest evidence of all hypotheses,
         evidence_all_channels (np.ndarray): Evidence values for all hypotheses.
 
     Returns:
@@ -440,7 +444,7 @@ def get_evidence_update_threshold(
             not in the allowed values
     """
     # TODO: Better Args description
-    max_global_evidence = np.max(evidence_all_channels)
+    # max_global_evidence = np.max(evidence_all_channels)
 
     if type(evidence_update_threshold) in [int, float]:
         return evidence_update_threshold

--- a/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
@@ -451,6 +451,10 @@ def get_evidence_update_threshold(
         InvalidEvidenceUpdateThreshold: If `self.evidence_update_threshold` is
             not in the allowed values
     """
+    # return 0 for the threshold if there are no evidence scores
+    if evidence_all_channels.size == 0:
+        return 0
+
     if type(evidence_update_threshold) in [int, float]:
         return evidence_update_threshold
     elif evidence_update_threshold == "mean":

--- a/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
@@ -136,17 +136,17 @@ class DefaultHypothesesUpdater:
             x_percent_threshold: Used in two places:
                 1) All objects whose highest evidence is greater than the most likely
                     objects evidence - x_percent of the most like objects evidence are
-                    considered possible matches. That means to only have one possible match,
-                    no other object can have more evidence than the candidate match's
-                    evidence - x percent of it.
+                    considered possible matches. That means to only have one possible
+                    match, no other object can have more evidence than the candidate
+                    match's evidence - x percent of it.
                 2) Within one object, possible poses are considered possible if their
-                    evidence is larger than the most likely pose of this object - x percent
-                    of this poses evidence.
-                # TODO: should we use a separate threshold for within and between objects?
-                If this value is larger, the model is usually more robust to noise and
-                reaches a better performance but also requires a lot more steps to reach a
-                terminal condition, especially if there are many similar object in the data
-                set.
+                    evidence is larger than the most likely pose of this object
+                    - x percent of this poses evidence.
+                # TODO: should we use a separate threshold for within and between
+                objects? If this value is larger, the model is usually more robust to
+                noise and reaches a better performance but also requires a lot more
+                steps to reach a terminal condition, especially if there are many
+                similar object in the data set.
             evidence_update_threshold (float | str): How to decide which hypotheses
                 should be updated. When this parameter is either '[int]%' or
                 'x_percent_threshold', then this parameter is applied to the evidence
@@ -250,6 +250,7 @@ class DefaultHypothesesUpdater:
                     hypotheses, input_channel
                 )
 
+                # calculate the evidence_update_threshold
                 evidence_update_threshold = get_evidence_update_threshold(
                     self.evidence_update_threshold,
                     self.x_percent_threshold,
@@ -419,12 +420,16 @@ def all_usable_input_channels(
 
 
 def get_evidence_update_threshold(
-    evidence_update_threshold, x_percent_threshold, evidence_all_channels: np.ndarray
+    evidence_update_threshold: int,
+    x_percent_threshold: float | str,
+    evidence_all_channels: np.ndarray,
 ):
     """Determine how much evidence a hypothesis should have to be updated.
 
     Args:
-        max_global_evidence (float): Maximum evidence value from all hypotheses.
+        evidence_update_threshold (float | str): update threshold type.
+        x_percent_threshold (int): x_percent threshold used in the calculation of
+            evidence threshold.
         evidence_all_channels (np.ndarray): Evidence values for all hypotheses.
 
     Returns:
@@ -434,6 +439,7 @@ def get_evidence_update_threshold(
         InvalidEvidenceUpdateThreshold: If `self.evidence_update_threshold` is
             not in the allowed values
     """
+    # TODO: Better Args description
     max_global_evidence = np.max(evidence_all_channels)
 
     if type(evidence_update_threshold) in [int, float]:

--- a/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
@@ -752,6 +752,7 @@ class EvidenceGraphLM(GraphLM):
             displacements=displacements,
             graph_id=graph_id,
             mapper=self.channel_hypothesis_mapping[graph_id],
+            max_global_evidence=self.current_mlh["evidence"],
         )
 
         if not hypotheses_updates:

--- a/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
@@ -1172,9 +1172,3 @@ class EvidenceGraphLM(GraphLM):
         stats["evidences"] = self.evidence
         stats["symmetry_evidence"] = self.symmetry_evidence
         return stats
-
-
-class InvalidEvidenceUpdateThreshold(ValueError):
-    """Raised when the evidence update threshold is invalid."""
-
-    pass

--- a/src/tbp/monty/frameworks/models/evidence_matching/resampling_hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/resampling_hypotheses_updater.py
@@ -34,6 +34,7 @@ from tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer import (
 )
 from tbp.monty.frameworks.models.evidence_matching.hypotheses_updater import (
     all_usable_input_channels,
+    get_evidence_update_threshold,
 )
 from tbp.monty.frameworks.utils.evidence_matching import ChannelMapper
 from tbp.monty.frameworks.utils.graph_matching_utils import (
@@ -83,6 +84,8 @@ class ResamplingHypothesesUpdater:
         past_weight: float = 1,
         present_weight: float = 1,
         umbilical_num_poses: int = 8,
+        x_percent_threshold: int = 10,
+        evidence_update_threshold: float | str = "all",
     ):
         """Initializes the ResamplingHypothesesUpdater.
 
@@ -130,6 +133,29 @@ class ResamplingHypothesesUpdater:
             umbilical_num_poses (int): Number of sampled rotations in the direction of
                 the plane perpendicular to the point normal. These are sampled at
                 umbilical points (i.e., points where PC directions are undefined).
+            x_percent_threshold: Used in two places:
+                1) All objects whose highest evidence is greater than the most likely
+                    objects evidence - x_percent of the most like objects evidence are
+                    considered possible matches. That means to only have one possible
+                    match, no other object can have more evidence than the candidate
+                    match's evidence - x percent of it.
+                2) Within one object, possible poses are considered possible if their
+                    evidence is larger than the most likely pose of this object
+                    - x percent of this poses evidence.
+                # TODO: should we use a separate threshold for within and between
+                objects? If this value is larger, the model is usually more robust to
+                noise and reaches a better performance but also requires a lot more
+                steps to reach a terminal condition, especially if there are many
+                similar object in the data set.
+            evidence_update_threshold (float | str): How to decide which hypotheses
+                should be updated. When this parameter is either '[int]%' or
+                'x_percent_threshold', then this parameter is applied to the evidence
+                for the Most Likely Hypothesis (MLH) to determine a minimum evidence
+                threshold in order for other hypotheses to be updated. Any hypotheses
+                falling below the resulting evidence threshold do not get updated. The
+                other options set a fixed threshold that does not take MLH evidence into
+                account. In [int, float, '[int]%', 'mean', 'median', 'all',
+                'x_percent_threshold']. Defaults to 'all'.
         """
         self.feature_evidence_calculator = feature_evidence_calculator
         self.feature_evidence_increment = feature_evidence_increment
@@ -147,6 +173,8 @@ class ResamplingHypothesesUpdater:
         self.initial_possible_poses = get_initial_possible_poses(initial_possible_poses)
         self.tolerances = tolerances
         self.umbilical_num_poses = umbilical_num_poses
+        self.x_percent_threshold = x_percent_threshold
+        self.evidence_update_threshold = evidence_update_threshold
 
         self.use_features_for_matching = self.features_for_matching_selector.select(
             feature_evidence_increment=self.feature_evidence_increment,
@@ -172,7 +200,7 @@ class ResamplingHypothesesUpdater:
         displacements: dict | None,
         graph_id: str,
         mapper: ChannelMapper,
-        evidence_update_threshold: float,
+        max_global_evidence: float,
     ) -> list[ChannelHypotheses]:
         """Update hypotheses based on sensor displacement and sensed features.
 
@@ -189,7 +217,8 @@ class ResamplingHypothesesUpdater:
             graph_id (str): Identifier of the graph being updated
             mapper (ChannelMapper): Mapper for the graph_id to extract data from
                 evidence, locations, and poses based on the input channel
-            evidence_update_threshold (float): Evidence update threshold.
+            max_global_evidence (float): Highest evidence of all hypotheses (i.e.,
+                current mlh evidence),
 
         Returns:
             list[ChannelHypotheses]: The list of hypotheses updates to be applied to
@@ -222,6 +251,14 @@ class ResamplingHypothesesUpdater:
                 graph_id=graph_id,
                 informed_count=informed_count,
                 input_channel=input_channel,
+            )
+
+            # Calculate the evidence_update_threshold
+            evidence_update_threshold = get_evidence_update_threshold(
+                self.evidence_update_threshold,
+                self.x_percent_threshold,
+                max_global_evidence,
+                hypotheses.evidence,
             )
 
             # We only displace existing hypotheses since the newly resampled hypotheses


### PR DESCRIPTION
[PR #317](https://github.com/thousandbrainsproject/tbp.monty/pull/317) has significantly refactored the functionality of hypotheses updating outside of `EvidenceGraphLM`. We can now use it as a component of the LM and swap it out with e.g., `ResamplingHypothesesUpdater`. 

This PR proposes to refactor the evidence_update_threshold functionality outside of `EvidenceGraphLM` as well. I'm proposing this for the following reasons:
- Conceptually, calculating the evidence_update_threshold is part of the hypotheses update logic. A new hypotheses updater should be able to redefine this heuristic.
- In follow-up resampling work, I plan to simplify this heuristic and remove the functionality from the updater logic. The default would be to update all hypotheses without using a threshold. It is part of the `ResamplingHypothesesUpdater`and refactoring this function into the scope of the `HypothesesUpdater` is the first step.

**I turned the class function `_get_evidence_update_threshold` into a bare function (i.e., not belonging to any class) to be used by multiple classes.**

> [!NOTE]
> I modified the `_get_evidence_update_threshold` to handle the edge case of empty evidence array at the beginning of the function.

---

### Benchmark Comparisons

📌 Differences found in experiment: randrot_noise_10distinctobj_dist_agent
| Metric   |   main |   refactor_evidence_threshold |   Δ (delta) |
|----------|--------|-------------------------------|-------------|
| time     | 2.1265 |                         2.116 |     -0.0105 |

📌 Differences found in experiment: unsupervised_inference_distinctobj_dist_agent
| Metric                        |     main |   refactor_evidence_threshold | Δ (delta)   |
|-------------------------------|----------|-------------------------------|-------------|
| time                          |   4.2224 |                        4.2791 | +0.0567     |

