### PR TITLE
chore: update .rsyncignore

### DIFF
--- a/.rsyncignore
+++ b/.rsyncignore
@@ -1,8 +1,11 @@
 - .git
 - .github
+- .idea
 - .mypy_cache
+- .pytest_cache
 - .ruff_cache
 - .vale
+- .venv
 - .vscode
 - docs
 - rfcs


### PR DESCRIPTION
There were a few directories that were missing from the rsync ignore that we don't want to be syncing when running experiments on AWS.