### PR TITLE
chore: add @jeremyshoemaker as Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,3 +11,4 @@
 - [@scottcanoe](https://github.com/scottcanoe)
 - [@hlee9212](https://github.com/hlee9212)
 - [@ramyamounir](https://github.com/ramyamounir)
+- [@jeremyshoemaker](https://github.com/jeremyshoemaker)


### PR DESCRIPTION
Per discussion by the current Maintainers and in accordance with https://thousandbrainsproject.readme.io/docs/governance#adding-maintainers, @jeremyshoemaker is hereby added as a TBP Maintainer.

Welcome @jeremyshoemaker!