### PR TITLE
feat: DISABLE_WANDB envrionment variable

### DIFF
--- a/docs/how-to-use-monty/getting-started.md
+++ b/docs/how-to-use-monty/getting-started.md
@@ -215,7 +215,7 @@ If you want to run an experiment with parallel processing to make use of multipl
 python benchmarks/run_parallel.py -e my_experiment
 ```
 
-If you wish to disable W&B for benchmark experiments, you can pass the environment variable `DISABLE_WANDB=1` as a prefix to the run command.
+If you wish to disable W&B for benchmark experiments, you can pass the inline environment variable `DISABLE_WANDB=1` to the run command.
 
 ```shell
 DISABLE_WANDB=1 python benchmarks/run.py -e my_experiment

--- a/docs/how-to-use-monty/getting-started.md
+++ b/docs/how-to-use-monty/getting-started.md
@@ -215,6 +215,14 @@ If you want to run an experiment with parallel processing to make use of multipl
 python benchmarks/run_parallel.py -e my_experiment
 ```
 
+If you wish to disable W&B for benchmark experiments, you can pass the environment variable `DISABLE_WANDB=1` as a prefix to the run command.
+
+```shell
+DISABLE_WANDB=1 python benchmarks/run.py -e my_experiment
+#OR
+DISABLE_WANDB=1 python benchmarks/run_parallel.py -e my_experiment
+```
+
 # 5. What Next?
 A good next step to get more familiar with our approach and the Monty code base is to go through our [tutorials](./tutorials.md). They include follow-along code and detailed explanations on how Monty experiments are structured, how Monty can be configured in different ways, and what happens when you run a Monty experiment.
 

--- a/src/tbp/monty/frameworks/run.py
+++ b/src/tbp/monty/frameworks/run.py
@@ -16,6 +16,7 @@ import time
 
 from tbp.monty.frameworks.config_utils.cmd_parser import create_cmd_parser
 from tbp.monty.frameworks.utils.dataclass_utils import config_to_dict
+from tbp.monty.frameworks.utils.profile_utils import str2bool
 
 
 def merge_args(config, cmd_args=None):
@@ -89,6 +90,10 @@ def main(all_configs, experiments=None):
         exp = all_configs[experiment]
         exp_config = merge_args(exp, cmd_args)  # TODO: is this really even necessary?
         exp_config = config_to_dict(exp_config)
+
+        # Disable wandb with environment variable
+        if str2bool(os.getenv("DISABLE_WANDB", "0")):
+            exp_config["logging_config"]["wandb_handlers"] = []
 
         # Update run_name and output dir with experiment name
         # NOTE: wandb args are further processed in monty_experiment

--- a/src/tbp/monty/frameworks/run.py
+++ b/src/tbp/monty/frameworks/run.py
@@ -93,7 +93,7 @@ def main(all_configs, experiments=None):
 
         # Disable wandb with environment variable
         if str2bool(os.getenv("DISABLE_WANDB", "0")):
-            exp_config["logging_config"]["wandb_handlers"] = []
+            exp_config["logging_config"]["wandb_handlers"].clear()
 
         # Update run_name and output dir with experiment name
         # NOTE: wandb args are further processed in monty_experiment

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -37,6 +37,7 @@ from tbp.monty.frameworks.loggers.monty_handlers import (
 )
 from tbp.monty.frameworks.run import print_config
 from tbp.monty.frameworks.utils.dataclass_utils import config_to_dict
+from tbp.monty.frameworks.utils.profile_utils import str2bool
 
 """
 Just like run.py, but run episodes in parallel. Running in parallel is as simple as
@@ -627,6 +628,10 @@ def main(
 
     exp = exp if is_unittest else all_configs[experiment]
     exp = config_to_dict(exp)
+
+    # Disable wandb with environment variable
+    if str2bool(os.getenv("DISABLE_WANDB", "0")):
+        exp["logging_config"]["wandb_handlers"] = []
 
     if len(exp["logging_config"]["run_name"]) > 0:
         experiment = exp["logging_config"]["run_name"]

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -631,7 +631,7 @@ def main(
 
     # Disable wandb with environment variable
     if str2bool(os.getenv("DISABLE_WANDB", "0")):
-        exp["logging_config"]["wandb_handlers"] = []
+        exp["logging_config"]["wandb_handlers"].clear()
 
     if len(exp["logging_config"]["run_name"]) > 0:
         experiment = exp["logging_config"]["run_name"]

--- a/src/tbp/monty/frameworks/utils/profile_utils.py
+++ b/src/tbp/monty/frameworks/utils/profile_utils.py
@@ -120,3 +120,7 @@ def get_total_time(df):
     total = df["cumtime"].sum()
     print(f"total time: {total} s")
     return total
+
+
+def str2bool(value: str) -> bool:
+    return value.lower() in ("1", "true", "yes", "on")


### PR DESCRIPTION
This adds support for DISABLE_WANDB environment variable which simply clears the `wandb_handlers` from the configs. To disable w&b, you can run the commands with inline environment variable, e.g., 

```bash
DISABLE_WANDB=1 python benchmarks/run.py -e base_config_10distinctobj_dist_agent
#OR
DISABLE_WANDB=1 python benchmarks/run_parallel.py -e base_config_10distinctobj_dist_agent
```

