### PR TITLE
refactor!: replace logging BasicConfig with standard tiered config

### DIFF
--- a/src/tbp/monty/frameworks/config_utils/config_args.py
+++ b/src/tbp/monty/frameworks/config_utils/config_args.py
@@ -111,7 +111,7 @@ class LoggingConfig:
     wandb_handlers: list = field(default_factory=list)
     python_log_level: str = "INFO"
     python_log_to_file: bool = True
-    python_log_to_stdout: bool = True
+    python_log_to_stderr: bool = True
     output_dir: str = os.path.expanduser(
         os.path.join(monty_logs_dir, "projects/monty_runs/")
     )

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -49,6 +49,8 @@ __all__ = [
     "SaccadeOnImageFromStreamDataLoader",
 ]
 
+logger = logging.getLogger(__name__)
+
 
 class EnvironmentDataset(Dataset):
     """Wraps an embodied environment with a :class:`torch.utils.data.Dataset`.
@@ -321,7 +323,7 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
         Also add any potential distractor objects.
         """
         next_object = (self.current_object + 1) % self.n_objects
-        logging.info(
+        logger.info(
             f"\n\nGoing from {self.current_object} to {next_object} of {self.n_objects}"
         )
         self.change_object_by_idx(next_object)
@@ -366,7 +368,7 @@ class EnvironmentDataLoaderPerObject(EnvironmentDataLoader):
             "semantic_id": self.semantic_label_to_id[self.object_names[idx]],
             **self.object_params,
         }
-        logging.info(f"New primary target: {pformat(self.primary_target)}")
+        logger.info(f"New primary target: {pformat(self.primary_target)}")
 
     def add_distractor_objects(
         self, primary_target_obj, init_params, primary_target_name
@@ -632,7 +634,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
         Returns:
             The observation from the jump attempt.
         """
-        logging.debug(
+        logger.debug(
             "Attempting a 'jump' like movement to evaluate an object hypothesis"
         )
 
@@ -722,7 +724,7 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
 
         A successful jump is "on-object", i.e. the object is perceived by the sensor.
         """
-        logging.debug(
+        logger.debug(
             "Object visible, maintaining new pose for hypothesis-testing action"
         )
 
@@ -756,8 +758,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
 
         A failed jump is "off-object", i.e. the object is not perceived by the sensor.
         """
-        logging.debug("No object visible from hypothesis jump, or inside object!")
-        logging.debug("Returning to previous position")
+        logger.debug("No object visible from hypothesis jump, or inside object!")
+        logger.debug("Returning to previous position")
 
         set_agent_pose = SetAgentPose(
             agent_id=self.motor_system._policy.agent_id,
@@ -867,7 +869,7 @@ class OmniglotDataLoader(EnvironmentDataLoaderPerObject):
     def cycle_object(self):
         """Switch to the next character image."""
         next_object = (self.current_object + 1) % self.n_objects
-        logging.info(
+        logger.info(
             f"\n\nGoing from {self.current_object} to {next_object} of {self.n_objects}"
         )
         self.change_object_by_idx(next_object)
@@ -952,7 +954,7 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
     def cycle_object(self):
         """Switch to the next scene image."""
         next_scene = (self.current_scene_version + 1) % self.n_versions
-        logging.info(
+        logger.info(
             f"\n\nGoing from {self.current_scene_version} to {next_scene} of "
             f"{self.n_versions}"
         )
@@ -965,7 +967,7 @@ class SaccadeOnImageDataLoader(EnvironmentDataLoaderPerObject):
             idx: Index of the new object and ints parameters in object params
         """
         assert idx <= self.n_versions, "idx must be <= self.n_versions"
-        logging.info(
+        logger.info(
             f"changing to obj {idx} -> scene {self.scenes[idx]}, version "
             f"{self.versions[idx]}"
         )
@@ -1040,7 +1042,7 @@ class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):
     def cycle_scene(self):
         """Switch to the next scene image."""
         next_scene = self.current_scene + 1
-        logging.info(f"\n\nGoing from {self.current_scene} to {next_scene}")
+        logger.info(f"\n\nGoing from {self.current_scene} to {next_scene}")
         # TODO: Do we need a separate method for this ?
         self.change_scene_by_idx(next_scene)
 
@@ -1050,7 +1052,7 @@ class SaccadeOnImageFromStreamDataLoader(SaccadeOnImageDataLoader):
         Args:
             idx: Index of the new object and ints parameters in object params
         """
-        logging.info(f"changing to scene {idx}")
+        logger.info(f"changing to scene {idx}")
         self.dataset.env.switch_to_scene(idx)
         self.current_scene = idx
         # TODO: Currently not differentiating between different poses/views

--- a/src/tbp/monty/frameworks/environments/two_d_data.py
+++ b/src/tbp/monty/frameworks/environments/two_d_data.py
@@ -25,6 +25,8 @@ from tbp.monty.frameworks.environments.embodied_environment import (
     EmbodiedEnvironment,
 )
 
+logger = logging.getLogger(__name__)
+
 __all__ = [
     "OmniglotEnvironment",
     "SaccadeOnImageEnvironment",
@@ -221,7 +223,7 @@ class OmniglotEnvironment(EmbodiedEnvironment):
         char_dir = "/" + char_img_names + "_" + str(self.character_version).zfill(2)
         current_image = load_img(img_char_dir + char_dir + ".png")
         move_path = load_motor(stroke_char_dir + char_dir + ".txt")
-        logging.info(f"Finished loading new image from {img_char_dir + char_dir}")
+        logger.info(f"Finished loading new image from {img_char_dir + char_dir}")
         locations = self.motor_to_locations(move_path)
         maxloc = current_image.shape[0] - self.patch_size
         # Don't use locations at the border where patch doesn't fit anymore
@@ -633,7 +635,7 @@ class SaccadeOnImageEnvironment(EmbodiedEnvironment):
         elif action_name == "turn_right":
             new_loc[1] += amount
         else:
-            logging.error(f"{action_name} is not a valid action, not moving.")
+            logger.error(f"{action_name} is not a valid action, not moving.")
         # Make sure location stays within move area
         if new_loc[0] < self.move_area[0][0]:
             new_loc[0] = self.move_area[0][0]

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -23,6 +23,8 @@ from .monty_experiment import MontyExperiment
 # turn interactive plotting off -- call plt.show() to open all figures
 plt.ioff()
 
+logger = logging.getLogger(__name__)
+
 
 class MontyObjectRecognitionExperiment(MontyExperiment):
     """Experiment customized for object-pose recognition with a single object.
@@ -84,7 +86,7 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
                 self.show_observations(observation, loader_step)
 
             if self.model.check_reached_max_matching_steps(self.max_steps):
-                logging.info(
+                logger.info(
                     f"Terminated due to maximum matching steps : {self.max_steps}"
                 )
                 # Need to break here already, otherwise there are problems
@@ -92,12 +94,12 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
                 return loader_step
 
             if loader_step >= (self.max_total_steps):
-                logging.info(f"Terminated due to maximum episode steps : {loader_step}")
+                logger.info(f"Terminated due to maximum episode steps : {loader_step}")
                 self.model.deal_with_time_out()
                 return loader_step
 
             if self.model.is_motor_only_step:
-                logging.debug(
+                logger.debug(
                     "Performing a motor-only step, so passing info straight to motor"
                 )
                 # On these sensations, we just want to pass information to the motor

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -18,6 +18,8 @@ from tbp.monty.frameworks.utils.dataclass_utils import config_to_dict
 
 from .monty_experiment import MontyExperiment
 
+logger = logging.getLogger(__name__)
+
 
 class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
     """Just run exploratory steps and tell the model the object and pose.
@@ -134,5 +136,5 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
 
     def evaluate(self):
         """Use experiment just for supervised pretraining -> no eval."""
-        logging.warning("No evalualtion mode for supervised experiment.")
+        logger.warning("No evalualtion mode for supervised experiment.")
         pass

--- a/src/tbp/monty/frameworks/loggers/monty_handlers.py
+++ b/src/tbp/monty/frameworks/loggers/monty_handlers.py
@@ -22,6 +22,8 @@ from tbp.monty.frameworks.utils.logging_utils import (
     maybe_rename_existing_file,
 )
 
+logger = logging.getLogger(__name__)
+
 ###
 # Template for MontyHandler
 ###
@@ -113,7 +115,7 @@ class BasicCSVStatsHandler(MontyHandler):
         mode_key = f"{mode}_stats"
         output_file = os.path.join(output_dir, f"{mode}_stats.csv")
         stats = basic_logs.get(mode_key, {})
-        logging.debug(pformat(stats))
+        logger.debug(pformat(stats))
 
         # Remove file if it existed before to avoid appending to previous results file
         if output_file not in self.reports_per_file:

--- a/src/tbp/monty/frameworks/models/buffer.py
+++ b/src/tbp/monty/frameworks/models/buffer.py
@@ -22,6 +22,8 @@ from scipy.spatial.transform import Rotation
 
 from tbp.monty.frameworks.actions.actions import Action, ActionJSONEncoder
 
+logger = logging.getLogger(__name__)
+
 
 class BaseBuffer:
     @abc.abstractclassmethod
@@ -346,7 +348,7 @@ class FeatureAtLocationBuffer(BaseBuffer):
         all_features_on_object = {}
         # Number of steps where at least one input was on the object
         global_on_object_ids = np.where(self.on_object)[0]
-        logging.debug(
+        logger.debug(
             f"Observed {np.array(self.locations).shape} locations, "
             f"{len(global_on_object_ids)} global on object"
         )
@@ -355,7 +357,7 @@ class FeatureAtLocationBuffer(BaseBuffer):
             channel_off_object_ids = np.where(
                 self.features[input_channel]["on_object"] is False
             )[0]
-            logging.debug(
+            logger.debug(
                 f"{input_channel} has "
                 f"{len(self.locations) - len(channel_off_object_ids)} "
                 "on object observations"
@@ -373,7 +375,7 @@ class FeatureAtLocationBuffer(BaseBuffer):
                         ),
                         refcheck=False,
                     )
-                logging.debug(
+                logger.debug(
                     f"{input_channel} observations for feature {feature} have "
                     f"shape {np.array(self.features[input_channel][feature]).shape}"
                 )

--- a/src/tbp/monty/frameworks/models/displacement_matching.py
+++ b/src/tbp/monty/frameworks/models/displacement_matching.py
@@ -20,6 +20,8 @@ from tbp.monty.frameworks.models.object_model import GraphObjectModel
 from tbp.monty.frameworks.utils.graph_matching_utils import is_in_ranges
 from tbp.monty.frameworks.utils.sensor_processing import point_pair_features
 
+logger = logging.getLogger(__name__)
+
 
 class DisplacementGraphLM(GraphLM):
     """Learning module that uses displacement stored in graphs to recognize objects."""
@@ -134,7 +136,7 @@ class DisplacementGraphLM(GraphLM):
                     "detected_scale": scale,
                 }
                 self.buffer.add_overall_stats(lm_episode_stats)
-                logging.debug(f"(location, rotation, scale): {pose_and_scale}")
+                logger.debug(f"(location, rotation, scale): {pose_and_scale}")
 
         return pose_and_scale
 
@@ -209,7 +211,7 @@ class DisplacementGraphLM(GraphLM):
         elif self.match_attribute == "PPF":
             query = self.buffer.get_current_ppf(input_channel="first")
         else:
-            logging.error("match_attribute not defined")
+            logger.error("match_attribute not defined")
 
         # This is just whether we are on the object or not here.
         target = self._select_features_to_use(observation)
@@ -219,7 +221,7 @@ class DisplacementGraphLM(GraphLM):
                 input_channel="first"
             )
 
-        logging.debug(f"query: {query}")
+        logger.debug(f"query: {query}")
 
         self._update_possible_matches(query=query, target=target)
 
@@ -351,13 +353,13 @@ class DisplacementGraphLM(GraphLM):
         self.possible_paths[graph_id] = current_possible_paths
         self.next_possible_paths[graph_id] = new_possible_paths
         self.scale_factors[graph_id] = path_scale_factors
-        # logging.info(
+        # logger.info(
         #     "possible paths for "
         #     + graph_id
         #     + ": "
         #     + str(self.possible_paths[graph_id])
         # )
-        # logging.info(
+        # logger.info(
         #     "next possible paths for "
         #     + graph_id
         #     + ": "
@@ -489,13 +491,12 @@ class DisplacementGraphMemory(GraphMemory):
             scale_factors,
         )
 
-    # ------------------ Getters & Setters ---------------------
     # ------------------ Logging & Saving ----------------------
     def load_state_dict(self, state_dict):
         """Load graphs into memory from a state_dict and add point pair features."""
-        logging.info("loading models")
+        logger.info("loading models")
         for obj_name, model in state_dict.items():
-            logging.debug(f"loading {obj_name}: {model}")
+            logger.debug(f"loading {obj_name}: {model}")
             for input_channel in model:
                 if (self.match_attribute == "PPF") and (
                     model[input_channel].has_ppf is False
@@ -518,7 +519,7 @@ class DisplacementGraphMemory(GraphMemory):
             graph_id: Name of the object.
             input_channel: ?
         """
-        logging.info(f"Adding a new graph to memory.")
+        logger.info(f"Adding a new graph to memory.")
 
         model = GraphObjectModel(
             object_id=graph_id,
@@ -539,7 +540,4 @@ class DisplacementGraphMemory(GraphMemory):
         if graph_id not in self.models_in_memory:
             self.models_in_memory[graph_id] = {}
         self.models_in_memory[graph_id][input_channel] = model
-        logging.info(f"Added new graph with id {graph_id} to memory.")
-
-    # ------------------------ Helper --------------------------
-    # ----------------------- Logging --------------------------
+        logger.info(f"Added new graph with id {graph_id} to memory.")

--- a/src/tbp/monty/frameworks/models/evidence_matching/graph_memory.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/graph_memory.py
@@ -17,6 +17,8 @@ from tbp.monty.frameworks.models.object_model import (
     GridTooSmallError,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class EvidenceGraphMemory(GraphMemory):
     """Custom GraphMemory that stores GridObjectModel instead of GraphObjectModel."""
@@ -60,8 +62,6 @@ class EvidenceGraphMemory(GraphMemory):
         node_directions = node_directions.reshape((num_nodes, 3, 3))
         return node_directions
 
-    # ------------------ Logging & Saving ----------------------
-
     # ======================= Private ==========================
 
     # ------------------- Main Algorithm -----------------------
@@ -87,12 +87,10 @@ class EvidenceGraphMemory(GraphMemory):
                         graph_id, loaded_graph
                     )
 
-                logging.info(f"Loaded {model} for {input_channel}")
+                logger.info(f"Loaded {model} for {input_channel}")
                 self.models_in_memory[graph_id][input_channel] = channel_model
             except GridTooSmallError:
-                logging.info(
-                    "Grid too small for given locations. Not adding to memory."
-                )
+                logger.info("Grid too small for given locations. Not adding to memory.")
 
     def _initialize_model_with_graph(self, graph_id, graph):
         model = GridObjectModel(
@@ -118,7 +116,7 @@ class EvidenceGraphMemory(GraphMemory):
             graph_id: name of new graph.
             input_channel: ?
         """
-        logging.info(f"Adding a new graph to memory.")
+        logger.info(f"Adding a new graph to memory.")
 
         model = GridObjectModel(
             object_id=graph_id,
@@ -133,10 +131,10 @@ class EvidenceGraphMemory(GraphMemory):
                 self.models_in_memory[graph_id] = {}
             self.models_in_memory[graph_id][input_channel] = model
 
-            logging.info(f"Added new graph with id {graph_id} to memory.")
-            logging.info(model)
+            logger.info(f"Added new graph with id {graph_id} to memory.")
+            logger.info(model)
         except GridTooSmallError:
-            logging.info(
+            logger.info(
                 "Grid too small for given locations. Not building a model "
                 f"for {graph_id}"
             )
@@ -164,7 +162,7 @@ class EvidenceGraphMemory(GraphMemory):
             object_rotation: rotation of the sensed object relative to the model
             object_scale: scale of the object relative to the model of it
         """
-        logging.info(f"Updating existing graph for {graph_id}")
+        logger.info(f"Updating existing graph for {graph_id}")
 
         try:
             self.models_in_memory[graph_id][input_channel].update_model(
@@ -174,9 +172,9 @@ class EvidenceGraphMemory(GraphMemory):
                 object_location_rel_body=object_location_rel_body,
                 object_rotation=object_rotation,
             )
-            logging.info(
+            logger.info(
                 f"Extended graph {graph_id} with new points. New model:\n"
                 f"{self.models_in_memory[graph_id]}"
             )
         except GridTooSmallError:
-            logging.info("Grid too small for given locations. Not updating model.")
+            logger.info("Grid too small for given locations. Not updating model.")

--- a/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_displacer.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_displacer.py
@@ -31,6 +31,8 @@ from tbp.monty.frameworks.utils.spatial_arithmetics import (
     rotate_pose_dependent_features,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class HypothesesDisplacer(Protocol):
     def displace_hypotheses_and_compute_evidence(
@@ -146,7 +148,7 @@ class DefaultHypothesesDisplacer:
         )[0]
         num_hypotheses_to_test = hyp_ids_to_test.shape[0]
         if num_hypotheses_to_test > 0:
-            logging.info(
+            logger.info(
                 f"Testing {num_hypotheses_to_test} out of "
                 f"{total_hypotheses_count} hypotheses for {graph_id} "
                 f"(evidence > {evidence_update_threshold})"
@@ -210,7 +212,7 @@ class DefaultHypothesesDisplacer:
         Returns:
             The location evidence.
         """
-        logging.debug(
+        logger.debug(
             f"Calculating evidence for {graph_id} using input from {input_channel}"
         )
 

--- a/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
@@ -42,6 +42,8 @@ from tbp.monty.frameworks.utils.spatial_arithmetics import (
     align_multiple_orthonormal_vectors,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class HypothesesUpdater(Protocol):
     def update_hypotheses(
@@ -199,7 +201,7 @@ class DefaultHypothesesUpdater:
         )
 
         if len(input_channels_to_use) == 0:
-            logging.info(
+            logger.info(
                 f"No input channels observed for {graph_id} that are stored in the "
                 "model. Not updating evidence."
             )
@@ -270,7 +272,7 @@ class DefaultHypothesesUpdater:
         all_possible_locations = np.zeros((1, 3))
         all_possible_rotations = np.zeros((1, 3, 3))
 
-        logging.debug(f"Determining possible poses using input from {input_channel}")
+        logger.debug(f"Determining possible poses using input from {input_channel}")
         node_directions = self.graph_memory.get_rotation_features_at_all_nodes(
             graph_id, input_channel
         )

--- a/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
@@ -41,6 +41,8 @@ from tbp.monty.frameworks.utils.graph_matching_utils import (
     get_scaled_evidences,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class EvidenceGraphLM(GraphLM):
     """Learning module that accumulates evidence for objects and poses.
@@ -313,7 +315,7 @@ class EvidenceGraphLM(GraphLM):
                     # call this to prevent main thread from continuing in code
                     # before all evidences are updated.
                     thread.join()
-            logging.debug("Updating possible matches after vote")
+            logger.debug("Updating possible matches after vote")
             self.possible_matches = self._threshold_possible_matches()
             self.current_mlh = self._calculate_most_likely_hypothesis()
 
@@ -468,7 +470,7 @@ class EvidenceGraphLM(GraphLM):
         If we timed out it is None and we will not update the graph memory.
         """
         self.terminal_state = terminal_state
-        logging.debug(f"terminal state: {terminal_state}")
+        logger.debug(f"terminal state: {terminal_state}")
         if terminal_state is None:  # at beginning of episode
             graph_id = None
         elif (terminal_state == "no_match") or len(self.get_possible_matches()) == 0:
@@ -532,7 +534,7 @@ class EvidenceGraphLM(GraphLM):
                 pose_and_scale = np.concatenate(
                     [mlh["location"], r_euler, [mlh["scale"]]]
                 )
-                logging.debug(f"(location, rotation, scale): {pose_and_scale}")
+                logger.debug(f"(location, rotation, scale): {pose_and_scale}")
                 # Set LM variables to detected object & pose
                 self.detected_pose = pose_and_scale
                 self.detected_rotation_r = mlh["rotation"]
@@ -560,7 +562,7 @@ class EvidenceGraphLM(GraphLM):
                     self.buffer.add_overall_stats(symmetry_stats)
                 return pose_and_scale
             else:
-                logging.debug(f"object {object_id} detected but pose not resolved yet.")
+                logger.debug(f"object {object_id} detected but pose not resolved yet.")
                 return None
         else:
             return None
@@ -650,10 +652,10 @@ class EvidenceGraphLM(GraphLM):
             possible_object_hypotheses_ids = np.where(
                 self.evidence[object_id] > max_obj_evidence - x_percent_of_max
             )[0]
-            logging.debug(
+            logger.debug(
                 f"possible hpids: {possible_object_hypotheses_ids} for {object_id}"
             )
-            logging.debug(f"hpid evidence is > {max_obj_evidence} - {x_percent_of_max}")
+            logger.debug(f"hpid evidence is > {max_obj_evidence} - {x_percent_of_max}")
             return possible_object_hypotheses_ids
 
     def get_evidence_for_each_graph(self):
@@ -772,7 +774,7 @@ class EvidenceGraphLM(GraphLM):
 
         end_time = time.time()
         assert not np.isnan(np.max(self.evidence[graph_id])), "evidence contains NaN."
-        logging.debug(
+        logger.debug(
             f"evidence update for {graph_id} took "
             f"{np.round(end_time - start_time, 2)} seconds."
             f" New max evidence: {np.round(np.max(self.evidence[graph_id]), 3)}"
@@ -929,7 +931,7 @@ class EvidenceGraphLM(GraphLM):
         possible_locations = np.array(
             self.possible_locations[graph_id][possible_object_hypotheses_ids]
         )
-        logging.debug(f"{possible_locations.shape[0]} possible locations")
+        logger.debug(f"{possible_locations.shape[0]} possible locations")
 
         center_location = np.mean(possible_locations, axis=0)
         distances_to_center = np.linalg.norm(
@@ -937,7 +939,7 @@ class EvidenceGraphLM(GraphLM):
         )
         location_unique = np.max(distances_to_center) < self.path_similarity_threshold
         if location_unique:
-            logging.info(
+            logger.info(
                 "all possible locations are in radius "
                 f"{self.path_similarity_threshold} of {center_location}"
             )
@@ -945,7 +947,7 @@ class EvidenceGraphLM(GraphLM):
         possible_rotations = np.array(self.possible_poses[graph_id])[
             possible_object_hypotheses_ids
         ]
-        logging.debug(f"{possible_rotations.shape[0]} possible rotations")
+        logger.debug(f"{possible_rotations.shape[0]} possible rotations")
 
         # Compute the difference between each rotation matrix in the list of possible
         # rotations and the most likely rotation in radians.
@@ -980,7 +982,7 @@ class EvidenceGraphLM(GraphLM):
         """
         if self.last_possible_hypotheses is None:
             return False  # need more steps to meet symmetry condition
-        logging.debug(
+        logger.debug(
             f"\n\nchecking for symmetry for hp ids {possible_object_hypotheses_ids}"
             f" with last ids {self.last_possible_hypotheses}"
         )
@@ -990,13 +992,13 @@ class EvidenceGraphLM(GraphLM):
             hypothesis_overlap = previous_hyps.intersection(current_hyps)
             if len(hypothesis_overlap) / len(current_hyps) > 0.9:
                 # at least 90% of current possible ids were also in previous ids
-                logging.info("added symmetry evidence")
+                logger.info("added symmetry evidence")
                 self.symmetry_evidence += 1
             else:  # has to be consequtive
                 self.symmetry_evidence = 0
 
         if self._enough_symmetry_evidence_accumulated():
-            logging.info(
+            logger.info(
                 f"Symmetry detected for hypotheses {possible_object_hypotheses_ids}"
             )
             return True
@@ -1053,7 +1055,7 @@ class EvidenceGraphLM(GraphLM):
                     else:
                         shape = 1
                     default_weights = np.ones(shape) * default
-                    logging.debug(
+                    logger.debug(
                         f"adding {key} to feature_weights with value {default_weights}"
                     )
                     self.feature_weights[input_channel][key] = default_weights
@@ -1074,7 +1076,7 @@ class EvidenceGraphLM(GraphLM):
             The possible matches.
         """
         if len(self.graph_memory) == 0:
-            logging.info("no objects in memory yet.")
+            logger.info("no objects in memory yet.")
             return []
         graph_ids, graph_evidences = self.get_evidence_for_each_graph()
         # median_ge = np.median(graph_evidences)
@@ -1090,8 +1092,8 @@ class EvidenceGraphLM(GraphLM):
             )
             th = max_ge - x_percent_of_max if max_ge > 0 else 0
             pm = [graph_ids[i] for i, ge in enumerate(graph_evidences) if ge > th]
-            logging.debug(f"evidences for each object: {graph_evidences}")
-            logging.debug(
+            logger.debug(f"evidences for each object: {graph_evidences}")
+            logger.debug(
                 f"mean evidence: {np.round(mean_ge, 3)}, std: {np.round(std_ge, 3)}"
                 f" -> th={th}"
             )
@@ -1151,7 +1153,7 @@ class EvidenceGraphLM(GraphLM):
             if not mlh:  # No objects in memory
                 mlh = self.current_mlh
                 mlh["graph_id"] = "new_object0"
-            logging.info(
+            logger.info(
                 f"current most likely hypothesis: {mlh['graph_id']} "
                 f"with evidence {np.round(mlh['evidence'], 2)}"
             )

--- a/src/tbp/monty/frameworks/models/evidence_matching/model.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/model.py
@@ -22,6 +22,8 @@ from tbp.monty.frameworks.utils.spatial_arithmetics import (
     align_orthonormal_vectors,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class MontyForEvidenceGraphMatching(MontyForGraphMatching):
     """Monty model for evidence based graphs.
@@ -77,7 +79,7 @@ class MontyForEvidenceGraphMatching(MontyForGraphMatching):
                             receiving_lm_pose[1:],
                             as_scipy=False,
                         )
-                        logging.debug(
+                        logger.debug(
                             f"LM {j} to {i} - displacement: {sensor_disp}, "
                             f"rotation: "
                             f"{sensor_rotation_disp}"
@@ -115,7 +117,7 @@ class MontyForEvidenceGraphMatching(MontyForGraphMatching):
                                 )
                             else:
                                 lm_state_votes[obj] = transformed_lm_states_for_object
-            logging.debug(f"VOTE from LMs {self.lm_to_lm_vote_matrix[i]} to LM {i}")
+            logger.debug(f"VOTE from LMs {self.lm_to_lm_vote_matrix[i]} to LM {i}")
             vote = lm_state_votes
             combined_votes.append(vote)
         return combined_votes

--- a/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
@@ -25,6 +25,7 @@ from tbp.monty.frameworks.models.evidence_matching.learning_module import (
     EvidenceGraphLM,
 )
 
+logger = logging.getLogger(__name__)
 
 class LoggerSDR:
     """A simple logger that saves the data passed to it.
@@ -41,7 +42,7 @@ class LoggerSDR:
     # of Monty loggers. Fix issue #328 first.
     def __init__(self, path):
         if path is None:
-            logging.warning("EvidenceSDR log path is set to None.")
+            logger.warning("EvidenceSDR log path is set to None.")
             return
 
         path = os.path.expanduser(path)
@@ -115,7 +116,7 @@ class EncoderSDR:
         log_flag=False,
     ):
         if sdr_on_bits >= sdr_length or sdr_on_bits <= 0:
-            logging.warning(
+            logger.warning(
                 f"Invalid sparsity: sdr_on_bits set to 2% ({round(sdr_length * 0.02)})"
             )
             sdr_on_bits = round(sdr_length * 0.02)
@@ -126,7 +127,7 @@ class EncoderSDR:
         self.stability = stability
         if self.stability > 1.0 or self.stability < 0.0:
             self.stability = np.clip(self.stability, 0.0, 1.0)
-            logging.warning(
+            logger.warning(
                 f"Invalid stability parameter: stability clamped to {self.stability}"
             )
         self.log_flag = log_flag
@@ -312,11 +313,11 @@ class EncoderSDR:
         # return if no target provided
         stats = {}
         if np.all(np.isnan(target_overlaps)):
-            logging.warning("Empty overlap targets. No training needed.")
+            logger.warning("Empty overlap targets. No training needed.")
             return stats
 
         if np.all(np.array(target_overlaps.shape) > self.n_objects):
-            logging.warning(
+            logger.warning(
                 "Overlap targets have larger size than "
                 + f"{(self.n_objects, self.n_objects)}"
             )

--- a/src/tbp/monty/frameworks/models/feature_location_matching.py
+++ b/src/tbp/monty/frameworks/models/feature_location_matching.py
@@ -29,6 +29,8 @@ from tbp.monty.frameworks.utils.spatial_arithmetics import (
     rotate_pose_dependent_features,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class FeatureGraphLM(GraphLM):
     """Learning module that uses features at locations to recognize objects."""
@@ -125,7 +127,7 @@ class FeatureGraphLM(GraphLM):
         object_id_vote = {}
         for obj in all_objects:
             object_id_vote[obj] = obj in possible_matches
-        logging.info(
+        logger.info(
             f"PM: {possible_matches} out of all: {all_objects} "
             f"-> vote: {object_id_vote}"
         )
@@ -161,7 +163,7 @@ class FeatureGraphLM(GraphLM):
                     vote_data["neg_object_id_votes"][possible_obj]
                     > vote_data["pos_object_id_votes"][possible_obj]
                 ):
-                    logging.info(f"Removing {possible_obj} from matches after vote.")
+                    logger.info(f"Removing {possible_obj} from matches after vote.")
                     self._remove_object_from_matches(possible_obj)
 
                 # Check that object is still in matches after ID update
@@ -170,7 +172,7 @@ class FeatureGraphLM(GraphLM):
                         self.NUM_OTHER_LMS
                     ):
                         k = vote_data["pos_location_votes"][possible_obj].shape[0]
-                        logging.info(f"only received {k} votes")
+                        logger.info(f"only received {k} votes")
                     else:
                         # k should not be > num_lms - 1
                         k = self.NUM_OTHER_LMS
@@ -197,7 +199,7 @@ class FeatureGraphLM(GraphLM):
                             self.possible_paths[possible_obj].pop(path_id)
                             self.possible_poses[possible_obj].pop(path_id)
                             removed_locations = np.vstack([removed_locations, location])
-                    logging.info(
+                    logger.info(
                         f"removed {removed_locations.shape[0] - 1} locations from "
                         f"possible matches for {possible_obj}"
                     )
@@ -234,7 +236,7 @@ class FeatureGraphLM(GraphLM):
             current_model_loc = model_locs[-1]
             scale = self.get_object_scale(object_id)  # NOTE: Scale doesn't work for FM
             pose_and_scale = np.concatenate([current_model_loc, r_euler[0], [scale]])
-            logging.debug(f"(location, rotation, scale): {pose_and_scale}")
+            logger.debug(f"(location, rotation, scale): {pose_and_scale}")
 
             # Update own state
             self.detected_pose = pose_and_scale
@@ -321,7 +323,7 @@ class FeatureGraphLM(GraphLM):
         else:  # has to be consequtive
             self.symmetry_evidence = 0
         if self._enough_symmetry_evidence_accumulated():
-            logging.info(f"Symmetry detected for poses {current_unique_poses}")
+            logger.info(f"Symmetry detected for poses {current_unique_poses}")
             return True
         else:
             return False
@@ -333,8 +335,6 @@ class FeatureGraphLM(GraphLM):
             Whether enough evidence for symmetry has been accumulated.
         """
         return self.symmetry_evidence >= self.required_symmetry_evidence
-
-    # ------------------ Logging & Saving ----------------------
 
     # ======================= Private ==========================
 
@@ -427,12 +427,12 @@ class FeatureGraphLM(GraphLM):
 
             self.possible_poses[graph_id] = new_possible_poses
             if len(self.possible_poses[graph_id]) < 10:
-                logging.info(
+                logger.info(
                     f"possible poses after matching for "
                     f"{graph_id}: {self.get_possible_poses()[graph_id]}"
                 )
         self.possible_paths[graph_id] = new_possible_paths
-        logging.debug(
+        logger.debug(
             f"possible paths after matching for "
             f"{graph_id}: {len(self.possible_paths[graph_id])}"
         )
@@ -624,7 +624,7 @@ class FeatureGraphLM(GraphLM):
             # 2 possibilities since the curvature directions may be flipped
             possible_s_d = possible_sensed_directions(sensed_directions, 2)
         else:
-            logging.debug(
+            logger.debug(
                 "PC 1 is similar to PC2 -> Their directions are not meaningful"
             )
             possible_s_d = possible_sensed_directions(

--- a/src/tbp/monty/frameworks/models/goal_state_generation.py
+++ b/src/tbp/monty/frameworks/models/goal_state_generation.py
@@ -16,6 +16,7 @@ from tbp.monty.frameworks.models.abstract_monty_classes import GoalStateGenerato
 from tbp.monty.frameworks.models.states import GoalState
 from tbp.monty.frameworks.utils.communication_utils import get_state_from_channel
 
+logger = logging.getLogger(__name__)
 
 class GraphGoalStateGenerator(GoalStateGenerator):
     """Generate sub-goal states until the received goal state is achieved.
@@ -626,7 +627,7 @@ class EvidenceGoalStateGenerator(GraphGoalStateGenerator):
         Returns:
             The index of the point in the model to test.
         """
-        logging.debug("Proposing an evaluation location based on graph mismatch")
+        logger.debug("Proposing an evaluation location based on graph mismatch")
 
         top_id, second_id = self.parent_lm.get_top_two_mlh_ids()
 
@@ -976,7 +977,7 @@ class EvidenceGoalStateGenerator(GraphGoalStateGenerator):
             # of the way towards being certain about the ID
             # (len(pm_smaller_thresh) == 1), then we sometimes (hence the randomness)
             # focus on pose.
-            logging.debug(
+            logger.debug(
                 "Hypothesis jump indicated: One object more likely, focusing on pose"
             )
             self.focus_on_pose = True
@@ -995,7 +996,7 @@ class EvidenceGoalStateGenerator(GraphGoalStateGenerator):
             ]
             != [top_id, second_id]
         ):
-            logging.debug(
+            logger.debug(
                 "Hypothesis jump indicated: change or shuffle in top-two MLH IDs"
             )
             return True
@@ -1010,7 +1011,7 @@ class EvidenceGoalStateGenerator(GraphGoalStateGenerator):
             top_mlh["rotation"].as_euler("xyz")
             != self.prev_top_mlhs[0]["rotation"].as_euler("xyz")
         ):
-            logging.debug(
+            logger.debug(
                 "Hypothesis jump indicated: change in most-likely rotation of MLH"
             )
             return True
@@ -1019,7 +1020,7 @@ class EvidenceGoalStateGenerator(GraphGoalStateGenerator):
         # still perform a jump; note however that this threshold exponentially
         # increases, so that we avoid continuously returning to the same location
         elif num_elapsed_steps % (self.wait_factor * self.elapsed_steps_factor) == 0:
-            logging.debug(
+            logger.debug(
                 "Hypothesis jump indicated: sufficient steps elapsed with no jump"
             )
 

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -27,6 +27,8 @@ from tbp.monty.frameworks.models.goal_state_generation import GraphGoalStateGene
 from tbp.monty.frameworks.models.monty_base import MontyBase
 from tbp.monty.frameworks.models.object_model import GraphObjectModel
 
+logger = logging.getLogger(__name__)
+
 
 class MontyForGraphMatching(MontyBase):
     """General Monty model for recognizing object using graphs."""
@@ -63,22 +65,20 @@ class MontyForGraphMatching(MontyBase):
         for sm in self.sensor_modules:
             sm.pre_episode()
 
-        logging.debug(
+        logger.debug(
             f"Models in memory: {self.learning_modules[0].get_all_known_object_ids()}"
         )
 
     def send_vote_to_lm(self, lm, lm_id, combined_votes):
         """Route correct votes to a given LM."""
-        logging.debug(
-            f"Matches before voting (LM {lm_id}): {lm.get_possible_matches()}"
-        )
+        logger.debug(f"Matches before voting (LM {lm_id}): {lm.get_possible_matches()}")
         if len(combined_votes) < 1:
             # Deal with set vote from displacement LM
             lm.receive_votes(combined_votes)
         else:
             lm.receive_votes(combined_votes[lm_id])
 
-        logging.debug(f"Matches after voting (LM {lm_id}): {lm.get_possible_matches()}")
+        logger.debug(f"Matches after voting (LM {lm_id}): {lm.get_possible_matches()}")
 
     def update_stats_after_vote(self, lm):
         """Add voting stats to buffer and check individual terminal condition."""
@@ -156,7 +156,7 @@ class MontyForGraphMatching(MontyBase):
         num_lms_done = 0
         for lm in self.learning_modules:
             lm.update_terminal_condition()
-            logging.debug(
+            logger.debug(
                 f"{lm.learning_module_id} has terminal state: {lm.terminal_state}"
             )
             # If any LM is not done yet, we are not done yet
@@ -164,7 +164,7 @@ class MontyForGraphMatching(MontyBase):
                 num_lms_done += 1
 
         if num_lms_done >= self.min_lms_match:
-            logging.info("\n\nMONTY DETECTED MATCH\n\n")
+            logger.info("\n\nMONTY DETECTED MATCH\n\n")
             return True
 
     def reset(self):
@@ -232,7 +232,7 @@ class MontyForGraphMatching(MontyBase):
 
                 if self.step_type == "matching_step":
                     input_channels = [obs.sender_id for obs in sensory_inputs]
-                    logging.info(
+                    logger.info(
                         f"Sending input from {input_channels}"
                         f" to {self.learning_modules[i].learning_module_id}"
                     )
@@ -240,13 +240,13 @@ class MontyForGraphMatching(MontyBase):
                 assert callable(lm_step_method), f"{lm_step_method} must be callable"
                 lm_step_method(sensory_inputs)
                 if self.step_type == "matching_step":
-                    logging.debug(f"Stepping learning module {i}")
+                    logger.debug(f"Stepping learning module {i}")
                 self.learning_modules[i].add_lm_processing_to_buffer_stats(
                     lm_processed=True
                 )
             else:
                 if self.step_type == "matching_step":
-                    logging.info(f"Skipping step on learning module {i}")
+                    logger.info(f"Skipping step on learning module {i}")
                 self.learning_modules[i].add_lm_processing_to_buffer_stats(
                     lm_processed=False
                 )
@@ -284,13 +284,13 @@ class MontyForGraphMatching(MontyBase):
                 # TODO: This LM may already have some IDs narrowed down by using
                 # incoming voted. Account for that.
                 pm = set()
-            logging.info(f"Possible matches for LM {i}: {pm}")
+            logger.info(f"Possible matches for LM {i}: {pm}")
             if union_of_pm is None:
                 union_of_pm = pm
             else:
                 union_of_pm = set.union(union_of_pm, pm)
         if len(self.learning_modules) > 1:
-            logging.info(f"Union of matches: {union_of_pm}")
+            logger.info(f"Union of matches: {union_of_pm}")
         return union_of_pm
 
     def _combine_votes(self, votes_per_lm):
@@ -342,10 +342,10 @@ class MontyForGraphMatching(MontyBase):
                         # "If I am here, you should be there."
                         lm_loc_vote = votes_per_lm[j]["location_vote"][obj]
                         lm_rot_vote = votes_per_lm[j]["rotation_vote"][obj]
-                        logging.debug(
+                        logger.debug(
                             f"loc vote from LM {j} - {obj}: {lm_loc_vote.shape}"
                         )
-                        logging.debug(
+                        logger.debug(
                             f"rot vote from LM {j} - {obj}: {len(lm_rot_vote)}"
                         )
                         sending_lm_pose = votes_per_lm[j]["sensed_pose_rel_body"]
@@ -355,7 +355,7 @@ class MontyForGraphMatching(MontyBase):
                         sensor_rotation_disp, _ = Rotation.align_vectors(
                             sending_lm_pose[1:], receiving_lm_pose[1:]
                         )
-                        logging.debug(
+                        logger.debug(
                             f"LM {i} to {j} - displacement: {sensor_disp}, "
                             f"rotation: "
                             f"{sensor_rotation_disp.as_euler('xyz', degrees=True)}"
@@ -397,7 +397,7 @@ class MontyForGraphMatching(MontyBase):
                                     lm_loc_vote_transformed
                                 )
                                 lm_object_rotation_votes[obj] = lm_rot_vote_transformed
-                logging.info(
+                logger.info(
                     f"VOTE from LMs {self.lm_to_lm_vote_matrix[i]} to LM {i}: + "
                     f"{pos_object_id_votes}, - {neg_object_id_votes}"
                 )
@@ -421,7 +421,7 @@ class MontyForGraphMatching(MontyBase):
             combined_votes = self._combine_votes(votes_per_lm)
             # Receive votes
             for i in range(len(self.learning_modules)):
-                logging.debug(f"------ Sending votes to LM {i} -------")
+                logger.debug(f"------ Sending votes to LM {i} -------")
                 self.send_vote_to_lm(self.learning_modules[i], i, combined_votes)
                 self.update_stats_after_vote(self.learning_modules[i])
 
@@ -532,18 +532,18 @@ class MontyForGraphMatching(MontyBase):
             lm.stepwise_target_object = self.semantic_id_to_label[
                 sensory_inputs[0]._semantic_id
             ]
-            logging.debug(f"Stepwise target: {lm.stepwise_target_object}")
+            logger.debug(f"Stepwise target: {lm.stepwise_target_object}")
         except KeyError:
             # Semantic sensor may not be available, or the "patch" key
             # may be different
-            logging.debug("Semantic ID not available for stepwise-targets")
+            logger.debug("Semantic ID not available for stepwise-targets")
             lm.stepwise_target_object = "no_label"
         except TypeError:
             # semantic_id_to_label is not specified, e.g. in unit tests
-            logging.debug("semantic_id_to_label mapping not specified")
+            logger.debug("semantic_id_to_label mapping not specified")
             lm.stepwise_target_object = "no_label"
         except AttributeError:
-            logging.debug("semantic_id_to_label mapping not specified")
+            logger.debug("semantic_id_to_label mapping not specified")
             lm.stepwise_target_object = "no_label"
 
         # Add logging information : TODO use the buffer to log this appropriately
@@ -643,9 +643,9 @@ class GraphLM(LearningModule):
         self.buffer.append_input_states(observations)
 
         if first_movement_detected:
-            logging.debug("performing matching step.")
+            logger.debug("performing matching step.")
         else:
-            logging.debug("we have not moved yet.")
+            logger.debug("we have not moved yet.")
 
         self._compute_possible_matches(
             observations, first_movement_detected=first_movement_detected
@@ -668,7 +668,7 @@ class GraphLM(LearningModule):
     def post_episode(self):
         """If training, update memory after each episode."""
         if (self.mode == "train") and len(self.buffer) > 0:
-            logging.info(f"\n---Updating memory of {self.learning_module_id}---")
+            logger.info(f"\n---Updating memory of {self.learning_module_id}---")
             self._update_memory()
             self._update_target_graph_mapping(self.detected_object, self.primary_target)
 
@@ -686,7 +686,7 @@ class GraphLM(LearningModule):
         possible_matches = set(self.get_possible_matches())
         all_objects = set(self.get_all_known_object_ids())
         vote = all_objects.difference(possible_matches)
-        logging.debug(
+        logger.debug(
             f"PM: {possible_matches} out of all: {all_objects} -> vote: {vote}"
         )
         return vote
@@ -703,7 +703,7 @@ class GraphLM(LearningModule):
             current_possible_matches = self.get_possible_matches()
             for vote in vote_data:
                 if vote in current_possible_matches:
-                    logging.debug(f"REMOVING {vote} FROM MATCHES")
+                    logger.debug(f"REMOVING {vote} FROM MATCHES")
                     self.possible_matches.pop(vote)
             self._add_votes_to_buffer_stats(vote_data)
 
@@ -752,15 +752,13 @@ class GraphLM(LearningModule):
             object_id = possible_matches[0]
             pose = self.get_unique_pose_if_available(object_id)
             if pose is None:  # No pose determined yet
-                logging.info(
-                    f"Pose for {self.learning_module_id} not narrowed down yet"
-                )
+                logger.info(f"Pose for {self.learning_module_id} not narrowed down yet")
             else:
                 self.set_individual_ts("match")
-                logging.info(f"{self.learning_module_id} recognized object {object_id}")
+                logger.info(f"{self.learning_module_id} recognized object {object_id}")
         # > 1 possible match
         else:
-            logging.info(f"{self.learning_module_id} did not recognize an object yet.")
+            logger.info(f"{self.learning_module_id} did not recognize an object yet.")
         return self.terminal_state
 
     # ------------------ Getters & Setters ---------------------
@@ -909,12 +907,12 @@ class GraphLM(LearningModule):
     # ------------------ Logging & Saving ----------------------
 
     def set_individual_ts(self, terminal_state):
-        logging.info(
+        logger.info(
             f"Setting terminal state of {self.learning_module_id} to {terminal_state}"
         )
         self.set_detected_object(terminal_state)
         if terminal_state == "match":
-            logging.info(
+            logger.info(
                 f"{self.learning_module_id}: "
                 f"Detected {self.detected_object} "
                 f"at location {np.round(self.detected_pose[:3], 3)},"
@@ -996,7 +994,7 @@ class GraphLM(LearningModule):
                 None,
             ]
 
-        logging.debug(f"query: {query}")
+        logger.debug(f"query: {query}")
 
         self._update_possible_matches(query=query)
 
@@ -1157,7 +1155,7 @@ class GraphMemory(LMMemory):
     ):
         """Determine how to update memory and call corresponding function."""
         if graph_id is None:
-            logging.info("no match found in time, not updating memory")
+            logger.info("no match found in time, not updating memory")
         else:
             for input_channel in features.keys():
                 (
@@ -1171,7 +1169,7 @@ class GraphMemory(LMMemory):
                     graph_id in self.get_memory_ids()
                     and input_channel in self.get_input_channels_in_graph(graph_id)
                 ):
-                    logging.info(
+                    logger.info(
                         f"{graph_id} already in memory ({self.get_memory_ids()})"
                     )
                     self._extend_graph(
@@ -1185,7 +1183,7 @@ class GraphMemory(LMMemory):
                         object_scale=object_scale,
                     )
                 else:
-                    logging.info(f"{graph_id} not in memory ({self.get_memory_ids()})")
+                    logger.info(f"{graph_id} not in memory ({self.get_memory_ids()})")
                     print(f"building graph for {input_channel}")
                     self._build_graph(
                         input_channel_locations,
@@ -1313,7 +1311,7 @@ class GraphMemory(LMMemory):
         node_features = {}
         graph = self.get_graph(graph_id, input_channel)
         if graph is None:
-            logging.debug(
+            logger.debug(
                 f"{input_channel} not stored in graph {graph_id} yet. "
                 "-> Input not used for matching."
             )
@@ -1335,9 +1333,9 @@ class GraphMemory(LMMemory):
     # ------------------ Logging & Saving ----------------------
     def load_state_dict(self, state_dict):
         """Load graphs from state dict and add to memory."""
-        logging.info("loading models")
+        logger.info("loading models")
         for obj_name, model in state_dict.items():
-            logging.info(f"loading {obj_name} with features from {model.keys()}")
+            logger.info(f"loading {obj_name} with features from {model.keys()}")
             # Add loaded graph to memory
             self._add_graph_to_memory(model, obj_name)
 
@@ -1370,7 +1368,7 @@ class GraphMemory(LMMemory):
             graph_id: name of new graph.
             input_channel: ?
         """
-        logging.info(f"Adding a new graph to memory.")
+        logger.info(f"Adding a new graph to memory.")
         model = GraphObjectModel(
             object_id=graph_id,
         )
@@ -1389,7 +1387,7 @@ class GraphMemory(LMMemory):
             self.models_in_memory[graph_id] = {}
         self.models_in_memory[graph_id][input_channel] = model
 
-        logging.info(f"Added new graph with id {graph_id} to memory.")
+        logger.info(f"Added new graph with id {graph_id} to memory.")
 
     def _extend_graph(
         self,
@@ -1414,7 +1412,7 @@ class GraphMemory(LMMemory):
             object_rotation: detected rotation of object model relative to world.
             object_scale: detected scale of object model relative to world. Not used.
         """
-        logging.info(f"Updating existing graph for {graph_id}")
+        logger.info(f"Updating existing graph for {graph_id}")
 
         self.models_in_memory[graph_id][input_channel].update_model(
             locations=locations,
@@ -1424,7 +1422,7 @@ class GraphMemory(LMMemory):
             object_rotation=object_rotation,
         )
 
-        logging.info(
+        logger.info(
             f"Extended graph {graph_id} with new points. New model:\n"
             f"{self.models_in_memory[graph_id][input_channel]}"
         )

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -22,6 +22,7 @@ from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.frameworks.models.states import State
 from tbp.monty.frameworks.utils.communication_utils import get_first_sensory_state
 
+logger = logging.getLogger(__name__)
 
 class MontyBase(Monty):
     LOGGING_REGISTRY = dict(TEST=TestLogger)
@@ -310,14 +311,14 @@ class MontyBase(Monty):
         if self.exceeded_min_steps:
             if self.step_type == "exploratory_step":
                 self._is_done = True
-                logging.info(f"finished exploring after {self.exploratory_steps} steps")
+                logger.info(f"finished exploring after {self.exploratory_steps} steps")
 
             elif self.step_type == "matching_step":
                 if self.experiment_mode == "train":
                     self.switch_to_exploratory_step()
                 else:
                     self._is_done = True
-                    logging.info(
+                    logger.info(
                         f"finished evaluating after {self.matching_steps} steps"
                     )
 
@@ -484,19 +485,19 @@ class MontyBase(Monty):
 
         if self.step_type == "matching_step":
             self.matching_steps += 1
-            logging.info(f"--- Global Matching Step {self.matching_steps} ---")
+            logger.info(f"--- Global Matching Step {self.matching_steps} ---")
         elif self.step_type == "exploratory_step":
             self.exploratory_steps += 1
 
     def switch_to_matching_step(self):
         self.step_type = "matching_step"
         self.is_seeking_match = True
-        logging.debug(f"Going into matching mode after {self.episode_steps} steps")
+        logger.debug(f"Going into matching mode after {self.episode_steps} steps")
 
     def switch_to_exploratory_step(self):
         self.step_type = "exploratory_step"
         self.is_seeking_match = False
-        logging.info(f"Going into exploratory mode after {self.matching_steps} steps")
+        logger.info(f"Going into exploratory mode after {self.matching_steps} steps")
 
 
 class LearningModuleBase(LearningModule):
@@ -550,7 +551,7 @@ class SensorModuleBase(SensorModule):
         self.state = None
 
     def __call__(self, observation):
-        logging.warning(
+        logger.warning(
             "SensorModuleBase only outputs placeholder values. Use a "
             "concrete SM implementation to actually extract features from "
             "the raw sensory data."
@@ -572,7 +573,7 @@ class SensorModuleBase(SensorModule):
         pass
 
     def step(self, data):
-        logging.warning(
+        logger.warning(
             "SensorModuleBase only outputs placeholder values. Use a "
             "concrete SM implementation to actually extract features from "
             "the raw sensory data."

--- a/src/tbp/monty/frameworks/models/object_model.py
+++ b/src/tbp/monty/frameworks/models/object_model.py
@@ -35,6 +35,8 @@ from tbp.monty.frameworks.utils.object_model_utils import (
 )
 from tbp.monty.frameworks.utils.spatial_arithmetics import apply_rf_transform_to_points
 
+logger = logging.getLogger(__name__)
+
 
 class GraphObjectModel(ObjectModel):
     """Object model class that represents object as graphs."""
@@ -45,7 +47,7 @@ class GraphObjectModel(ObjectModel):
         Args:
             object_id: id of the object
         """
-        logging.info(f"init object model with id {object_id}")
+        logger.info(f"init object model with id {object_id}")
         self.object_id = object_id
         self._graph = None
         self.has_ppf = False
@@ -64,7 +66,7 @@ class GraphObjectModel(ObjectModel):
         self.k_n = k_n
         self.graph_delta_thresholds = graph_delta_thresholds
         self.set_graph(graph)
-        logging.info(f"built graph {self._graph}")
+        logger.info(f"built graph {self._graph}")
 
     def update_model(
         self,
@@ -89,7 +91,7 @@ class GraphObjectModel(ObjectModel):
             rf_features,
         )
 
-        logging.info("building graph")
+        logger.info("building graph")
         new_graph = self._build_adjacency_graph(
             all_locations,
             all_features,
@@ -345,7 +347,7 @@ class GridObjectModel(GraphObjectModel):
             num_voxels_per_dim: number of voxels per dimension in the models grids.
                 Defines the resolution of the model.
         """
-        logging.info(f"init object model with id {object_id}")
+        logger.info(f"init object model with id {object_id}")
         self.object_id = object_id
         self._graph = None
         self._max_nodes = max_nodes
@@ -376,14 +378,14 @@ class GridObjectModel(GraphObjectModel):
             observation_feature_mapping,
         ) = self._extract_feature_array(features)
         # TODO: part of init method?
-        logging.info(f"building graph from {locations.shape[0]} observations")
+        logger.info(f"building graph from {locations.shape[0]} observations")
         self._initialize_and_fill_grid(
             locations=locations,
             features=feature_array,
             observation_feature_mapping=observation_feature_mapping,
         )
         self._graph = self._build_graph_from_grids()
-        logging.info(f"built graph {self._graph}")
+        logger.info(f"built graph {self._graph}")
 
     def update_model(
         self,
@@ -405,7 +407,7 @@ class GridObjectModel(GraphObjectModel):
             feature_array,
             observation_feature_mapping,
         ) = self._extract_feature_array(rf_features)
-        logging.info(f"adding {locations.shape[0]} observations")
+        logger.info(f"adding {locations.shape[0]} observations")
         self._update_grids(
             locations=rf_locations,
             features=feature_array,
@@ -467,7 +469,7 @@ class GridObjectModel(GraphObjectModel):
         """Set self._graph property and convert input graph to right format."""
         if type(graph) is not NumpyGraph:
             # could also check if is type torch_geometric.data.data.Data
-            logging.debug(f"turning graph of type {type(graph)} into numpy graph")
+            logger.debug(f"turning graph of type {type(graph)} into numpy graph")
             graph = torch_graph_to_numpy(graph)
         if self.use_original_graph:
             # Just use pretrained graph. Do not use grids to constrain nodes.
@@ -561,7 +563,7 @@ class GridObjectModel(GraphObjectModel):
         )
         percent_in_bounds = sum(locations_in_bounds) / len(locations_in_bounds)
         if percent_in_bounds < 0.9:
-            logging.info(
+            logger.info(
                 "Too many observations outside of grid "
                 f"({np.round(percent_in_bounds * 100, 2)}%). Skipping update of grids."
             )

--- a/src/tbp/monty/frameworks/models/sensor_modules.py
+++ b/src/tbp/monty/frameworks/models/sensor_modules.py
@@ -27,6 +27,7 @@ from tbp.monty.frameworks.utils.sensor_processing import (
 )
 from tbp.monty.frameworks.utils.spatial_arithmetics import get_angle
 
+logger = logging.getLogger(__name__)
 
 class DetailedLoggingSM(SensorModuleBase):
     """Sensor module that keeps track of raw observations for logging."""
@@ -208,7 +209,7 @@ class DetailedLoggingSM(SensorModuleBase):
 
         invalid_signals = (not valid_pn) or (not valid_pc)
         if invalid_signals:
-            logging.debug("Either the point-normal or pc-directions were ill-defined")
+            logger.debug("Either the point-normal or pc-directions were ill-defined")
 
         return features, morphological_features, invalid_signals
 
@@ -636,12 +637,12 @@ class FeatureChangeSM(HabitatDistantPatchSM, NoiseMixin):
             return patch_observation
 
         if self.last_features is None:  # first step
-            logging.debug("Performing first sensation step of FeatureChangeSM")
+            logger.debug("Performing first sensation step of FeatureChangeSM")
             self.last_features = patch_observation
             return patch_observation
 
         else:
-            logging.debug("Performing FeatureChangeSM step")
+            logger.debug("Performing FeatureChangeSM step")
             significant_feature_change = self.check_feature_change(patch_observation)
 
             # Save bool which will tell us whether to pass the information to LMs
@@ -669,7 +670,7 @@ class FeatureChangeSM(HabitatDistantPatchSM, NoiseMixin):
         if not observed_features.get_on_object():
             # Even for the surface-agent sensor, do not return a feature for LM
             # processing that is not on the object
-            logging.debug(f"No new point because not on object")
+            logger.debug(f"No new point because not on object")
             return False
 
         for feature in self.delta_thresholds.keys():
@@ -679,7 +680,7 @@ class FeatureChangeSM(HabitatDistantPatchSM, NoiseMixin):
 
             if feature == "n_steps":
                 if self.last_sent_n_steps_ago >= self.delta_thresholds[feature]:
-                    logging.debug(f"new point because of {feature}")
+                    logger.debug(f"new point because of {feature}")
                     return True
             elif feature == "distance":
                 distance = np.linalg.norm(
@@ -688,7 +689,7 @@ class FeatureChangeSM(HabitatDistantPatchSM, NoiseMixin):
                 )
 
                 if distance > self.delta_thresholds[feature]:
-                    logging.debug(f"new point because of {feature}")
+                    logger.debug(f"new point because of {feature}")
                     return True
 
             elif feature == "hsv":
@@ -702,7 +703,7 @@ class FeatureChangeSM(HabitatDistantPatchSM, NoiseMixin):
                 delta_change_sv = np.abs(last_feat[1:] - current_feat[1:])
                 for i, dc in enumerate(delta_change_sv):
                     if dc > self.delta_thresholds[feature][i + 1]:
-                        logging.debug(f"new point because of {feature} - {i + 1}")
+                        logger.debug(f"new point because of {feature} - {i + 1}")
                         return True
 
             elif feature == "pose_vectors":
@@ -711,7 +712,7 @@ class FeatureChangeSM(HabitatDistantPatchSM, NoiseMixin):
                     current_feat[0],
                 )
                 if angle_between >= self.delta_thresholds[feature][0]:
-                    logging.debug(
+                    logger.debug(
                         f"new point because of {feature} angle : {angle_between}"
                     )
                     return True
@@ -721,9 +722,9 @@ class FeatureChangeSM(HabitatDistantPatchSM, NoiseMixin):
                 if len(delta_change.shape) > 0:
                     for i, dc in enumerate(delta_change):
                         if dc > self.delta_thresholds[feature][i]:
-                            logging.debug(f"new point because of {feature} - {dc}")
+                            logger.debug(f"new point because of {feature} - {dc}")
                             return True
                 elif delta_change > self.delta_thresholds[feature]:
-                    logging.debug(f"new point because of {feature}")
+                    logger.debug(f"new point because of {feature}")
                     return True
         return False

--- a/src/tbp/monty/frameworks/run.py
+++ b/src/tbp/monty/frameworks/run.py
@@ -17,6 +17,8 @@ import time
 from tbp.monty.frameworks.config_utils.cmd_parser import create_cmd_parser
 from tbp.monty.frameworks.utils.dataclass_utils import config_to_dict
 
+logger = logging.getLogger(__name__)
+
 
 def merge_args(config, cmd_args=None):
     """Override experiment "config" parameters with command line args.
@@ -110,4 +112,4 @@ def main(all_configs, experiments=None):
         os.makedirs(exp_config["logging_config"]["output_dir"], exist_ok=True)
         start_time = time.time()
         run(exp_config)
-        logging.info(f"Done running {experiment} in {time.time() - start_time} seconds")
+        logger.info(f"Done running {experiment} in {time.time() - start_time} seconds")

--- a/src/tbp/monty/frameworks/utils/dataclass_utils.py
+++ b/src/tbp/monty/frameworks/utils/dataclass_utils.py
@@ -7,11 +7,16 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
+from __future__ import annotations
 
 import dataclasses
 import importlib
 from inspect import Parameter, signature
-from typing import Callable, Optional, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Type
+from typing_extensions import TypeIs
+
+if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
 
 __all__ = [
     "as_dataclass_dict",
@@ -150,7 +155,7 @@ def create_dataclass_args(
     return dataclasses.make_dataclass(dataclass_name, _fields, bases=bases, frozen=True)
 
 
-def config_to_dict(config):
+def config_to_dict(config: DataclassInstance | Dict[str, Any]) -> Dict[str, Any]:
     """Convert config composed of mixed dataclass and dict elements to pure dict.
 
     We want to convert configs composed of mixed dataclass and dict elements to
@@ -158,14 +163,33 @@ def config_to_dict(config):
 
     TODO: Remove once all other configs are converted to dict only
 
+    Args:
+        config(DataclassInstance | Dict[str, Any]): Config to convert to dict.
+
     Returns:
-        Pure dict version of config.
+        (Dict[str, Any]): Pure dict version of config.
     """
     if isinstance(config, dict):
-        return {k: config_to_dict(v) for k, v in config.items()}
+        return {
+            k: config_to_dict(v) if is_config_like(v) else v for k, v in config.items()
+        }
     if dataclasses.is_dataclass(config):
         return dataclasses.asdict(config)
-    return config
+
+
+def is_config_like(obj: Any) -> TypeIs[DataclassInstance | Dict[str, Any]]:
+    """Returns True if obj is a dataclass or dict, False otherwise.
+
+    Args:
+        obj(Any): Object to check.
+
+    Returns:
+        (TypeIs[DataclassInstance | Dict[str, Any]]): True if config is a dataclass or
+            dict, False otherwise.
+    """
+    return isinstance(obj, dict) or (
+        dataclasses.is_dataclass(obj) and not isinstance(obj, type)
+    )
 
 
 def get_subset_of_args(arguments, function):

--- a/src/tbp/monty/frameworks/utils/graph_matching_utils.py
+++ b/src/tbp/monty/frameworks/utils/graph_matching_utils.py
@@ -19,6 +19,8 @@ from scipy.spatial.transform import Rotation
 
 from tbp.monty.frameworks.utils.spatial_arithmetics import get_more_directions_in_plane
 
+logger = logging.getLogger(__name__)
+
 
 def get_correct_k_n(k_n, num_datapoints):
     """Determine k_n given the number of datapoints.
@@ -40,9 +42,9 @@ def get_correct_k_n(k_n, num_datapoints):
     if num_datapoints <= k_n:
         if num_datapoints > 2:
             k_n = num_datapoints - 1
-            logging.debug(f"Setting k_n to {k_n}")
+            logger.debug(f"Setting k_n to {k_n}")
         else:
-            logging.error("not enough observations collected to build graph.")
+            logger.error("not enough observations collected to build graph.")
             return None
     return k_n
 
@@ -212,7 +214,7 @@ def get_relevant_curvature(features):
     elif "gaussian_curvature_sc" in features.keys():
         curvatures = features["gaussian_curvature_sc"]
     else:
-        logging.error(
+        logger.error(
             f"No curvatures contained in the features {list(features.keys())}."
         )
         # Return large curvature so we use an almost circular search sphere.

--- a/src/tbp/monty/frameworks/utils/logging_utils.py
+++ b/src/tbp/monty/frameworks/utils/logging_utils.py
@@ -27,6 +27,8 @@ from tbp.monty.frameworks.utils.spatial_arithmetics import (
     rotations_to_quats,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def load_stats(
     exp_path,
@@ -900,13 +902,13 @@ def maybe_rename_existing_file(log_file, extension, report_count):
         old_name = log_file.split(extension)[0]
         new_name = old_name + "_old" + extension
 
-        logging.warning(
+        logger.warning(
             f"Output file {log_file} already exists. This file will be moved"
             f" to {new_name}"
         )
 
         if os.path.exists(new_name):
-            logging.warning(
+            logger.warning(
                 f"Output file {new_name} also already exists. This file will be removed"
                 " before renaming."
             )
@@ -918,12 +920,12 @@ def maybe_rename_existing_file(log_file, extension, report_count):
 def maybe_rename_existing_directory(path, report_count):
     if (report_count == 0) and os.path.exists(path):
         new_path = path + "_old"
-        logging.warning(
+        logger.warning(
             f"Output path {path} already exists. This path will be movedto {new_path}"
         )
 
         if os.path.exists(new_path):
-            logging.warning(
+            logger.warning(
                 f"{new_path} also exists, and will be removed before renaming"
             )
             os.remove(new_path)

--- a/src/tbp/monty/frameworks/utils/object_model_utils.py
+++ b/src/tbp/monty/frameworks/utils/object_model_utils.py
@@ -18,6 +18,8 @@ from tbp.monty.frameworks.utils.spatial_arithmetics import (
     get_right_hand_angle,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class NumpyGraph:
     """Alternative way to represent graphs without using torch.
@@ -111,7 +113,7 @@ def already_in_list(
                     )  # Use circular difference to reflect angular nature of hue
 
                     if hue_d > graph_delta_thresholds[feature][0]:
-                        logging.debug(
+                        logger.debug(
                             f"Interesting point because of {feature} : {hue_d}"
                         )
                         redundant_point = False
@@ -137,13 +139,13 @@ def already_in_list(
                     if len(delta_change.shape) > 0:
                         for i, dc in enumerate(delta_change):
                             if dc > graph_delta_thresholds[feature][i]:
-                                logging.debug(
+                                logger.debug(
                                     f"Interesting point because of {feature} : {dc}"
                                 )
                                 redundant_point = False
                                 break
                     elif delta_change > graph_delta_thresholds[feature]:
-                        logging.debug(
+                        logger.debug(
                             f"Interesting point because of {feature} : {delta_change}"
                         )
                         redundant_point = False
@@ -323,7 +325,7 @@ def pose_vector_mean(pose_vecs, pose_fully_defined):
     # are from opposite sides of an objects surface.
     valid_pose_vecs = np.where(np.any(pose_vecs, axis=1))[0]
     if len(valid_pose_vecs) == 0:
-        logging.debug(f"no valid pose vecs: {pose_vecs}")
+        logger.debug(f"no valid pose vecs: {pose_vecs}")
         return None, False
     # TODO: more generic names
     pns = pose_vecs[valid_pose_vecs, :3]

--- a/src/tbp/monty/frameworks/utils/sensor_processing.py
+++ b/src/tbp/monty/frameworks/utils/sensor_processing.py
@@ -19,6 +19,8 @@ from tbp.monty.frameworks.utils.spatial_arithmetics import (
     non_singular_mat,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def get_point_normal_naive(point_cloud, patch_radius_frac=2.5):
     """Estimate point normal.
@@ -115,7 +117,7 @@ def get_point_normal_naive(point_cloud, patch_radius_frac=2.5):
             # -> try a smaller tan_len
             tan_len = tan_len // 2
             if tan_len < 1:
-                # logging.debug(
+                # logger.debug(
                 #     "Too many off object points around center for point-normal"
                 # )
                 norm1 = norm2 = [0, 0, 1]
@@ -185,13 +187,13 @@ def get_point_normal_ordinary_least_squares(
         else:  # Not enough point to compute
             point_normal = np.array([0.0, 0.0, 1.0])
             valid_pn = False
-            logging.debug("Warning : Singular matrix encountered in get_point_normal!")
+            logger.debug("Warning : Singular matrix encountered in get_point_normal!")
 
     # Patch center does not lie on an object
     else:
         point_normal = np.array([0.0, 0.0, 1.0])
         valid_pn = False
-        logging.debug("Warning : Patch center does not lie on an object!")
+        logger.debug("Warning : Patch center does not lie on an object!")
 
     return point_normal, valid_pn
 
@@ -246,13 +248,13 @@ def get_point_normal_total_least_squares(
         except np.linalg.LinAlgError:
             n_dir = np.array([0.0, 0.0, 1.0])
             valid_pn = False
-            logging.debug("Warning : Non-diagonalizable matrix for PN estimation!")
+            logger.debug("Warning : Non-diagonalizable matrix for PN estimation!")
 
     # Patch center does not lie on an object
     else:
         n_dir = np.array([0.0, 0.0, 1.0])
         valid_pn = False
-        logging.debug("Warning : Patch center does not lie on an object!")
+        logger.debug("Warning : Patch center does not lie on an object!")
 
     return n_dir, valid_pn
 
@@ -407,7 +409,7 @@ def get_curvature_at_point(point_cloud, center_id, normal):
         else:
             k1, k2, dir1, dir2 = 0, 0, [0, 0, 0], [0, 0, 0]
             valid_pc = False
-            logging.debug(
+            logger.debug(
                 "Warning : Singular matrix encountered in get-curvature-at-point!"
             )
 
@@ -554,7 +556,7 @@ def get_principal_curvatures(
         else:
             k1, k2, pc1_dir, pc2_dir = 0, 0, [0, 0, 0], [0, 0, 0]
             valid_pc = False
-            logging.debug(
+            logger.debug(
                 "Warning : Singular matrix encountered in get-curvature-at-point!"
             )
 

--- a/src/tbp/monty/frameworks/utils/spatial_arithmetics.py
+++ b/src/tbp/monty/frameworks/utils/spatial_arithmetics.py
@@ -16,6 +16,8 @@ import numpy as np
 import torch
 from scipy.spatial.transform import Rotation
 
+logger = logging.getLogger(__name__)
+
 
 def rotations_to_quats(rotations, invert=False):
     # We get euler rotations from feature LM
@@ -160,13 +162,13 @@ def get_angle_torch(v1, v2):
 def check_orthonormal(matrix):
     is_orthogonal = np.mean(np.abs(np.linalg.inv(matrix) - matrix.T)) < 0.01
     if not is_orthogonal:
-        logging.debug(
+        logger.debug(
             "not orthogonal. Error: "
             f"{np.mean(np.abs(np.linalg.inv(matrix) - matrix.T))}"
         )
     is_normal = np.mean(np.abs(np.linalg.norm(matrix, axis=1) - [1, 1, 1])) < 0.01
     if not is_normal:
-        logging.debug(
+        logger.debug(
             "not normal. Error: "
             f"{np.mean(np.abs(np.linalg.norm(matrix, axis=1) - [1, 1, 1]))}"
         )

--- a/tests/unit/base_config_test.py
+++ b/tests/unit/base_config_test.py
@@ -194,15 +194,17 @@ class BaseConfigTest(unittest.TestCase):
             new_lm = exp_2.model.learning_modules[0]
             self.assertEqual(new_lm.test_attr_2, new_attr, "attrs did not match")
 
-    def test_logging_debug_level(self):
+    def test_logging_debug_level(self) -> None:
         """Check that logs go to a file, we can load them, and they have basic info."""
         base_config = copy.deepcopy(self.base_config)
         with MontyExperiment(base_config) as exp:
             # Add some stuff to the logs, verify it shows up
             info_message = "INFO is in the log"
             warning_message = "WARNING is in the log"
-            logging.info(info_message)
-            logging.warning(warning_message)
+
+            logger = logging.getLogger("tbp.monty")
+            logger.info(info_message)
+            logger.warning(warning_message)
 
             with open(os.path.join(exp.output_dir, "log.txt"), "r") as f:
                 log = f.read()
@@ -210,7 +212,7 @@ class BaseConfigTest(unittest.TestCase):
             self.assertTrue(info_message in log)
             self.assertTrue(warning_message in log)
 
-    def test_logging_info_level(self):
+    def test_logging_info_level(self) -> None:
         """Check that if we set logging level to info, debug logs do not show up."""
         base_config = copy.deepcopy(self.base_config)
         base_config["logging_config"].python_log_level = logging.INFO
@@ -218,8 +220,10 @@ class BaseConfigTest(unittest.TestCase):
             # Add some stuff to the logs, verify it shows up
             debug_message = "DEBUG is in the log"
             warning_message = "WARNING is in the log"
-            logging.debug(debug_message)
-            logging.warning(warning_message)
+
+            logger = logging.getLogger("tbp.monty")
+            logger.debug(debug_message)
+            logger.warning(warning_message)
 
             with open(os.path.join(exp.output_dir, "log.txt"), "r") as f:
                 log = f.read()

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -1185,8 +1185,6 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
 
     def test_same_sequence_recognition_elm(self):
         """Test that the object is recognized with same action sequence."""
-        logging.basicConfig(level="DEBUG")
-
         fake_obs_test = copy.deepcopy(self.fake_obs_learn)
 
         graph_lm = self.get_elm_with_fake_object(self.fake_obs_learn)


### PR DESCRIPTION
This pull request replaces the original global logging basic configuration with a standard tiered configuration.

This will allow us to create very detailed level, filter, handler, formatter, configuration per module level.

Note that `python_log_to_stdout` option was misnamed, as it attached a non-configured `logging.StreamHandler`, which logs to `sys.stderr` by default.

The updated Python logger usage is now to get the logger by module name at the top of the module:
```python
# ...
from tbp.monty.frameworks.models.object_model import GraphObjectModel

logger = logging.getLogger(__name__)


class MontyForGraphMatching(MontyBase):
    """General Monty model for recognizing object using graphs."""
# ...
```

Additionally, Python loggers are now initialized before the Monty model so that logging during initialization of the Monty model works.

The "logging" of metrics used for statistics and plotting is unaffected.

The default log format is updated to `"%(levelname)s:%(name)s:%(funcName)s:%(lineno)d:%(message)s"`

Example of new default python logging output:
```
INFO:tbp.monty.frameworks.models.graph_matching:_step_learning_modules:235:Sending input from ['patch'] to learning_module_0
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 2730 out of 4440 hypotheses for mug (evidence > 2.8473207648464793)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 1206 out of 1342 hypotheses for dice (evidence > 2.8473207648464793)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 2558 out of 5888 hypotheses for bowl (evidence > 2.8473207648464793)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 2413 out of 4878 hypotheses for potted_meat_can (evidence > 2.8473207648464793)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 3692 out of 3850 hypotheses for spoon (evidence > 2.8473207648464793)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 1684 out of 4166 hypotheses for mustard_bottle (evidence > 2.8473207648464793)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 933 out of 1658 hypotheses for strawberry (evidence > 2.8473207648464793)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 640 out of 640 hypotheses for golf_ball (evidence > 2.8473207648464793)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 1970 out of 3814 hypotheses for c_lego_duplo (evidence > 2.8473207648464793)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 1482 out of 1490 hypotheses for banana (evidence > 2.8473207648464793)
INFO:tbp.monty.frameworks.models.evidence_matching.learning_module:_calculate_most_likely_hypothesis:1156:current most likely hypothesis: spoon with evidence 15.65
INFO:tbp.monty.frameworks.models.graph_matching:_get_union_of_possible_matches:287:Possible matches for LM 0: {'banana', 'dice', 'potted_meat_can', 'bowl', 'mug', 'spoon'}
INFO:tbp.monty.frameworks.models.monty_base:update_step_counters:488:--- Global Matching Step 11 ---
INFO:tbp.monty.frameworks.models.graph_matching:_step_learning_modules:235:Sending input from ['patch'] to learning_module_0
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 926 out of 1658 hypotheses for strawberry (evidence > 3.129311527623278)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 2721 out of 4440 hypotheses for mug (evidence > 3.129311527623278)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 640 out of 640 hypotheses for golf_ball (evidence > 3.129311527623278)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 2395 out of 4878 hypotheses for potted_meat_can (evidence > 3.129311527623278)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 2545 out of 5888 hypotheses for bowl (evidence > 3.129311527623278)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 1681 out of 4166 hypotheses for mustard_bottle (evidence > 3.129311527623278)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 1197 out of 1342 hypotheses for dice (evidence > 3.129311527623278)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 3663 out of 3850 hypotheses for spoon (evidence > 3.129311527623278)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 1477 out of 1490 hypotheses for banana (evidence > 3.129311527623278)
INFO:tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer:displace_hypotheses_and_compute_evidence:151:Testing 1915 out of 3814 hypotheses for c_lego_duplo (evidence > 3.129311527623278)
```

Lastly, types associated with the changes to the logger initialization are updated. This required an update to `config_to_dict` as it did more than it claimed and could return `Any`, which was unnecessarily broad. Instead, the recursive call to `config_to_dict` is now guarded by the `is_config_like` check.