### PR TITLE
docs: include asdict and MyExperiments imports in all tutorials

### DIFF
--- a/docs/how-to-use-monty/tutorials/multiple-learning-modules.md
+++ b/docs/how-to-use-monty/tutorials/multiple-learning-modules.md
@@ -21,7 +21,9 @@ To follow along, open the `benchmarks/configs/my_experiments.py` file and paste 
 
 ```python
 import os
+from dataclasses import asdict
 
+from benchmarks.configs.names import MyExperiments
 from tbp.monty.frameworks.config_utils.config_args import (
     FiveLMMontyConfig,
     MontyArgs,

--- a/docs/how-to-use-monty/tutorials/running-inference-with-a-pretrained-model.md
+++ b/docs/how-to-use-monty/tutorials/running-inference-with-a-pretrained-model.md
@@ -13,9 +13,11 @@ To follow along, open the `benchmarks/configs/my_experiments.py` file and paste 
 
 ```python
 import os
+from dataclasses import asdict
 
 import numpy as np
 
+from benchmarks.configs.names import MyExperiments
 from tbp.monty.frameworks.config_utils.config_args import (
     EvalLoggingConfig,
     MontyArgs,

--- a/docs/how-to-use-monty/tutorials/unsupervised-continual-learning.md
+++ b/docs/how-to-use-monty/tutorials/unsupervised-continual-learning.md
@@ -17,9 +17,11 @@ To follow along, open the `benchmarks/configs/my_experiments.py` file and paste 
 
 ```python
 import os
+from dataclasses import asdict
 
 import numpy as np
 
+from benchmarks.configs.names import MyExperiments
 from tbp.monty.frameworks.config_utils.config_args import (
     CSVLoggingConfig,
     MontyArgs,


### PR DESCRIPTION
Updating tutorials to reduce the likelihood of [people running into the missing imports problem](https://thousandbrains.discourse.group/t/missing-imports-in-tutorials-leads-to-name-myexperiments-is-not-defined-error).

Also, some tutorials had these and others didn't, so this update makes the tutorials consistent.