### PR TITLE
chore: demonstrate initializing TouchObject alters benchmarks

### DIFF
--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -29,6 +29,7 @@ from tbp.monty.frameworks.actions.actions import (
 from tbp.monty.frameworks.models.motor_policies import (
     GetGoodView,
     InformedPolicy,
+    PositioningProcedure,
     SurfacePolicy,
 )
 from tbp.monty.frameworks.models.motor_system import MotorSystem
@@ -687,10 +688,10 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
 
         # Check depth-at-center to see if the object is in front of us
         # As for methods such as touch_object, we use the view-finder
-        depth_at_center = self.motor_system._policy.get_depth_at_center(
-            self._observation,
-            view_sensor_id="view_finder",
-            initial_pose=False,
+        depth_at_center = PositioningProcedure.depth_at_center(
+            agent_id=self.motor_system._policy.agent_id,
+            observation=self._observation,
+            sensor_id="view_finder",
         )
 
         # If depth_at_center < 1.0, there is a visible element within 1 meter of the

--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -496,7 +496,8 @@ class InformedEnvironmentDataLoader(EnvironmentDataLoaderPerObject):
 
             self.motor_system._state = motor_system_state
 
-            self._counter += 1  # TODO clean up incrementing of counter
+            if not attempting_to_find_object:
+                self._counter += 1
 
             return self._observation
 

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -400,6 +400,25 @@ class PositioningProcedure(BasePolicy):
     indicates that the procedure has terminated or truncated.
     """
 
+    @staticmethod
+    def depth_at_center(agent_id: str, observation: Any, sensor_id: str) -> float:
+        """Determine the depth of the central pixel for the sensor.
+
+        Args:
+            agent_id (str): The ID of the agent to use.
+            observation (Observations): The observation to use.
+            sensor_id (str): The ID of the sensor to use.
+
+        Returns:
+            (float): The depth of the central pixel for the sensor.
+        """
+        # TODO: A lot of assumptions are made here about the shape of the observation.
+        #       This should be made robust.
+        observation_shape = observation[agent_id][sensor_id]["depth"].shape
+        return observation[agent_id][sensor_id]["depth"][
+            observation_shape[0] // 2, observation_shape[1] // 2
+        ]
+
     @abc.abstractmethod
     def positioning_call(
         self,
@@ -837,40 +856,6 @@ class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
 
         return super().pre_episode()
 
-    def get_depth_at_center(self, raw_observation, view_sensor_id, initial_pose=True):
-        """Determine the depth of the central pixel.
-
-        Method primarily used by surface-agent, but also by distant agent after
-        performing a hypothesis-testing jump; determines the depth of the central pixel,
-        to inform whether the object is visible at all
-
-        initial_pose : Whether we are checking depth-at center as part of the first
-            start of an experiment; if using get_depth_at_center to check for
-            the observation after e.g. a hypothesis-testing jump, then we don't
-            want to throw an error if the object is nowhere to be seen; instead, we
-            simply move back
-
-        Returns:
-            Depth at the center of the view sensor.
-        """
-        observation_shape = raw_observation[self.agent_id][view_sensor_id][
-            "depth"
-        ].shape
-        depth_at_center = raw_observation[self.agent_id][view_sensor_id]["depth"][
-            observation_shape[0] // 2, observation_shape[1] // 2
-        ]
-        if initial_pose:
-            assert depth_at_center > 0, (
-                "Object must be initialized such that "
-                "agent can visualize it by moving forward"
-            )
-            # TODO investigate - I think this may have always been passing in the
-            # original surface-agent policy implementation because the surface
-            # sensor clips at 1.0, so even if the object isn't strictly visible (or
-            # we're inside the object))  there's a risk we have initialized without the
-            # object in view
-        return depth_at_center
-
     ###
     # Methods that define behavior of __call__
     ###
@@ -1147,7 +1132,11 @@ class SurfacePolicy(InformedPolicy):
             (MoveForward | OrientHorizontal | OrientVertical): Action to take.
         """
         # If the viewfinder sees the object within range, then move to it
-        depth_at_center = self.get_depth_at_center(raw_observation, view_sensor_id)
+        depth_at_center = PositioningProcedure.depth_at_center(
+            agent_id=self.agent_id,
+            observation=raw_observation,
+            sensor_id=view_sensor_id,
+        )
         if depth_at_center < 1.0:
             distance = (
                 depth_at_center

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1313,9 +1313,13 @@ class SurfacePolicy(InformedPolicy):
 
         # TODO: Remove this once TouchObject positioning procedure is implemented
         """
+        if self.attempting_to_find_object:
+            # When the TouchObject positioning procedure is separated, there
+            # will be no post_action calls when attempting to find the object.
+            return
+
         super().post_action(action, state)
-        if not self.attempting_to_find_object:
-            self.last_surface_policy_action = action
+        self.last_surface_policy_action = action
 
     def _orient_horizontal(self, state: MotorSystemState) -> OrientHorizontal:
         """Orient the agent horizontally.

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1252,6 +1252,9 @@ class SurfacePolicy(InformedPolicy):
         Returns:
             (OrientHorizontal | OrientVertical | MoveTangentially | MoveForward | None):
                 The action to take.
+
+        Raises:
+            ObjectNotVisible: If the object is not visible.
         """
         # Check if we have poor visualization of the object
         if (

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -793,6 +793,10 @@ class GetGoodView(PositioningProcedure):
         return agent_rotation * sensor_rotation
 
 
+class ObjectNotVisible(RuntimeError):
+    """Error raised when the object is not visible."""
+
+
 class InformedPolicy(BasePolicy, JumpToGoalStateMixin):
     """Policy that takes observation as input.
 
@@ -1266,7 +1270,7 @@ class SurfacePolicy(InformedPolicy):
             # Set attempting_to_find_object to True here so that post_action will
             # not interfere with self.last_surface_policy_action
             self.attempting_to_find_object = True
-            return None  # Will result in moving to try to find the object
+            raise ObjectNotVisible  # Will result in moving to try to find the object
             # This is determined by some logic in embodied_data.py, in particular
             # the next method of InformedEnvironmentDataLoader
 


### PR DESCRIPTION
This pull request partially implements https://github.com/thousandbrainsproject/tbp.monty/pull/339. **It demonstrates that simply initializing `TouchObject` will cause benchmark deviations.** 🤔 

The goal of having this pull request separate is to isolate and merge changes that do not alter benchmarks, while working towards identifying the most minor possible change responsible for benchmark changes in https://github.com/thousandbrainsproject/tbp.monty/pull/339.

Since there are no algorithm changes, the culprit appears to be a change in `rng` sequence due to `BasePolicy.__init__` code, where a random action is initialized, which uses the `rng`:
```python
        # Ensure our first action only samples from those that can be random
        self.action: Action | None = self.get_random_action(
            self.action_sampler.sample(self.agent_id)
        )
```

## Benchmarks

_comparison with fb1e7d0d910454067627682b5796de00a2b21c4a_

base_config_10distinctobj_dist_agent,100.00,0.00,37,16.20,2,9 ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/0fqswz3r/overview
base_config_10distinctobj_surf_agent,100.00,0.71,27,17.02,2,11 ❌ (worse) - https://wandb.ai/thousand-brains-project/Monty/runs/39duz0x2/overview
```diff
-base_config_10distinctobj_surf_agent,100.00,0.00,28,14.01,2,11
+base_config_10distinctobj_surf_agent,100.00,0.71,27,17.02,2,11 
```
randrot_noise_10distinctobj_dist_agent,100.00,3.00,55,22.49,3,21 ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/3jw0robr/overview
randrot_noise_10distinctobj_dist_on_distm,99.00,1.00,38,12.15,2 ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/kio3z60p/overview
randrot_noise_10distinctobj_surf_agent,99.00,1.00,28,26.27,3,20 ❌ (worse) - https://wandb.ai/thousand-brains-project/Monty/runs/m3os8itx/overview
```diff
-randrot_noise_10distinctobj_surf_agent,100.00,1.00,29,20.42,3,21
+randrot_noise_10distinctobj_surf_agent,99.00,1.00,28,26.27,3,20
```
randrot_10distinctobj_surf_agent,100.00,1.00,27,18.99,2,11 ❌ (worse) - https://wandb.ai/thousand-brains-project/Monty/runs/feugazb7/overview
```diff
-randrot_10distinctobj_surf_agent,100.00,0.00,28,17.23,2,10
+randrot_10distinctobj_surf_agent,100.00,1.00,27,18.99,2,11
```
randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.48,5,42 ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/svcsq7s0/overview
base_10simobj_surf_agent,95.71,7.86,68,16.67,5,25 😐 (different) - https://wandb.ai/thousand-brains-project/Monty/runs/8rzzeyco/overview
```diff
-base_10simobj_surf_agent,93.57,8.57,70,13.98,6,27
+base_10simobj_surf_agent,95.71,7.86,68,16.67,5,25
```
randrot_noise_10simobj_dist_agent,84.00,40.00,237,35.01,11,96 ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/bm6lqsl1/overview
randrot_noise_10simobj_surf_agent,91.00,38.00,181,22.39,18,147 ❌ (worse) - https://wandb.ai/thousand-brains-project/Monty/runs/grt39f4s/overview
```diff
-randrot_noise_10simobj_surf_agent,93.00,34.00,172,20.94,16,137
+randrot_noise_10simobj_surf_agent,91.00,38.00,181,22.39,18,147
```
randomrot_rawnoise_10distinctobj_surf_agent,68.00,74.00,15,89.75,3,6 👍 (better) - https://wandb.ai/thousand-brains-project/Monty/runs/q853aeog/overview
```diff
-randomrot_rawnoise_10distinctobj_surf_agent,64.00,77.00,16,106.51,4,7
+randomrot_rawnoise_10distinctobj_surf_agent,68.00,74.00,15,89.75,3,6
```
base_10multi_distinctobj_dist_agent,79.29,10.71,31,19.84,3,1 ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/ihry8ce4/overview

base_77obj_dist_agent,93.51,12.99,108,15.86,19,62 ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/s6669ojf/overview
base_77obj_surf_agent,98.27,4.76,52,6.47,12,36 😐 (different) - https://wandb.ai/thousand-brains-project/Monty/runs/7mw8tpof/overview
```diff
-base_77obj_surf_agent,98.70,6.49,56,12.94,12,34
+base_77obj_surf_agent,98.27,4.76,52,6.47,12,36
``` 
randrot_noise_77obj_dist_agent,89.61,22.51,152,37.47,34,123 ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/kyb6cr08/overview
randrot_noise_77obj_surf_agent,94.81,24.24,119,33.25,35,125 👍 (better) - https://wandb.ai/thousand-brains-project/Monty/runs/zfts3fbb/overview
```diff
-randrot_noise_77obj_surf_agent,93.94,23.38,115,34.80,32,113
+randrot_noise_77obj_surf_agent,94.81,24.24,119,33.25,35,125
```
randrot_noise_77obj_5lms_dist_agent,88.31,0.00,70,58.25,9,87 ✅ - https://wandb.ai/thousand-brains-project/Monty/runs/rp45zd7d/overview