### PR TITLE
chore: add correct percentage figure to plot tool

### DIFF
--- a/tools/plot/cli.py
+++ b/tools/plot/cli.py
@@ -15,7 +15,11 @@ from pathlib import Path
 monty_root = Path(__file__).resolve().parent.parent.parent
 sys.path.append(str(monty_root))
 
-from tools.plot import objects_evidence_over_time, pose_error_over_time  # noqa: E402
+from tools.plot import (  # noqa: E402
+    correct_percentage_per_episode,
+    objects_evidence_over_time,
+    pose_error_over_time,
+)
 
 
 def main():
@@ -34,6 +38,7 @@ def main():
 
     objects_evidence_over_time.add_subparser(subparsers, parent_parser)
     pose_error_over_time.add_subparser(subparsers, parent_parser)
+    correct_percentage_per_episode.add_subparser(subparsers, parent_parser)
 
     args = parser.parse_args()
 

--- a/tools/plot/correct_percentage_per_episode.py
+++ b/tools/plot/correct_percentage_per_episode.py
@@ -25,12 +25,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def plot_correct_percentage_per_episode(exp_path: str, learning_module: str) -> int:
+def plot_correct_percentage_per_episode(
+    exp_path: str, learning_module: str, target_object_key: str
+) -> int:
     """Bar chart showing how many steps the correct object had the highest evidence.
 
     Args:
         exp_path: Path to the experiment directory containing the detailed stats file.
         learning_module: The learning module to use for extracting evidence data.
+        target_object_key: The key for extracting labels from stats file.
+            choices are "primary" or "stepwise".
 
     Returns:
         Exit code.
@@ -47,7 +51,7 @@ def plot_correct_percentage_per_episode(exp_path: str, learning_module: str) -> 
 
     for _, episode_data in enumerate(detailed_stats.values()):
         evidences_data = episode_data[learning_module]["max_evidence"]
-        target_obj = episode_data["target"]["primary_target_object"]
+        target_obj = episode_data["target"][target_object_key + "_target_object"]
 
         count = sum(1 for ts in evidences_data if max(ts, key=ts.get) == target_obj)
         percentage = (count / len(evidences_data)) * 100
@@ -144,10 +148,18 @@ def add_subparser(
         default="LM_0",
         help='The name of the learning module (default: "LM_0").',
     )
+    parser.add_argument(
+        "-t",
+        "--target_object",
+        choices=["primary", "stepwise"],
+        default="primary",
+        help='Whether to use "primary_target_object" or "stepwise_target_object" '
+        'for labels (default: "primary").',
+    )
     parser.set_defaults(
         func=lambda args: sys.exit(
             plot_correct_percentage_per_episode(
-                args.experiment_log_dir, args.learning_module
+                args.experiment_log_dir, args.learning_module, args.target_object
             )
         )
     )

--- a/tools/plot/correct_percentage_per_episode.py
+++ b/tools/plot/correct_percentage_per_episode.py
@@ -1,0 +1,129 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+from matplotlib import pyplot as plt
+from matplotlib import rcParams
+
+from tbp.monty.frameworks.utils.logging_utils import load_stats
+
+logger = logging.getLogger(__name__)
+
+
+def plot_correct_percentage_per_episode(exp_path: str) -> int:
+    """Bar chart showing how many steps the correct object had the highest evidence.
+
+    Args:
+        exp_path: Path to the experiment directory containing the detailed stats file.
+
+    Returns:
+        Exit code.
+    """
+    if not Path(exp_path).exists():
+        logger.error(f"Experiment path not found: {exp_path}")
+        return 1
+
+    # Load detailed stats
+    _, _, detailed_stats, _ = load_stats(exp_path, False, False, True, False)
+
+    correct_object_hits = []
+    episode_labels = []
+
+    for _, episode_data in enumerate(detailed_stats.values()):
+        evidences_data = episode_data["LM_0"]["max_evidence"]
+        target_obj = episode_data["target"]["primary_target_object"]
+
+        count = sum(1 for ts in evidences_data if max(ts, key=ts.get) == target_obj)
+        percentage = (count / len(evidences_data)) * 100
+
+        correct_object_hits.append(percentage)
+        episode_labels.append(target_obj)
+
+    rcParams.update(
+        {
+            "font.size": 12,
+            "axes.titlesize": 18,
+            "axes.labelsize": 14,
+            "xtick.labelsize": 11,
+            "ytick.labelsize": 11,
+            "axes.edgecolor": "black",
+            "axes.linewidth": 1.0,
+        }
+    )
+
+    fig, ax = plt.subplots(figsize=(14, 6))
+    bars = ax.bar(
+        episode_labels,
+        correct_object_hits,
+        color="#8ecae6",
+        edgecolor="black",
+        linewidth=1.2,
+    )
+
+    # Add value labels above each bar
+    for bar in bars:
+        height = bar.get_height()
+        ax.annotate(
+            f"{height:.1f}%",
+            xy=(bar.get_x() + bar.get_width() / 2, height),
+            xytext=(0, 4),
+            textcoords="offset points",
+            ha="center",
+            va="bottom",
+            fontsize=11,
+        )
+
+    ax.set_title("Correct Object MLH Percentage per Episode", fontweight="bold")
+    ax.set_xlabel("Episode (target object)")
+    ax.set_ylabel("Correct Steps (%)")
+    ax.set_ylim(0, 100)
+    ax.set_xticks(range(len(episode_labels)))
+    ax.set_xticklabels(episode_labels)
+
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.grid(axis="y", linestyle="--", alpha=0.2)
+
+    fig.tight_layout()
+    plt.show()
+
+    return 0
+
+
+def add_subparser(
+    subparsers: argparse._SubParsersAction,
+    parent_parser: Optional[argparse.ArgumentParser] = None,
+) -> None:
+    """Add the correct_percentage_per_episode subparser to the main parser.
+
+    Args:
+        subparsers: The subparsers object from the main parser.
+        parent_parser: Optional parent parser for shared arguments.
+    """
+    parser = subparsers.add_parser(
+        "correct_percentage_per_episode",
+        help="Plot a bar chart of how often the correct object was the MLH.",
+        parents=[parent_parser] if parent_parser else [],
+    )
+    parser.add_argument(
+        "experiment_log_dir",
+        help=(
+            "The directory containing the experiment log with the detailed stats file."
+        ),
+    )
+    parser.set_defaults(
+        func=lambda args: sys.exit(
+            plot_correct_percentage_per_episode(args.experiment_log_dir)
+        )
+    )

--- a/tools/plot/correct_percentage_per_episode.py
+++ b/tools/plot/correct_percentage_per_episode.py
@@ -41,8 +41,8 @@ def plot_correct_percentage_per_episode(exp_path: str) -> int:
     # Load detailed stats
     _, _, detailed_stats, _ = load_stats(exp_path, False, False, True, False)
 
-    correct_object_hits = []
-    episode_labels = []
+    correct_object_hits, episode_labels = [], []
+    total_correct, total_steps = 0, 0
 
     for _, episode_data in enumerate(detailed_stats.values()):
         evidences_data = episode_data["LM_0"]["max_evidence"]
@@ -53,6 +53,14 @@ def plot_correct_percentage_per_episode(exp_path: str) -> int:
 
         correct_object_hits.append(percentage)
         episode_labels.append(target_obj)
+
+        total_correct += count
+        total_steps += len(evidences_data)
+
+    # Insert summary bar
+    overall_percentage = (total_correct / total_steps) * 100
+    correct_object_hits.append(overall_percentage)
+    episode_labels.append("Overall")
 
     rcParams.update(
         {
@@ -66,11 +74,14 @@ def plot_correct_percentage_per_episode(exp_path: str) -> int:
         }
     )
 
+    # Make the summary bar's color different
+    colors = ["#8ecae6"] * (len(correct_object_hits) - 1) + ["#ffb703"]
+
     fig, ax = plt.subplots(figsize=(14, 6))
     bars = ax.bar(
         episode_labels,
         correct_object_hits,
-        color="#8ecae6",
+        color=colors,
         edgecolor="black",
         linewidth=1.2,
     )

--- a/tools/plot/correct_percentage_per_episode.py
+++ b/tools/plot/correct_percentage_per_episode.py
@@ -25,11 +25,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def plot_correct_percentage_per_episode(exp_path: str) -> int:
+def plot_correct_percentage_per_episode(exp_path: str, learning_module: str) -> int:
     """Bar chart showing how many steps the correct object had the highest evidence.
 
     Args:
         exp_path: Path to the experiment directory containing the detailed stats file.
+        learning_module: The learning module to use for extracting evidence data.
 
     Returns:
         Exit code.
@@ -45,7 +46,7 @@ def plot_correct_percentage_per_episode(exp_path: str) -> int:
     total_correct, total_steps = 0, 0
 
     for _, episode_data in enumerate(detailed_stats.values()):
-        evidences_data = episode_data["LM_0"]["max_evidence"]
+        evidences_data = episode_data[learning_module]["max_evidence"]
         target_obj = episode_data["target"]["primary_target_object"]
 
         count = sum(1 for ts in evidences_data if max(ts, key=ts.get) == target_obj)
@@ -137,8 +138,16 @@ def add_subparser(
             "The directory containing the experiment log with the detailed stats file."
         ),
     )
+    parser.add_argument(
+        "-lm",
+        "--learning_module",
+        default="LM_0",
+        help='The name of the learning module (default: "LM_0").',
+    )
     parser.set_defaults(
         func=lambda args: sys.exit(
-            plot_correct_percentage_per_episode(args.experiment_log_dir)
+            plot_correct_percentage_per_episode(
+                args.experiment_log_dir, args.learning_module
+            )
         )
     )

--- a/tools/plot/correct_percentage_per_episode.py
+++ b/tools/plot/correct_percentage_per_episode.py
@@ -7,16 +7,20 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-import argparse
+from __future__ import annotations
+
 import logging
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from matplotlib import pyplot as plt
 from matplotlib import rcParams
 
 from tbp.monty.frameworks.utils.logging_utils import load_stats
+
+if TYPE_CHECKING:
+    import argparse
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +107,7 @@ def plot_correct_percentage_per_episode(exp_path: str) -> int:
 
 def add_subparser(
     subparsers: argparse._SubParsersAction,
-    parent_parser: Optional[argparse.ArgumentParser] = None,
+    parent_parser: argparse.ArgumentParser | None = None,
 ) -> None:
     """Add the correct_percentage_per_episode subparser to the main parser.
 

--- a/tools/plot/objects_evidence_over_time.py
+++ b/tools/plot/objects_evidence_over_time.py
@@ -7,11 +7,12 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-import argparse
+from __future__ import annotations
+
 import logging
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING
 
 from matplotlib import patches, transforms
 from matplotlib import pyplot as plt
@@ -19,6 +20,9 @@ from matplotlib.ticker import MultipleLocator
 
 from tbp.monty.frameworks.environments.ycb import DISTINCT_OBJECTS
 from tbp.monty.frameworks.utils.logging_utils import load_stats
+
+if TYPE_CHECKING:
+    import argparse
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +124,7 @@ def plot_objects_evidence_over_time(exp_path: str) -> int:
 
 def add_subparser(
     subparsers: argparse._SubParsersAction,
-    parent_parser: Optional[argparse.ArgumentParser] = None,
+    parent_parser: argparse.ArgumentParser | None = None,
 ) -> None:
     """Add the objects_evidence_over_time subparser to the main parser.
 

--- a/tools/plot/pose_error_over_time.py
+++ b/tools/plot/pose_error_over_time.py
@@ -7,11 +7,12 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-import argparse
+from __future__ import annotations
+
 import logging
 import sys
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING
 
 import matplotlib.lines as mlines
 import matplotlib.pyplot as plt
@@ -19,6 +20,9 @@ import numpy as np
 import pandas as pd
 
 from tbp.monty.frameworks.utils.logging_utils import load_stats
+
+if TYPE_CHECKING:
+    import argparse
 
 logger = logging.getLogger(__name__)
 
@@ -169,7 +173,7 @@ def plot_pose_error_over_time(exp_path: str) -> int:
 
 def add_subparser(
     subparsers: argparse._SubParsersAction,
-    parent_parser: Optional[argparse.ArgumentParser] = None,
+    parent_parser: argparse.ArgumentParser | None = None,
 ) -> None:
     """Add the pose_error_over_time subparser to the main parser.
 

--- a/tools/plot/tests/correct_percentage_per_episode.py
+++ b/tools/plot/tests/correct_percentage_per_episode.py
@@ -1,0 +1,20 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import unittest
+
+from tools.plot.correct_percentage_per_episode import (
+    plot_correct_percentage_per_episode,
+)
+
+
+class TestCorrectPercentagePerEpisode(unittest.TestCase):
+    def test_exit_1_if_exp_path_does_not_exist(self):
+        exit_code = plot_correct_percentage_per_episode("nonexistent_path")
+        self.assertEqual(exit_code, 1)


### PR DESCRIPTION
This PR adds a simple script to the plot tool under the name `correct_percentage_per_episode`. It will plot a bar chart with the percentage of correct steps on the y-axis and the episode target on the x-axis. The idea was suggested by @nielsleadholm and it would be a nice metric to report as part of the unsupervised inference experiments.

```zsh
usage: cli.py correct_percentage_per_episode [-h] [--debug] [-lm LEARNING_MODULE] [-t {primary,stepwise}] experiment_log_dir

positional arguments:
  experiment_log_dir    The directory containing the experiment log with the detailed stats file.

optional arguments:
  -h, --help            show this help message and exit
  --debug               Enable debug logging
  -lm LEARNING_MODULE, --learning_module LEARNING_MODULE
                        The name of the learning module (default: "LM_0").
  -t {primary,stepwise}, --target_object {primary,stepwise}
                        Whether to use "primary_target_object" or "stepwise_target_object" for labels (default: "primary").
```

For example with the No Reset results below:
![max_scores](https://github.com/user-attachments/assets/8b2954c3-fe74-4e95-85c4-5e7a62ef7821)

The plot tool would output this:
![Summary](https://github.com/user-attachments/assets/68c6618d-b2d2-4aa1-b3dd-d35113979371)


