### PR TITLE
fix: remove None from evidence_update_threshold return types

### DIFF
--- a/src/tbp/monty/frameworks/utils/evidence_matching.py
+++ b/src/tbp/monty/frameworks/utils/evidence_matching.py
@@ -460,7 +460,7 @@ def evidence_update_threshold(
     x_percent_threshold: float | str,
     max_global_evidence: float,
     evidence_all_channels: np.ndarray,
-) -> float | None:
+) -> float:
     """Determine how much evidence a hypothesis should have to be updated.
 
     Args:


### PR DESCRIPTION
This minor PR addresses @tristanls's [comment](https://github.com/thousandbrainsproject/tbp.monty/pull/340#discussion_r2180953481) on fixing the incorrect return type (`None`).