### PR TITLE
style: address os.rename (PTH104)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,7 +265,6 @@ ignore = [
     "PT018", # PT018: Assertion should be broken down into multiple parts
     "PT027", # PT027: Use `pytest.raises` instead of unittest-style `assertRaises`
     "PTH103", # PTH103: `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-    "PTH104", # PTH104: `os.rename()` should be replaced by `Path.rename()`
     "PTH107", # PTH107: `os.remove()` should be replaced by `Path.unlink()`
     "PTH110", # PTH110: `os.path.exists()` should be replaced by `Path.exists()`
     "PTH111", # PTH111: `os.path.expanduser()` should be replaced by `Path.expanduser()`

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -207,13 +207,11 @@ def move_reproducibility_data(base_dir, parallel_dirs):
         assert "eval_episode_0_target.txt" in files
         action_file = f"eval_episode_{cnt}_actions.jsonl"
         target_file = f"eval_episode_{cnt}_target.txt"
-        os.rename(
-            os.path.join(rdir, "eval_episode_0_actions.jsonl"),
-            os.path.join(outdir, action_file),
+        Path(os.path.join(rdir, "eval_episode_0_actions.jsonl")).rename(
+            os.path.join(outdir, action_file)
         )
-        os.rename(
-            os.path.join(rdir, "eval_episode_0_target.txt"),
-            os.path.join(outdir, target_file),
+        Path(os.path.join(rdir, "eval_episode_0_target.txt")).rename(
+            os.path.join(outdir, target_file)
         )
 
 

--- a/src/tbp/monty/frameworks/utils/logging_utils.py
+++ b/src/tbp/monty/frameworks/utils/logging_utils.py
@@ -14,6 +14,7 @@ import logging
 import os
 from collections import deque
 from itertools import chain
+from pathlib import Path
 from sys import getsizeof
 
 import numpy as np
@@ -914,7 +915,7 @@ def maybe_rename_existing_file(log_file, extension, report_count):
             )
             os.remove(new_name)
 
-        os.rename(log_file, new_name)
+        Path(log_file).rename(new_name)
 
 
 def maybe_rename_existing_directory(path, report_count):
@@ -930,7 +931,7 @@ def maybe_rename_existing_directory(path, report_count):
             )
             os.remove(new_path)
 
-        os.rename(path, new_path)
+        Path(path).rename(new_path)
 
 
 def get_rgba_frames_single_sm(observations):


### PR DESCRIPTION
<img width="2116" height="1196" alt="CleanShot 2025-07-10 at 20 39 40@2x" src="https://github.com/user-attachments/assets/55f1cebf-5d5b-47d5-8a0a-eebc05e933d8" />

I didn't fix `os.path.join` yet (other ruff rule for future PR), just trying to get the ball rolling replacing `os.path` module `pathlib`. Main purpose is to remove this from the ignore list in `pyproject.toml`.