### PR TITLE
refactor: move test-only classes into test code

### DIFF
--- a/src/tbp/monty/frameworks/config_utils/config_args.py
+++ b/src/tbp/monty/frameworks/config_utils/config_args.py
@@ -57,11 +57,6 @@ from tbp.monty.frameworks.models.evidence_matching.model import (
     MontyForEvidenceGraphMatching,
 )
 from tbp.monty.frameworks.models.graph_matching import MontyForGraphMatching
-from tbp.monty.frameworks.models.monty_base import (
-    LearningModuleBase,
-    MontyBase,
-    SensorModuleBase,
-)
 from tbp.monty.frameworks.models.motor_policies import (
     BasePolicy,
     InformedPolicy,
@@ -561,80 +556,6 @@ class MontyConfig:
     lm_to_lm_matrix: Dict
     lm_to_lm_vote_matrix: Dict
     monty_args: Union[Dict, MontyArgs]
-
-
-@dataclass
-class SingleCameraMontyConfig(MontyConfig):
-    monty_class: Callable = MontyBase
-    learning_module_configs: Union[dataclass, Dict] = field(
-        default_factory=lambda: dict(
-            learning_module_1=dict(
-                learning_module_class=LearningModuleBase,
-                learning_module_args={},
-            )
-        )
-    )
-    sensor_module_configs: Union[dataclass, Dict] = field(
-        default_factory=lambda: dict(
-            sensor_module_0=dict(
-                sensor_module_class=SensorModuleBase,
-                sensor_module_args=dict(sensor_module_id="sensor_id_0"),
-            ),
-        )
-    )
-    motor_system_config: Union[dataclass, Dict] = field(
-        default_factory=MotorSystemConfig
-    )
-    sm_to_agent_dict: Dict = field(
-        default_factory=lambda: dict(sensor_id_0="agent_id_0")
-    )
-    sm_to_lm_matrix: List = field(default_factory=lambda: [[0]])
-    lm_to_lm_matrix: Optional[List] = None
-    lm_to_lm_vote_matrix: Optional[List] = None
-    monty_args: Union[Dict, MontyArgs] = field(default_factory=MontyArgs)
-
-
-@dataclass
-class BaseMountMontyConfig(MontyConfig):
-    monty_class: Callable = MontyBase
-    learning_module_configs: Union[dataclass, Dict] = field(
-        default_factory=lambda: dict(
-            learning_module_0=dict(
-                learning_module_class=LearningModuleBase,
-                learning_module_args={},
-            ),
-            learning_module_1=dict(
-                learning_module_class=LearningModuleBase,
-                learning_module_args={},
-            ),
-        )
-    )
-    sensor_module_configs: Union[dataclass, Dict] = field(
-        default_factory=lambda: dict(
-            sensor_module_0=dict(
-                sensor_module_class=SensorModuleBase,
-                sensor_module_args=dict(sensor_module_id="sensor_id_0"),
-            ),
-            sensor_module_1=dict(
-                sensor_module_class=SensorModuleBase,
-                sensor_module_args=dict(sensor_module_id="sensor_id_1"),
-            ),
-        )
-    )
-    motor_system_config: Union[dataclass, Dict] = field(
-        default_factory=MotorSystemConfig
-    )
-    sm_to_agent_dict: Dict = field(
-        # TODO: move SAM to config args?
-        default_factory=lambda: dict(
-            sensor_id_0="agent_id_0",
-            sensor_id_1="agent_id_0",
-        )
-    )
-    sm_to_lm_matrix: List = field(default_factory=lambda: [[0], [1]])
-    lm_to_lm_matrix: Optional[List] = None
-    lm_to_lm_vote_matrix: Optional[List] = None
-    monty_args: Union[Dict, MontyArgs] = field(default_factory=MontyArgs)
 
 
 @dataclass

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -501,51 +501,6 @@ class MontyBase(Monty):
         logger.info(f"Going into exploratory mode after {self.matching_steps} steps")
 
 
-class LearningModuleBase(LearningModule):
-    """Dummy placeholder class used only for tests."""
-
-    def __init__(self):
-        self.test_attr_1 = True
-        self.test_attr_2 = True
-
-    def reset(self):
-        pass
-
-    def matching_step(self, inputs):
-        pass
-
-    def exploratory_step(self, inputs):
-        pass
-
-    def receive_votes(self, inputs):
-        pass
-
-    def send_out_vote(self):
-        pass
-
-    def state_dict(self):
-        return dict(test_attr_1=self.test_attr_1, test_attr_2=self.test_attr_2)
-
-    def load_state_dict(self, state_dict):
-        self.test_attr_1 = state_dict["test_attr_1"]
-        self.test_attr_2 = state_dict["test_attr_2"]
-
-    def pre_episode(self):
-        pass
-
-    def post_episode(self):
-        pass
-
-    def set_experiment_mode(self, inputs):
-        pass
-
-    def propose_goal_state(self):
-        pass
-
-    def get_output(self):
-        pass
-
-
 class SensorModuleBase(SensorModule):
     def __init__(self, sensor_module_id):
         self.sensor_module_id = sensor_module_id

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -15,7 +15,6 @@ import numpy as np
 
 from tbp.monty.frameworks.loggers.exp_logger import TestLogger
 from tbp.monty.frameworks.models.abstract_monty_classes import (
-    LearningModule,
     Monty,
     SensorModule,
 )

--- a/tests/unit/base_config_test.py
+++ b/tests/unit/base_config_test.py
@@ -22,10 +22,7 @@ import tempfile
 import unittest
 from pprint import pprint
 
-from tbp.monty.frameworks.config_utils.config_args import (
-    LoggingConfig,
-    SingleCameraMontyConfig,
-)
+from tbp.monty.frameworks.config_utils.config_args import LoggingConfig
 from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     DebugExperimentArgs,
     EnvironmentDataLoaderPerObjectEvalArgs,
@@ -38,6 +35,9 @@ from tbp.monty.frameworks.experiments import MontyExperiment
 from tbp.monty.simulators.habitat.configs import (
     EnvInitArgsSinglePTZ,
     SinglePTZHabitatDatasetArgs,
+)
+from tests.unit.frameworks.config_utils.fakes.config_args import (
+    FakeSingleCameraMontyConfig,
 )
 
 
@@ -52,7 +52,7 @@ class BaseConfigTest(unittest.TestCase):
             logging_config=LoggingConfig(
                 output_dir=self.output_dir, python_log_level="DEBUG"
             ),
-            monty_config=SingleCameraMontyConfig(),
+            monty_config=FakeSingleCameraMontyConfig(),
             dataset_class=ED.EnvironmentDataset,
             dataset_args=SinglePTZHabitatDatasetArgs(
                 env_init_args=EnvInitArgsSinglePTZ(data_path=None).__dict__

--- a/tests/unit/frameworks/config_utils/__init__.py
+++ b/tests/unit/frameworks/config_utils/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.

--- a/tests/unit/frameworks/config_utils/fakes/__init__.py
+++ b/tests/unit/frameworks/config_utils/fakes/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.

--- a/tests/unit/frameworks/config_utils/fakes/config_args.py
+++ b/tests/unit/frameworks/config_utils/fakes/config_args.py
@@ -1,0 +1,51 @@
+# Copyright 2025 Thousand Brains Project
+# Copyright 2022-2024 Numenta Inc.
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Union
+
+from tbp.monty.frameworks.config_utils.config_args import (
+    MontyArgs,
+    MontyConfig,
+    MotorSystemConfig,
+)
+from tbp.monty.frameworks.models.monty_base import MontyBase, SensorModuleBase
+from tests.unit.frameworks.models.fakes.learning_modules import FakeLearningModule
+
+
+@dataclass
+class FakeSingleCameraMontyConfig(MontyConfig):
+    monty_class: Callable = MontyBase
+    learning_module_configs: Union[dataclass, Dict] = field(
+        default_factory=lambda: dict(
+            learning_module_1=dict(
+                learning_module_class=FakeLearningModule,
+                learning_module_args={},
+            )
+        )
+    )
+    sensor_module_configs: Union[dataclass, Dict] = field(
+        default_factory=lambda: dict(
+            sensor_module_0=dict(
+                sensor_module_class=SensorModuleBase,
+                sensor_module_args=dict(sensor_module_id="sensor_id_0"),
+            ),
+        )
+    )
+    motor_system_config: Union[dataclass, Dict] = field(
+        default_factory=MotorSystemConfig
+    )
+    sm_to_agent_dict: Dict = field(
+        default_factory=lambda: dict(sensor_id_0="agent_id_0")
+    )
+    sm_to_lm_matrix: List = field(default_factory=lambda: [[0]])
+    lm_to_lm_matrix: Optional[List] = None
+    lm_to_lm_vote_matrix: Optional[List] = None
+    monty_args: Union[Dict, MontyArgs] = field(default_factory=MontyArgs)

--- a/tests/unit/frameworks/models/fakes/learning_modules.py
+++ b/tests/unit/frameworks/models/fakes/learning_modules.py
@@ -1,3 +1,12 @@
+# Copyright 2025 Thousand Brains Project
+# Copyright 2022-2024 Numenta Inc.
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
 from tbp.monty.frameworks.models.abstract_monty_classes import LearningModule
 
 

--- a/tests/unit/frameworks/models/fakes/learning_modules.py
+++ b/tests/unit/frameworks/models/fakes/learning_modules.py
@@ -1,0 +1,46 @@
+from tbp.monty.frameworks.models.abstract_monty_classes import LearningModule
+
+
+class FakeLearningModule(LearningModule):
+    """Dummy placeholder class used only for tests."""
+
+    def __init__(self):
+        self.test_attr_1 = True
+        self.test_attr_2 = True
+
+    def reset(self):
+        pass
+
+    def matching_step(self, inputs):
+        pass
+
+    def exploratory_step(self, inputs):
+        pass
+
+    def receive_votes(self, inputs):
+        pass
+
+    def send_out_vote(self):
+        pass
+
+    def state_dict(self):
+        return dict(test_attr_1=self.test_attr_1, test_attr_2=self.test_attr_2)
+
+    def load_state_dict(self, state_dict):
+        self.test_attr_1 = state_dict["test_attr_1"]
+        self.test_attr_2 = state_dict["test_attr_2"]
+
+    def pre_episode(self):
+        pass
+
+    def post_episode(self):
+        pass
+
+    def set_experiment_mode(self, inputs):
+        pass
+
+    def propose_goal_state(self):
+        pass
+
+    def get_output(self):
+        pass

--- a/tests/unit/profile_experiment_mixin_test.py
+++ b/tests/unit/profile_experiment_mixin_test.py
@@ -24,10 +24,7 @@ from unittest import TestCase
 
 import pytest
 
-from tbp.monty.frameworks.config_utils.config_args import (
-    LoggingConfig,
-    SingleCameraMontyConfig,
-)
+from tbp.monty.frameworks.config_utils.config_args import LoggingConfig
 from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     DebugExperimentArgs,
     EnvironmentDataLoaderPerObjectEvalArgs,
@@ -43,6 +40,9 @@ from tbp.monty.frameworks.experiments import MontyExperiment, ProfileExperimentM
 from tbp.monty.simulators.habitat.configs import (
     EnvInitArgsSinglePTZ,
     SinglePTZHabitatDatasetArgs,
+)
+from tests.unit.frameworks.config_utils.fakes.config_args import (
+    FakeSingleCameraMontyConfig,
 )
 
 
@@ -89,7 +89,7 @@ class ProfileExperimentMixinTest(TestCase):
             logging_config=LoggingConfig(
                 output_dir=self.output_dir, python_log_level="DEBUG"
             ),
-            monty_config=SingleCameraMontyConfig(),
+            monty_config=FakeSingleCameraMontyConfig(),
             dataset_class=EnvironmentDataset,
             dataset_args=SinglePTZHabitatDatasetArgs(
                 env_init_args=EnvInitArgsSinglePTZ(data_path=None).__dict__

--- a/tests/unit/run_test.py
+++ b/tests/unit/run_test.py
@@ -27,10 +27,7 @@ from unittest import mock
 import magnum as mn
 import numpy as np
 
-from tbp.monty.frameworks.config_utils.config_args import (
-    LoggingConfig,
-    SingleCameraMontyConfig,
-)
+from tbp.monty.frameworks.config_utils.config_args import LoggingConfig
 from tbp.monty.frameworks.config_utils.make_dataset_configs import (
     ExperimentArgs,
 )
@@ -43,6 +40,9 @@ from tbp.monty.frameworks.run import main, run
 from tbp.monty.simulators.habitat import SingleSensorAgent
 from tbp.monty.simulators.habitat.configs import (
     SinglePTZHabitatDatasetArgs,
+)
+from tests.unit.frameworks.config_utils.fakes.config_args import (
+    FakeSingleCameraMontyConfig,
 )
 
 DATASET_LEN = 1000
@@ -118,7 +118,7 @@ class MontyRunTest(unittest.TestCase):
                     monty_log_level="TEST",
                     monty_handlers=[],
                 ),
-                "monty_config": SingleCameraMontyConfig(),
+                "monty_config": FakeSingleCameraMontyConfig(),
                 "dataset_class": EnvironmentDataset,
                 "dataset_args": SinglePTZHabitatDatasetArgs(),
                 "train_dataloader_class": EnvironmentDataLoader,
@@ -139,7 +139,7 @@ class MontyRunTest(unittest.TestCase):
                     monty_log_level="TEST",
                     monty_handlers=[],
                 ),
-                "monty_config": SingleCameraMontyConfig(),
+                "monty_config": FakeSingleCameraMontyConfig(),
                 "dataset_class": EnvironmentDataset,
                 "dataset_args": SinglePTZHabitatDatasetArgs(),
                 "train_dataloader_class": EnvironmentDataLoader,


### PR DESCRIPTION
I noticed that `LearningModuleBase` is essentially a fake used only for testing, but it lives in `src/tbp/monty/frameworks/models/monty_base.py`:
```python
class LearningModuleBase(LearningModule):
    """Dummy placeholder class used only for tests."""

```
Its methods define some dummy testing behavior, so it could actually be bad if someone were to inherit from it (though none do). It is only used in two config classes, which are themselves only used for testing.

This PR migrates `LearningModuleBase` into `tests` as a fake. This is also done for the two config classes that use `LearningModuleBase`. Unit tests that used these test-only classes have been updated to use the fakes.

Note: Something similar may be done with `SensorModuleBase`, but that's a bit more complicated and may be a follow up PR.


