### PR TITLE
chore: version 0.8.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"


### PR DESCRIPTION
Minor version release due to Major version 0 and breaking changes since 0.7.0.

<img width="881" height="1269" alt="Screenshot 2025-07-16 at 14 30 12" src="https://github.com/user-attachments/assets/b6c7ff36-059c-4e8b-b160-16e3d8c8a979" />

## refactor! : extract `_get_evidence_update_threshold` into a bare function

- `EvidenceGraphLM` constructor parameter renamed from `evidence_update_threshold` to `evidence_threshold_config`.
- `InvalidEvidenceUpdateThreshold` error was moved and renamed to `InvalidEvidenceThresholdConfig`.

## refactor!: replace logging BasicConfig with standard tiered config

Using `logging` directly is no longer supported.

The updated Python logger usage is now to get the logger by module name at the top of the module:
```python
# ...
from tbp.monty.frameworks.models.object_model import GraphObjectModel

logger = logging.getLogger(__name__)


class MontyForGraphMatching(MontyBase):
    """General Monty model for recognizing object using graphs."""
# ...
```

Additionally, Python loggers are now initialized before the Monty model so that logging during initialization of the Monty model works.

The default log format is updated to `"%(levelname)s:%(name)s:%(funcName)s:%(lineno)d:%(message)s"`.

Lastly, types associated with the changes to the logger initialization are updated. This required an update to `config_to_dict` as it did more than it claimed and could return `Any`, which was unnecessarily broad. Instead, the recursive call to `config_to_dict` is now guarded by the `is_config_like` check.

## refactor!: move get_depth_at_center to PositioningProcedure

Instead of invoking `get_depth_at_center(...)` on an instance of `SurfacePolicy`, the invocation pattern is now a static invocation of `PositioningProcedure.depth_at_center(...)`.

## refactor!: raise ObjectNotVisible instead of returning None action

`InformedPolicy.dynamic_call` now raises `ObjectNotVisible` instead of returning `None` action.

## feat! : evidence slope tracker integration for resampling

`ResamplingHypothesesUpdater` default `hypotheses_existing_to_new_ratio` value is changed from `0.0` to `0.1`.

The `unsupervised_inference_distinctobj_dist_agent` and `unsupervised_inference_distinctobj_surf_agent` benchmark results are significantly improved, as the original baseline lacked the initial implementation introduced here.