### PR TITLE
refactor: rename `step_gsg` to `step`

### DIFF
--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -281,7 +281,7 @@ class GoalStateGenerator(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def step_gsg(self):
+    def step(self):
         """Called on each step of the LM to which the GSG belongs."""
         pass
 

--- a/src/tbp/monty/frameworks/models/goal_state_generation.py
+++ b/src/tbp/monty/frameworks/models/goal_state_generation.py
@@ -135,7 +135,7 @@ class GraphGoalStateGenerator(GoalStateGenerator):
 
     # ------------------- Main Algorithm -----------------------
 
-    def step_gsg(self, observations):
+    def step(self, observations):
         """Step the GSG.
 
         Check whether the GSG's output and driving goal-states are achieved, and

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -656,7 +656,7 @@ class GraphLM(LearningModule):
         if len(self.get_possible_matches()) == 0:
             self.set_individual_ts(terminal_state="no_match")
 
-        self.gsg.step_gsg(observations)
+        self.gsg.step(observations)
 
         stats = self.collect_stats_to_save()
         self.buffer.update_stats(stats, append=self.has_detailed_logger)


### PR DESCRIPTION
This PR renames the `GoalStateGenerator`'s `step_gsg` method to `step`. This change is intended to improving naming consistency.