### PR TITLE
chore: error when attempting to use uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -336,3 +336,6 @@ namespaces = true
 [tool.setuptools.package-data]
 # habitat-sim resources
 'tbp.monty.simulators.resources' = ['*.json', '*.yml', '*.txt']
+
+[tool.uv]
+environments = ["sys_platform == 'uv configuration is not yet supported'"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,4 +338,4 @@ namespaces = true
 'tbp.monty.simulators.resources' = ['*.json', '*.yml', '*.txt']
 
 [tool.uv]
-environments = ["sys_platform == 'uv configuration is not yet supported'"]
+environments = ["sys_platform == 'uv tool is not yet supported'"]


### PR DESCRIPTION
With this change, when someone attempts `uv sync`, they will observe:

```
(tbp.monty) me@transient_atmospheric_phenomenon ~/tbp/tbp.monty % uv sync
Resolved 226 packages in 1ms
error: The current Python platform is not compatible with the lockfile's supported environments: `sys_platform == 'uv tool is not yet supported'`
```