### PR TITLE
docs: Fix broken tutorial

### DIFF
--- a/.vale/styles/config/vocabularies/TBP/accept.txt
+++ b/.vale/styles/config/vocabularies/TBP/accept.txt
@@ -180,3 +180,4 @@ Montymentous
 Viviane
 Inferencing
 LEGOs
+reimplement


### PR DESCRIPTION
The first tutorial broke due to recent refactoring of the sensor- and learning-module hierarchy.

The original tutorial used the most general classes possible, such as `MontyExperiment` and a now-deleted Monty config that used `MontyBase`, `SensorModuleBase`, and `LearningModuleBase`. The way I got this tutorial working again was to use more a more typical setup with `MontySupervisedObjectPretrainingExperiment`, `PatchViewFinderMountHabitatDatasetArgs`, etc.

It would have been nice to use the most generic versions of these classes, but it turned out to be a bit complicated. More specifically, our class interfaces aren't totally consistent, so one class can't really be swapped out without also swapping out others. For example, `MontyBase` calls `lm.pre_episode()` without a `primary_target` argument. `LearningModuleBase` was the only learning module that didn't accept/require `primary_target`, so `MontyBase` is now unusable with `DetailedLoggingSM` and its subclasses.

For what it's worth, I think the way this tutorial broke was pretty informative. There are undocumented dependencies between some of our classes, largely owing to the fact that our abstract methods don't have specific, required signatures. I don't want to get too into the weeds on this here though.