### PR TITLE
chore: address PLE0605, invalid format for __all__

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,7 @@ explicit_package_bases = true
 # TODO: Remove global ignore and handle missing type stubs
 ignore_missing_imports = true
 mypy_path = "src"
+# strict = true
 warn_unused_configs = true
 
 [tool.ruff]
@@ -254,7 +255,6 @@ ignore = [
     "PIE807", # PIE807: Prefer `list` over useless lambda
     "PLE0302", # PLE0302: The special method `__getitem__` expects 2 parameters, 1 was given
     "PLR0402", # PLR0402: Use from {module} import {name} in lieu of alias
-    "PLE0605", # PLE0605: Invalid format for `__all__`, must be `tuple` or `list`
     "PLR0911", # PLR0911: Too many return statements
     "PLR0912", # PLR0912: Too many branches
     "PLR0913", # PLR0913: Too many arguments in function definition

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,6 @@ explicit_package_bases = true
 # TODO: Remove global ignore and handle missing type stubs
 ignore_missing_imports = true
 mypy_path = "src"
-# strict = true
 warn_unused_configs = true
 
 [tool.ruff]

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -46,7 +46,7 @@ from tbp.monty.frameworks.utils.dataclass_utils import (
     get_subset_of_args,
 )
 
-__all__ = {"MontyExperiment"}
+__all__ = ["MontyExperiment"]
 
 logger = logging.getLogger("tbp.monty")
 


### PR DESCRIPTION
(I think) because of the invalid format of `__all__`, `MontyExperiment` does not appear in the API docs.

Either way, fix the format.