### PR TITLE
feat: enable logging of resampling stats

### DIFF
--- a/src/tbp/monty/frameworks/models/mixins/no_reset_evidence.py
+++ b/src/tbp/monty/frameworks/models/mixins/no_reset_evidence.py
@@ -106,7 +106,7 @@ class TheoreticalLimitLMLoggingMixin:
 
         This includes:
             - IDs of removed and added hypotheses.
-            - Evidence slopes and ages of hypotheses in the channel.
+            - Evidence, evidence slopes and ages of hypotheses in the channel.
             - Hypotheses rotations and pose errors to the target rotations.
 
         Args:
@@ -118,6 +118,7 @@ class TheoreticalLimitLMLoggingMixin:
                 - remove_ids: Hypotheses removed during resampling. Note that these
                     IDs can only be used to index hypotheses from the previous timestep.
                 - add_ids: Hypotheses added during resampling at the current timestep.
+                - evidence: The hypotheses evidence scores.
                 - evidence_slopes: The slopes extracted from the `EvidenceSlopeTracker`
                 - ages: The ages of the hypotheses as tracked by the
                     `EvidenceSlopeTracker`.
@@ -131,10 +132,14 @@ class TheoreticalLimitLMLoggingMixin:
             self.possible_poses[graph_id], channel_stats.input_channel
         )
         channel_rotations_inv = Rotation.from_matrix(channel_rotations).inv()
+        channel_evidence = mapper.extract(
+            self.evidence[graph_id], channel_stats.input_channel
+        )
 
         stats = {}
         stats["remove_ids"] = channel_stats.removed_hypotheses_ids
         stats["add_ids"] = channel_stats.added_hypotheses_ids
+        stats["evidence"] = channel_evidence
         stats["evidence_slopes"] = tracker._calculate_slopes(
             channel_stats.input_channel
         )

--- a/src/tbp/monty/frameworks/models/mixins/no_reset_evidence.py
+++ b/src/tbp/monty/frameworks/models/mixins/no_reset_evidence.py
@@ -7,12 +7,17 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-from typing import Any, Dict
+from __future__ import annotations
+
+from typing import Any
 
 from scipy.spatial.transform import Rotation
 
 from tbp.monty.frameworks.models.evidence_matching.learning_module import (
     EvidenceGraphLM,
+)
+from tbp.monty.frameworks.models.evidence_matching.resampling_hypotheses_updater import (  # noqa: E501
+    ChannelResamplingStats,
 )
 from tbp.monty.frameworks.utils.logging_utils import compute_pose_error
 
@@ -46,12 +51,13 @@ class TheoreticalLimitLMLoggingMixin:
                 f"EvidenceGraphLM, got {cls.__bases__}"
             )
 
-    def _add_detailed_stats(self, stats: Dict[str, Any]) -> Dict[str, Any]:
+    def _add_detailed_stats(self, stats: dict[str, Any]) -> dict[str, Any]:
         """Add detailed statistics to the logging dictionary.
 
-        This includes metrics like the max evidence score per object, the theoretical
-        limit of Monty (i.e., pose error of Monty's best potential hypothesis on the
-        target object) , and the pose error of the MLH hypothesis on the target object.
+        This includes metrics like the resampling stats, max evidence score per object,
+        the theoretical limit of Monty (i.e., pose error of Monty's best potential
+        hypothesis on the target object) , and the pose error of the MLH hypothesis
+        on the target object.
 
         Args:
             stats: The existing statistics dictionary to augment.
@@ -64,6 +70,81 @@ class TheoreticalLimitLMLoggingMixin:
             self._theoretical_limit_target_object_pose_error()
         )
         stats["target_object_pose_error"] = self._mlh_target_object_pose_error()
+
+        if (
+            hasattr(self.hypotheses_updater, "save_stats")
+            and self.hypotheses_updater.save_stats
+        ):
+            stats["resampling_stats"] = self._resampling_stats()
+
+        return stats
+
+    def _resampling_stats(self) -> dict[str, dict[str, dict[str, Any]]]:
+        """Compile resampling statistics across all objects and input channels.
+
+        Iterates over each graph and associated channels, and gathers detailed
+        resampling statistics by calling `_channel_resampling_stats`.
+
+        Returns:
+            A nested dictionary mapping with keys:
+                graph_id -> input_channel -> resampling_statistic.
+        """
+        stats = {}
+        for graph_id, graph_stats in self.hypotheses_updater.resampling_stats.items():
+            stats[graph_id] = {
+                channel_stats.input_channel: self._channel_resampling_stats(
+                    graph_id, channel_stats
+                )
+                for channel_stats in graph_stats
+            }
+        return stats
+
+    def _channel_resampling_stats(
+        self, graph_id: str, channel_stats: ChannelResamplingStats
+    ) -> dict[str, Any]:
+        """Compute resampling statistics for a specific input channel.
+
+        This includes:
+            - IDs of removed and added hypotheses.
+            - Evidence slopes and ages of hypotheses in the channel.
+            - Hypotheses rotations and pose errors to the target rotations.
+
+        Args:
+            graph_id: The object ID for the graph in reference.
+            channel_stats: Resampling Stats for the specific input channel.
+
+        Returns:
+            A dictionary containing:
+                - remove_ids: Hypotheses removed during resampling. Note that these
+                    IDs can only be used to index hypotheses from the previous timestep.
+                - add_ids: Hypotheses added during resampling at the current timestep.
+                - evidence_slopes: The slopes extracted from the `EvidenceSlopeTracker`
+                - ages: The ages of the hypotheses as tracked by the
+                    `EvidenceSlopeTracker`.
+                - rotations: Rotations of the hypotheses. Note that the buffer encoder
+                    will encode those as euler "xyz" rotations in degrees.
+                - pose_errors: Rotation errors relative to the target pose.
+        """
+        tracker = self.hypotheses_updater.evidence_slope_trackers[graph_id]
+        mapper = self.channel_hypothesis_mapping[graph_id]
+        channel_rotations = mapper.extract(
+            self.possible_poses[graph_id], channel_stats.input_channel
+        )
+        channel_rotations_inv = Rotation.from_matrix(channel_rotations).inv()
+
+        stats = {}
+        stats["remove_ids"] = channel_stats.removed_hypotheses_ids
+        stats["add_ids"] = channel_stats.added_hypotheses_ids
+        stats["evidence_slopes"] = tracker._calculate_slopes(
+            channel_stats.input_channel
+        )
+        stats["ages"] = tracker.hyp_age[channel_stats.input_channel]
+        stats["rotations"] = channel_rotations_inv
+        stats["pose_errors"] = compute_pose_error(
+            channel_rotations_inv,
+            Rotation.from_quat(self.primary_target_rotation_quat),
+            return_min=False,
+        )
         return stats
 
     def _theoretical_limit_target_object_pose_error(self) -> float:
@@ -88,7 +169,7 @@ class TheoreticalLimitLMLoggingMixin:
             self.possible_poses[self.primary_target]
         ).inv()
         target_rotation = Rotation.from_quat(self.primary_target_rotation_quat)
-        error = compute_pose_error(hyp_rotations, target_rotation)
+        error = compute_pose_error(hyp_rotations, target_rotation, return_min=True)
         return error
 
     def _mlh_target_object_pose_error(self) -> float:

--- a/src/tbp/monty/frameworks/utils/evidence_matching.py
+++ b/src/tbp/monty/frameworks/utils/evidence_matching.py
@@ -278,7 +278,7 @@ class EvidenceSlopeTracker:
         hyp_age: Maps channel names to hypothesis age counters.
     """
 
-    def __init__(self, window_size: int = 3, min_age: int = 5) -> None:
+    def __init__(self, window_size: int = 12, min_age: int = 5) -> None:
         """Initializes the EvidenceSlopeTracker.
 
         Args:

--- a/src/tbp/monty/frameworks/utils/logging_utils.py
+++ b/src/tbp/monty/frameworks/utils/logging_utils.py
@@ -8,6 +8,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+from __future__ import annotations
+
 import copy
 import json
 import logging
@@ -18,6 +20,7 @@ from pathlib import Path
 from sys import getsizeof
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import quaternion
 import torch
@@ -390,8 +393,8 @@ def get_time_stats(all_ds, all_conditions) -> pd.DataFrame:
 
 
 def compute_pose_error(
-    predicted_rotation: Rotation, target_rotation: Rotation
-) -> float:
+    predicted_rotation: Rotation, target_rotation: Rotation, return_min: bool = True
+) -> npt.NDArray[np.float64] | float:
     """Computes the minimum angular pose error between predicted and target rotations.
 
     Both inputs must be instances of `scipy.spatial.transform.Rotation`. The
@@ -412,11 +415,15 @@ def compute_pose_error(
         predicted_rotation: Predicted rotation(s). Can be a single or list of
             rotation.
         target_rotation: Target rotation. Must represent a single rotation.
+        return_min: Returns the minimum pose error for a list of rotations,
+            otherwise, returns a list of pose errors. Defaults to True.
 
     Returns:
-        The minimum angular error in radians.
+        The angular error in radians.
     """
-    error = np.min((predicted_rotation * target_rotation.inv()).magnitude())
+    error = (predicted_rotation * target_rotation.inv()).magnitude()
+    if return_min:
+        error = np.min(error)
     return error
 
 


### PR DESCRIPTION
This PR is part 1 of adding a visualization that allows us to inspect the hypothesis space at every step of every episode for a Monty unsupervised inference experiment.

In this PR, I'm adding the code for logging resampling statistics such as which hypotheses have been added or removed at every step, the evidence values, slopes and ages, rotations, pose errors, etc.

Since this is a lot of information that we're logging I added a `ResamplingHypothesesUpdater` flag named `save_stats` which must be set to true in the configs to save all this extra logging information. This is similar to `save_raw_obs` for the SMs.

In a follow up PR, I will add the interactive visualization to make use of this logged information.