### PR TITLE
ci: update docs config to include constructors

### DIFF
--- a/tools/generate_api_docs/source/conf.py
+++ b/tools/generate_api_docs/source/conf.py
@@ -165,6 +165,10 @@ autodoc_mock_imports = [
     "torch_geometric",
     "torchvision",
 ]
+autodoc_default_options = {
+    # Make sphinx generate docs for specific dunder methods
+    "special-members": "__init__",
+}
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
 add_module_names = False


### PR DESCRIPTION
We're currently not including "dunder" methods, e.g. `__init__` in our generated API documentation. This changes the Sphinx configuration to include them.