### PR TITLE
feat!: collect telemetry from hypotheses updaters

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
@@ -10,7 +10,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal, Protocol
+from typing import Any, Dict, Literal, Optional, Protocol
 
 import numpy as np
 from scipy.spatial.transform import Rotation
@@ -44,6 +44,8 @@ from tbp.monty.frameworks.utils.spatial_arithmetics import (
 
 logger = logging.getLogger(__name__)
 
+HypothesesUpdateTelemetry = Optional[Dict[str, Any]]
+HypothesesUpdaterTelemetry = Dict[str, Any]
 
 class HypothesesUpdater(Protocol):
     def update_hypotheses(
@@ -54,7 +56,7 @@ class HypothesesUpdater(Protocol):
         graph_id: str,
         mapper: ChannelMapper,
         evidence_update_threshold: float,
-    ) -> list[ChannelHypotheses]:
+    ) -> tuple[list[ChannelHypotheses], HypothesesUpdateTelemetry]:
         """Update hypotheses based on sensor displacement and sensed features.
 
         Args:
@@ -169,7 +171,7 @@ class DefaultHypothesesUpdater:
         graph_id: str,
         mapper: ChannelMapper,
         evidence_update_threshold: float,
-    ) -> list[ChannelHypotheses]:
+    ) -> tuple[list[ChannelHypotheses], HypothesesUpdateTelemetry]:
         """Update hypotheses based on sensor displacement and sensed features.
 
         Updates existing hypothesis space or initializes a new hypothesis space
@@ -243,7 +245,7 @@ class DefaultHypothesesUpdater:
 
             hypotheses_updates.append(channel_possible_hypotheses)
 
-        return hypotheses_updates
+        return hypotheses_updates, None
 
     def _get_all_informed_possible_poses(
         self, graph_id: str, sensed_channel_features: dict, input_channel: str

--- a/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from typing import Any
 
 import numpy as np
 from scipy.spatial import KDTree
@@ -28,6 +29,7 @@ from tbp.monty.frameworks.models.evidence_matching.hypotheses import (
 from tbp.monty.frameworks.models.evidence_matching.hypotheses_updater import (
     DefaultHypothesesUpdater,
     HypothesesUpdater,
+    HypothesesUpdaterTelemetry,
 )
 from tbp.monty.frameworks.models.goal_state_generation import EvidenceGoalStateGenerator
 from tbp.monty.frameworks.models.graph_matching import GraphLM
@@ -173,7 +175,7 @@ class EvidenceGraphLM(GraphLM):
         hypotheses_updater_args: dict | None = None,
         *args,
         **kwargs,
-    ):
+    ) -> None:
         kwargs["initialize_base_modules"] = False
         super(EvidenceGraphLM, self).__init__(*args, **kwargs)
         # --- LM components ---
@@ -251,6 +253,7 @@ class EvidenceGraphLM(GraphLM):
             tolerances=self.tolerances,
         )
         self.hypotheses_updater = hypotheses_updater_class(**hypotheses_updater_args)
+        self.hypotheses_updater_telemetry: HypothesesUpdaterTelemetry = {}
 
     # =============== Public Interface Functions ===============
 
@@ -752,18 +755,23 @@ class EvidenceGraphLM(GraphLM):
             evidence_all_channels=self.evidence[graph_id],
         )
 
-        hypotheses_updates = self.hypotheses_updater.update_hypotheses(
-            hypotheses=Hypotheses(
-                evidence=self.evidence[graph_id],
-                locations=self.possible_locations[graph_id],
-                poses=self.possible_poses[graph_id],
-            ),
-            features=features,
-            displacements=displacements,
-            graph_id=graph_id,
-            mapper=self.channel_hypothesis_mapping[graph_id],
-            evidence_update_threshold=update_threshold,
+        hypotheses_updates, hypotheses_update_telemetry = (
+            self.hypotheses_updater.update_hypotheses(
+                hypotheses=Hypotheses(
+                    evidence=self.evidence[graph_id],
+                    locations=self.possible_locations[graph_id],
+                    poses=self.possible_poses[graph_id],
+                ),
+                features=features,
+                displacements=displacements,
+                graph_id=graph_id,
+                mapper=self.channel_hypothesis_mapping[graph_id],
+                evidence_update_threshold=update_threshold,
+            )
         )
+
+        if hypotheses_update_telemetry is not None:
+            self.hypotheses_updater_telemetry[graph_id] = hypotheses_update_telemetry
 
         if not hypotheses_updates:
             return

--- a/src/tbp/monty/frameworks/models/evidence_matching/resampling_hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/resampling_hypotheses_updater.py
@@ -9,9 +9,11 @@
 
 from __future__ import annotations
 
-from typing import Literal, Tuple, Type
+from dataclasses import asdict, dataclass
+from typing import Any, Literal, Tuple, Type
 
 import numpy as np
+import numpy.typing as npt
 from scipy.spatial.transform import Rotation
 
 from tbp.monty.frameworks.models.evidence_matching.feature_evidence.calculator import (
@@ -33,6 +35,7 @@ from tbp.monty.frameworks.models.evidence_matching.hypotheses_displacer import (
     DefaultHypothesesDisplacer,
 )
 from tbp.monty.frameworks.models.evidence_matching.hypotheses_updater import (
+    HypothesesUpdateTelemetry,
     all_usable_input_channels,
 )
 from tbp.monty.frameworks.utils.evidence_matching import (
@@ -46,6 +49,24 @@ from tbp.monty.frameworks.utils.graph_matching_utils import (
 from tbp.monty.frameworks.utils.spatial_arithmetics import (
     align_multiple_orthonormal_vectors,
 )
+
+
+@dataclass
+class ChannelHypothesesResamplingTelemetry:
+    """Hypotheses resampling telemetry for a channel.
+
+    For a given input channel, this class stores which hypotheses were removed or
+    added at the current step.
+
+    Note:
+        TODO: Additional description here regarding availability of hypotheses
+        identified by `removed_ids`.
+    """
+
+    added_ids: npt.NDArray[np.int_]
+    ages: npt.NDArray[np.int_]
+    evidence_slopes: npt.NDArray[np.float64]
+    removed_ids: npt.NDArray[np.int_]
 
 
 class ResamplingHypothesesUpdater:
@@ -89,6 +110,7 @@ class ResamplingHypothesesUpdater:
         ),
         hypotheses_count_multiplier: float = 1.0,
         hypotheses_existing_to_new_ratio: float = 0.1,
+        include_telemetry: bool = False,
         initial_possible_poses: Literal["uniform", "informed"]
         | list[Rotation] = "informed",
         max_nneighbors: int = 3,
@@ -122,6 +144,9 @@ class ResamplingHypothesesUpdater:
             hypotheses_existing_to_new_ratio: Controls the proportion of the
                 existing vs. newly sampled hypotheses during resampling. Defaults to
                 0.0.
+            include_telemetry: Flag to control if we want to calculate and return the
+                resampling telemetry in the `update_hypotheses` method. Defaults to
+                False.
             initial_possible_poses: Initial
                 possible poses that should be tested for. Defaults to "informed".
             max_nneighbors: Maximum number of nearest neighbors to consider in the
@@ -147,6 +172,7 @@ class ResamplingHypothesesUpdater:
         self.feature_weights = feature_weights
         self.features_for_matching_selector = features_for_matching_selector
         self.graph_memory = graph_memory
+        self.include_telemetry = include_telemetry
         self.initial_possible_poses = get_initial_possible_poses(initial_possible_poses)
         self.tolerances = tolerances
         self.umbilical_num_poses = umbilical_num_poses
@@ -189,7 +215,7 @@ class ResamplingHypothesesUpdater:
         graph_id: str,
         mapper: ChannelMapper,
         evidence_update_threshold: float,
-    ) -> list[ChannelHypotheses]:
+    ) -> tuple[list[ChannelHypotheses], HypothesesUpdateTelemetry]:
         """Update hypotheses based on sensor displacement and sensed features.
 
         Updates existing hypothesis space or initializes a new hypothesis space
@@ -208,7 +234,17 @@ class ResamplingHypothesesUpdater:
             evidence_update_threshold: Evidence update threshold.
 
         Returns:
-            The list of hypotheses updates to be applied to each input channel.
+            A tuple containing the list of hypotheses updates to be applied to each
+            input channel and hypotheses update telemetry for analysis. The hypotheses
+            update telemetry is a dictionary containing:
+                - added_ids: IDs of hypotheses added during resampling at the current
+                    timestep.
+                - ages: The ages of the hypotheses as tracked by the
+                    `EvidenceSlopeTracker`.
+                - evidence_slopes: The slopes extracted from the `EvidenceSlopeTracker`.
+                - removed_ids: IDs of hypotheses removed during resampling. Note that
+                    these IDs can only be used to index hypotheses from the previous
+                    timestep.
         """
         # Initialize a `EvidenceSlopeTracker` to keep track of evidence slopes
         # for hypotheses of a specific graph_id
@@ -221,6 +257,7 @@ class ResamplingHypothesesUpdater:
         )
 
         hypotheses_updates = []
+        resampling_telemetry: dict[str, Any] = {}
 
         for input_channel in input_channels_to_use:
             # Calculate sample count for each type
@@ -233,7 +270,7 @@ class ResamplingHypothesesUpdater:
             )
 
             # Sample hypotheses based on their type
-            existing_hypotheses = self._sample_existing(
+            existing_hypotheses, remove_ids = self._sample_existing(
                 existing_count=existing_count,
                 hypotheses=hypotheses,
                 input_channel=input_channel,
@@ -275,10 +312,29 @@ class ResamplingHypothesesUpdater:
             )
             hypotheses_updates.append(channel_hypotheses)
 
+            if self.include_telemetry:
+                resampling_telemetry[input_channel] = asdict(
+                    ChannelHypothesesResamplingTelemetry(
+                        added_ids=(
+                            np.arange(len(channel_hypotheses.evidence))[
+                                -len(informed_hypotheses.evidence) :
+                            ]
+                            if len(informed_hypotheses.evidence) > 0
+                            else np.array([], dtype=np.int_)
+                        ),
+                        ages=tracker.hyp_ages(input_channel),
+                        evidence_slopes=tracker.calculate_slopes(input_channel),
+                        removed_ids=remove_ids,
+                    )
+                )
+
             # Update tracker evidence
             tracker.update(channel_hypotheses.evidence, input_channel)
 
-        return hypotheses_updates
+        return (
+            hypotheses_updates,
+            resampling_telemetry if self.include_telemetry else None,
+        )
 
     def _num_hyps_per_node(self, channel_features: dict) -> int:
         """Calculate the number of hypotheses per node.
@@ -383,7 +439,7 @@ class ResamplingHypothesesUpdater:
         input_channel: str,
         mapper: ChannelMapper,
         tracker: EvidenceSlopeTracker,
-    ) -> ChannelHypotheses:
+    ) -> tuple[ChannelHypotheses, npt.NDArray[np.int_]]:
         """Samples the specified number of existing hypotheses to retain.
 
         Args:
@@ -401,14 +457,16 @@ class ResamplingHypothesesUpdater:
         # Return empty arrays for no hypotheses to sample
         if existing_count == 0:
             # Clear all channel hypotheses from the tracker
+            remove_ids = np.arange(tracker.total_size(input_channel))
             tracker.clear_hyp(input_channel)
 
-            return ChannelHypotheses(
+            channel_hypotheses = ChannelHypotheses(
                 input_channel=input_channel,
                 locations=np.zeros((0, 3)),
                 poses=np.zeros((0, 3, 3)),
                 evidence=np.zeros(0),
             )
+            return channel_hypotheses, remove_ids
 
         keep_ids, remove_ids = tracker.calculate_keep_and_remove_ids(
             num_keep=existing_count,
@@ -419,12 +477,13 @@ class ResamplingHypothesesUpdater:
         tracker.remove_hyp(remove_ids, input_channel)
 
         channel_hypotheses = mapper.extract_hypotheses(hypotheses, input_channel)
-        return ChannelHypotheses(
+        maintained_channel_hypotheses = ChannelHypotheses(
             input_channel=channel_hypotheses.input_channel,
             locations=channel_hypotheses.locations[keep_ids],
             poses=channel_hypotheses.poses[keep_ids],
             evidence=channel_hypotheses.evidence[keep_ids],
         )
+        return maintained_channel_hypotheses, remove_ids
 
     def _sample_informed(
         self,

--- a/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
@@ -7,6 +7,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+from __future__ import annotations
+
 from typing import List
 
 import numpy as np

--- a/src/tbp/monty/frameworks/utils/evidence_matching.py
+++ b/src/tbp/monty/frameworks/utils/evidence_matching.py
@@ -278,7 +278,7 @@ class EvidenceSlopeTracker:
         hyp_age: Maps channel names to hypothesis age counters.
     """
 
-    def __init__(self, window_size: int = 3, min_age: int = 5) -> None:
+    def __init__(self, window_size: int = 12, min_age: int = 5) -> None:
         """Initializes the EvidenceSlopeTracker.
 
         Args:
@@ -333,6 +333,14 @@ class EvidenceSlopeTracker:
             )
             self.hyp_age[channel] = np.concatenate((self.hyp_age[channel], new_age))
 
+    def hyp_ages(self, channel: str) -> npt.NDArray[np.int_]:
+        """Returns the ages of hypotheses in a channel.
+
+        Args:
+            channel: Name of the input channel.
+        """
+        return self.hyp_age[channel]
+
     def update(self, values: npt.NDArray[np.float64], channel: str) -> None:
         """Updates all hypotheses in a channel with new evidence values.
 
@@ -361,7 +369,7 @@ class EvidenceSlopeTracker:
         # Increment age
         self.hyp_age[channel] += 1
 
-    def _calculate_slopes(self, channel: str) -> npt.NDArray[np.float64]:
+    def calculate_slopes(self, channel: str) -> npt.NDArray[np.float64]:
         """Computes the average slope of hypotheses in a channel.
 
         This method calculates the slope of the evidence signal for each hypothesis by
@@ -442,7 +450,7 @@ class EvidenceSlopeTracker:
 
         # Retrieve valid slopes and sort them
         removable_mask = self.removable_indices_mask(channel)
-        slopes = self._calculate_slopes(channel)
+        slopes = self.calculate_slopes(channel)
         removable_slopes = slopes[removable_mask]
         removable_ids = total_ids[removable_mask]
         sorted_indices = np.argsort(removable_slopes)

--- a/src/tbp/monty/frameworks/utils/logging_utils.py
+++ b/src/tbp/monty/frameworks/utils/logging_utils.py
@@ -8,6 +8,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+from __future__ import annotations
+
 import copy
 import json
 import logging
@@ -18,6 +20,7 @@ from pathlib import Path
 from sys import getsizeof
 
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 import quaternion
 import torch
@@ -388,11 +391,10 @@ def get_time_stats(all_ds, all_conditions) -> pd.DataFrame:
     time_stats.columns = ["model_type", "time", "step"]
     return time_stats
 
-
-def compute_pose_error(
+def compute_pose_errors(
     predicted_rotation: Rotation, target_rotation: Rotation
-) -> float:
-    """Computes the minimum angular pose error between predicted and target rotations.
+) -> npt.NDArray[np.float64] | float:
+    """Computes the angular pose errors between predicted and target rotations.
 
     Both inputs must be instances of `scipy.spatial.transform.Rotation`. The
     `predicted_rotation` may contain a single rotation or a list of rotations,
@@ -400,7 +402,7 @@ def compute_pose_error(
 
     The pose error is defined as the geodesic distance on SO(3) — the angle of the
     relative rotation between predicted and target. If `predicted_rotation` contains
-    multiple rotations, this function returns the minimum error among them.
+    multiple rotations, this function returns the errors among them.
 
     Note that the `.inv()` operation in this method is due to how geodesic distance
     between two rotations is calculated, not a side-effect of whether the target
@@ -414,9 +416,30 @@ def compute_pose_error(
         target_rotation: Target rotation. Must represent a single rotation.
 
     Returns:
+        The angular errors in radians.
+    """
+    errors: npt.NDArray[np.float64] | float = (
+        predicted_rotation * target_rotation.inv()
+    ).magnitude()
+    return errors
+
+
+def compute_pose_error(
+    predicted_rotation: Rotation, target_rotation: Rotation
+) -> float:
+    """Computes the minimum angular pose error between predicted and target rotations.
+
+    See `compute_pose_errors` for more details.
+
+    Args:
+        predicted_rotation: Predicted rotation(s). Can be a single or list of
+            rotation.
+        target_rotation: Target rotation. Must represent a single rotation.
+
+    Returns:
         The minimum angular error in radians.
     """
-    error = np.min((predicted_rotation * target_rotation.inv()).magnitude())
+    error = np.min(compute_pose_errors(predicted_rotation, target_rotation))
     return error
 
 

--- a/tests/unit/frameworks/utils/evidence_matching_test.py
+++ b/tests/unit/frameworks/utils/evidence_matching_test.py
@@ -225,7 +225,7 @@ class EvidenceSlopeTrackerTest(unittest.TestCase):
         )
 
         # Slopes: (3.0 - 4.0) + (4.0 - 5.0) = (-1) + (-1) = -2 / 2 = -1.0
-        slopes = self.tracker._calculate_slopes(self.channel)
+        slopes = self.tracker.calculate_slopes(self.channel)
         self.assertAlmostEqual(slopes[0], -1.0)
 
     def test_update_raises_on_wrong_length(self) -> None:
@@ -267,7 +267,7 @@ class EvidenceSlopeTrackerTest(unittest.TestCase):
         self.tracker.update(np.array([2.0]), self.channel)
         self.tracker.update(np.array([3.0]), self.channel)
 
-        slopes = self.tracker._calculate_slopes(self.channel)
+        slopes = self.tracker.calculate_slopes(self.channel)
         expected_slope = ((2.0 - 1.0) + (3.0 - 2.0)) / 2  # = 1.0
         self.assertAlmostEqual(slopes[0], expected_slope)
 


### PR DESCRIPTION
This is an alternate proposal to implement the functionality in #396.

The pull request is marked `feat!` due to a breaking change, which changed the `EvidenceSlopeTracker.window_size` parameter default.

The overall design for collecting telemetry from hypotheses updaters is to update the protocol to return a tuple and then, in the case of `ResamplingHypothesesUpdater`, include telemetry in the returned tuple if configured to do so.

This proposal attempts to minimize coupling between code.

The `HypothesesUpdater` protocol update now requires that _any_ updater may return some telemetry, with the `DefaultHypothesesUpdater` returning `None`.

The `EvidenceGraphLM`, that uses hypotheses updaters, now collects any telemetry emitted by them.
```python
        if hypotheses_update_telemetry is not None:
            self.hypotheses_updater_telemetry[graph_id] = hypotheses_update_telemetry
```
This way, no matter what implementation of hypotheses updater is used, if it emits telemetry, it will be collected.

The learning module collects telemetry because of the coupling between Monty and MontyExperiment, where telemetry is collected via `_add_detailed_stats` call. Additionally, we _do not want_ the learning module to assume that it has a specific type of hypotheses updater, nor do we want it to reach into that one specific type of hypotheses updater and then reach into its tracker to do some computation.

I attempted to minimize changes to `TheoreticalLimitLMLoggingMixin`. The difference in implementation here vs #396 is that `TheoreticalLimitLMLoggingMixin` does not assume a specific telemetry format of the channel telemetry (aside from the generic dictionary of Any). It accepts channel telemetry and only appends what is in its scope to append. There is some weak coupling here in that it is technically possible for `TheoreticalLimitLMLoggingMixin` to override keys in channel telemetry, but addressing that is beyond the scope of this pull request.

Instead of reaching into the internals of `EvidenceSlopeTracker`, it now has `hyp_ages` method that can be called. Similarly, `_calculate_slopes` has been renamed to `calculate_slopes` as it is now part of its public API and called outside the class.

I thought that adding `compute_pose_errors` and reusing it in `compute_pose_error` was a better way to offer the quite different functionality, instead of using a parameter toggle.

Lastly, the use of the term "telemetry" is intentional as a marker for future refactoring. I am hoping that one day we'll end up emitting telemetry in a similar way we do `logger.info()` calls, out of band of the main code logic. When we get there, anything with "telemetry" in it will need to be refactored, and so this makes it easier to find (possibly maybe).