### PR TITLE
chore: version 0.10.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.9.1"
+__version__ = "0.10.0"


### PR DESCRIPTION
Minor version release due to Major version 0 and breaking changes since 0.9.1.

<img width="1302" height="1205" alt="Screenshot 2025-08-14 at 16 01 21" src="https://github.com/user-attachments/assets/c20ebcca-a6b1-44c7-b529-4b8f376de334" />

## refactor!: remove function unused in tbp.monty (to monty_lab) #406

* [breaking change] `find_transform_instance()` was removed from `transform_utils.py`

## refactor!: remove unused MontyBase.episodes #413

* [breaking change] `MontyBase.episodes` was removed.

## refactor!: remove unused MontyBase.epochs #412

* [breaking change] `MontyBase.epochs` was removed.

## refactor!: remove unused MontyBase attributes `sm_ids` and `n_lms` #419

* [breaking change] `MontyBase.sm_ids` and `MontyBase.n_lms` were removed.

## feat!: collect telemetry from hypotheses updaters #400

* [breaking change] `HypothesesUpdater` protocol is updated. `HypothesesUpdater.update_hypotheses` now returns `HypothesesUpdateTelemetry` in addition to the list of `ChannelHypotheses`.
* [new] `EvidenceSlopeTracker.hyp_ages`
* [new] `EvidenceSlopeTracker.calculate_slopes`
* [new] `compute_pose_errors` in `logging_utils.py`