### PR TITLE
refactor!: Dataclass class to dataclass_utils

### DIFF
--- a/src/tbp/monty/frameworks/config_utils/config_args.py
+++ b/src/tbp/monty/frameworks/config_utils/config_args.py
@@ -14,15 +14,12 @@ from dataclasses import dataclass, field
 from itertools import product
 from numbers import Number
 from typing import (
-    Any,
     Callable,
-    ClassVar,
     Dict,
     Iterable,
     List,
     Mapping,
     Optional,
-    Protocol,
     Union,
 )
 
@@ -71,6 +68,7 @@ from tbp.monty.frameworks.models.sensor_modules import (
     HabitatDistantPatchSM,
     HabitatSurfacePatchSM,
 )
+from tbp.monty.frameworks.utils.dataclass_utils import Dataclass
 
 # -- Table of contents --
 # -----------------------
@@ -80,17 +78,6 @@ from tbp.monty.frameworks.models.sensor_modules import (
 # -----------------------
 
 monty_logs_dir = os.getenv("MONTY_LOGS")
-
-
-class Dataclass(Protocol):
-    """A protocol for dataclasses to be used in type hints.
-
-    The reason this exists is because dataclass.dataclass is not a valid type.
-    """
-
-    __dataclass_fields__: ClassVar[Dict[str, Any]]
-    """Checking for presence of __dataclass_fields__ is a hack to check if a class is a
-    dataclass."""
 
 
 @dataclass

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -14,14 +14,11 @@ import datetime
 import logging
 import os
 import pprint
-from typing import TYPE_CHECKING, Any, Dict, Literal
+from typing import Any, Dict, Literal
 
 import numpy as np
 import torch
 from typing_extensions import Self
-
-if TYPE_CHECKING:
-    from _typeshed import DataclassInstance
 
 from tbp.monty.frameworks.environments.embodied_data import (
     EnvironmentDataLoader,
@@ -42,6 +39,7 @@ from tbp.monty.frameworks.models.abstract_monty_classes import (
 from tbp.monty.frameworks.models.motor_policies import MotorPolicy
 from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.frameworks.utils.dataclass_utils import (
+    Dataclass,
     config_to_dict,
     get_subset_of_args,
 )
@@ -58,7 +56,7 @@ class MontyExperiment:
     the outermost loops for training and evaluating (including run epoch and episode)
     """
 
-    def __init__(self, config: DataclassInstance | Dict[str, Any]) -> None:
+    def __init__(self, config: Dataclass | Dict[str, Any]) -> None:
         """Initialize the experiment based on the provided configuration.
 
         Args:

--- a/src/tbp/monty/frameworks/utils/dataclass_utils.py
+++ b/src/tbp/monty/frameworks/utils/dataclass_utils.py
@@ -13,17 +13,27 @@ import copy
 import dataclasses
 import importlib
 from inspect import Parameter, signature
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Type
+from typing import Any, Callable, ClassVar, Dict, Optional, Protocol, Type
 
 from typing_extensions import TypeIs
 
-if TYPE_CHECKING:
-    from _typeshed import DataclassInstance
+
+class Dataclass(Protocol):
+    """A protocol for dataclasses to be used in type hints.
+
+    The reason this exists is because dataclass.dataclass is not a valid type.
+    """
+
+    __dataclass_fields__: ClassVar[Dict[str, Any]]
+    """Checking for presence of __dataclass_fields__ is a hack to check if a class is a
+    dataclass."""
+
 
 __all__ = [
     "as_dataclass_dict",
     "create_dataclass_args",
     "from_dataclass_dict",
+    "Dataclass",
 ]
 
 # Keeps track of the dataclass type in a serializable dataclass dict
@@ -157,7 +167,7 @@ def create_dataclass_args(
     return dataclasses.make_dataclass(dataclass_name, _fields, bases=bases, frozen=True)
 
 
-def config_to_dict(config: DataclassInstance | Dict[str, Any]) -> Dict[str, Any]:
+def config_to_dict(config: Dataclass | Dict[str, Any]) -> Dict[str, Any]:
     """Convert config composed of mixed dataclass and dict elements to pure dict.
 
     We want to convert configs composed of mixed dataclass and dict elements to
@@ -219,7 +229,7 @@ def _config_to_dict_inner(obj: Any) -> Any:
         return copy.deepcopy(obj)
 
 
-def is_config_like(obj: Any) -> TypeIs[DataclassInstance | Dict[str, Any]]:
+def is_config_like(obj: Any) -> TypeIs[Dataclass | Dict[str, Any]]:
     """Returns True if obj is a dataclass or dict, False otherwise.
 
     Args:

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -30,7 +30,6 @@ import pandas as pd
 
 from tbp.monty.frameworks.actions.action_samplers import ConstantSampler
 from tbp.monty.frameworks.config_utils.config_args import (
-    Dataclass,
     FiveLMMontyConfig,
     InformedPolicy,
     LoggingConfig,
@@ -65,6 +64,7 @@ from tbp.monty.frameworks.models.sensor_modules import (
     DetailedLoggingSM,
     HabitatDistantPatchSM,
 )
+from tbp.monty.frameworks.utils.dataclass_utils import Dataclass
 from tbp.monty.frameworks.utils.logging_utils import load_models_from_dir
 from tbp.monty.simulators.habitat.configs import (
     EnvInitArgsFiveLMMount,

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -30,7 +30,6 @@ import pandas as pd
 
 from tbp.monty.frameworks.actions.action_samplers import ConstantSampler
 from tbp.monty.frameworks.config_utils.config_args import (
-    Dataclass,
     FiveLMMontyConfig,
     InformedPolicy,
     LoggingConfig,
@@ -55,6 +54,7 @@ from tbp.monty.frameworks.models.displacement_matching import DisplacementGraphL
 from tbp.monty.frameworks.models.feature_location_matching import FeatureGraphLM
 from tbp.monty.frameworks.models.graph_matching import GraphLM
 from tbp.monty.frameworks.models.motor_system import MotorSystem
+from tbp.monty.frameworks.utils.dataclass_utils import Dataclass
 from tbp.monty.frameworks.utils.follow_up_configs import (
     create_eval_config_multiple_episodes,
     create_eval_episode_config,


### PR DESCRIPTION
In the scope of #440 I noticed that we have two custom definitions of `Dataclass(Protocol)`. This pull request consolidates to one definition. I chose to use ours because the `_typeshed` `DataclassInstance` is misleading, in that (as we learned in #440), it will accept a class and an instance.