### PR TITLE
chore: version 0.11.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"


### PR DESCRIPTION
Minor version release due to Major version 0 and breaking changes since 0.10.0.

<img width="1319" height="747" alt="Screenshot 2025-09-04 at 14 05 58" src="https://github.com/user-attachments/assets/c70cec14-2fd0-454b-b50e-66ed44dfe906" />
<img width="1314" height="872" alt="Screenshot 2025-09-04 at 14 06 05" src="https://github.com/user-attachments/assets/267befca-a885-49be-9aa9-6b9868d0ac09" />
<img width="1318" height="297" alt="Screenshot 2025-09-04 at 14 06 10" src="https://github.com/user-attachments/assets/cd4ab600-f880-4e1e-8905-5bd249ecce25" />

## refactor!: Change getters to properties using `@property`in simulator.py. (https://github.com/thousandbrainsproject/tbp.monty/pull/424)

Accessing simulator properties changed for the following properties as follows:
```diff
- sim.get_num_objects()
+ sim.num_objects

- sim.get_action_space()
+ sim.action_space

- sim.get_observations()
+ sim.observations

- sim.get_states()
+ sim.states
```

##  refactor!: Dataclass class to dataclass_utils (#447)

`Dataclass` type definition was moved from `src/tbp/monty/framework/config_utils/config_args.py` to `src/tbp/monty/framework/utils/dataclass_utils.py` and replaces previous `DataclassInstance` use.
