### PR TITLE
fix: Broken doc links when 2+ links per line

### DIFF
--- a/tools/github_readme_sync/README.md
+++ b/tools/github_readme_sync/README.md
@@ -20,7 +20,7 @@ First, ensure you setup Monty. See [Getting Started - 2. Set up Your Environment
 Next, from the root Monty directory, install this tool's dependencies:
 
 ```
-pip install -e '.[dev,github_readme_sync_tool]'
+pip install -e '.[dev,github_readme_sync_tool,print_version_tool]'
 ```
 
 ## Usage

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -38,7 +38,7 @@ regex_images = re.compile(r"!\[(.*?)\]\((.*?)\)")
 regex_image_path = re.compile(
     r"(\.\./){1,5}figures/((.+)\.(png|jpg|jpeg|gif|svg|webp))"
 )
-regex_markdown_path = re.compile(r"\(([\./]*)([\w\-/]+)\.md(#.*)?\)")
+regex_markdown_path = re.compile(r"\(([\./]*)([\w\-/]+)\.md(#.*?)?\)")
 regex_cloudinary_video = re.compile(
     r"\[(.*?)\]\((https://res\.cloudinary\.com/([^/]+)/video/upload/v(\d+)/([^/]+\.mp4))\)",
     re.IGNORECASE,

--- a/tools/github_readme_sync/tests/readme_test.py
+++ b/tools/github_readme_sync/tests/readme_test.py
@@ -408,14 +408,14 @@ This is a test document.""",
     @patch.dict(os.environ, {"IMAGE_PATH": "user/repo"})
     def test_correct_file_locations_markdown(self):
         """Test file location correction for Markdown file paths."""
-        base_expected = f"[File 1](/docs/slug#sub-heading)"
+        base_expected = f"[File 1](/docs/slug#sub-heading) and [File 2](/docs/slug2#sub-heading)"
 
         # Test cases for Markdown file paths
         markdown_paths_with_deep_link = [
-            "[File 1](slug.md#sub-heading)",
-            "[File 1](contibuting/slug.md#sub-heading)",
-            "[File 1](../contibuting/slug.md#sub-heading)",
-            "[File 1](../../contibuting/slug.md#sub-heading)",
+            "[File 1](slug.md#sub-heading) and [File 2](slug2.md#sub-heading)",
+            "[File 1](contibuting/slug.md#sub-heading) and [File 2](contibuting/slug2.md#sub-heading)",
+            "[File 1](../contibuting/slug.md#sub-heading) and [File 2](../contibuting/slug2.md#sub-heading)",
+            "[File 1](../../contibuting/slug.md#sub-heading) and [File 2](../../contibuting/slug2.md#sub-heading)",
         ]
 
         markdown_paths_without_deep_link = [


### PR DESCRIPTION
I noticed many broken links on multiple doc pages. I tracked it down to a regex pattern in `github_readme_sync` behaving incorrectly when multiple links are on the same line.

[Example](https://thousandbrainsproject.readme.io/docs/long-term-goals-and-principles):

<img width="910" height="232" alt="image" src="https://github.com/user-attachments/assets/8edb94be-7bdf-48ea-b5bc-5d5de2b0e597" />