### PR TITLE
Support experiments located outside the tbp.monty dir

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -20,7 +20,7 @@ sys.path.insert(
 )
 
 
-from benchmarks.configs.load import load_configs
+from benchmarks.configs.load import load_configs, load_external_configs
 from benchmarks.configs.names import NAMES
 from tbp.monty.frameworks.config_utils.cmd_parser import create_cmd_parser
 from tbp.monty.frameworks.run_env import setup_env
@@ -39,6 +39,16 @@ if __name__ == "__main__":
         os.environ["MAGNUM_LOG"] = "quiet"
         os.environ["HABITAT_SIM_LOG"] = "quiet"
 
-    CONFIGS = load_configs(experiments)
+    if experiments:
+        CONFIGS = load_configs(experiments)
+        main(all_configs=CONFIGS, experiments=cmd_args.experiments)
+    elif cmd_args.experiments_dir:
+        print(f"Loading external experiments from {cmd_args.experiments_dir}")
 
-    main(all_configs=CONFIGS, experiments=cmd_args.experiments)
+        CONFIGS = load_external_configs(cmd_args.experiments_dir)
+        
+        print(f"Loaded experiments: {list(CONFIGS.keys())}")
+
+        main(all_configs=CONFIGS, experiments=CONFIGS.keys())
+
+    

--- a/src/tbp/monty/frameworks/config_utils/cmd_parser.py
+++ b/src/tbp/monty/frameworks/config_utils/cmd_parser.py
@@ -46,6 +46,12 @@ def create_cmd_parser(experiments: list[str]):
         action="store_true",
         help="Don't run an experiment; just print out the config for visual inspection",
     )
+    parser.add_argument(
+        "-d",
+        "--experiments_dir",
+        help="Set a directory for external experiments to be loaded from",
+        default=None,
+    )
 
     return parser
 


### PR DESCRIPTION
**What?**

This PR is an attempt to support specifying external experiments directory where experiments can be loaded from. This decouples a user's experiments with the tbp.monty benchmark experiments. I'm not exactly sure if this feature is already implemented but I submitted this PR as it may be useful for others.

While following the [documentation](https://thousandbrainsproject.readme.io/docs/running-your-first-experiment#setting-up-the-experiment-config), it instructed to put the custom experiments in the tbp.monty benchmarks directory and modifying it. I wanted to not touch anything in this directory, otherwise it'll be contaminated with untracked files from git's perspective, and instead load it from an external directory (e.g. a git repo) where my custom experiments are located.

**Example Usage**
The following loads the experiments files located in /Users/admin/tbp/experiments directory.


`python run.py -d /Users/admin/tbp/experiments`

I've also added a unit test.

**Test Result**
```
===================================================================================================================================================================================================================== short test summary info =====================================================================================================================================================================================================================
SKIPPED [1] tests/unit/simulators/mujoco/__init__.py:14: MuJoCo optional dependency not installed.
==================================================================================================================================================================================================== 400 passed, 1 skipped, 103 warnings in 287.01s (0:04:47) ===================
```