### PR TITLE
fix: Add missing log stat to wandb

### DIFF
--- a/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
+++ b/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
@@ -445,6 +445,11 @@ class BasicGraphMatchingLogger(BaseMontyLogger):
                 "individual_ts_rotation_error"
             ]
 
+        for p in self.performance_options:
+            overall_stats[f"overall/percent_{p}_per_lm"] = (
+                stats[f"num_{p}_per_lm"] / (stats["num_episodes"] * len(self.lms))
+            ) * 100
+
         if len(self.lms) > 1:  # add histograms when running multiple LMs
             overall_stats["episode/rotation_error_per_lm"] = wandb.Histogram(episode_re)
             overall_stats["episode/steps_per_lm"] = wandb.Histogram(


### PR DESCRIPTION
When adding metric logging for the compositional object benchmark we noticed that we were tracking per lm performance stats but forgot to add them to the wandb logs. This adds them.