### PR TITLE
feat: Live plotting option for all MontyExperiment instances

### DIFF
--- a/src/tbp/monty/frameworks/experiments/data_collection_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/data_collection_experiments.py
@@ -34,7 +34,10 @@ class DataCollectionExperiment(MontyObjectRecognitionExperiment):
             if step > self.max_steps:
                 break
             if self.show_sensor_output:
-                self.live_plotter.show_observations(observation, self.model, step)
+                self.live_plotter.show_observations(
+                    *self.live_plotter.hardcoded_assumptions(observation, self.model),
+                    step,
+                )
             self.pass_features_to_motor_system(observation, step)
         self.post_episode()
 

--- a/src/tbp/monty/frameworks/experiments/data_collection_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/data_collection_experiments.py
@@ -10,14 +10,10 @@
 
 import os
 
-import matplotlib.pyplot as plt
 import torch
 from tqdm import tqdm
 
 from .object_recognition_experiments import MontyObjectRecognitionExperiment
-
-# turn interactive plotting off -- call plt.show() to open all figures
-plt.ioff()
 
 
 class DataCollectionExperiment(MontyObjectRecognitionExperiment):

--- a/src/tbp/monty/frameworks/experiments/data_collection_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/data_collection_experiments.py
@@ -38,7 +38,7 @@ class DataCollectionExperiment(MontyObjectRecognitionExperiment):
             if step > self.max_steps:
                 break
             if self.show_sensor_output:
-                self.show_observations(observation, step)
+                self.live_plotter.show_observations(observation, self.model, step)
             self.pass_features_to_motor_system(observation, step)
         self.post_episode()
 
@@ -73,7 +73,7 @@ class DataCollectionExperiment(MontyObjectRecognitionExperiment):
         self.max_steps = self.max_train_steps
         self.logger_handler.pre_episode(self.logger_args)
         if self.show_sensor_output:
-            self.initialize_online_plotting()
+            self.live_plotter.initialize_online_plotting()
 
     def post_episode(self):
         torch.save(

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -44,7 +44,7 @@ from tbp.monty.frameworks.utils.dataclass_utils import (
     config_to_dict,
     get_subset_of_args,
 )
-from tbp.monty.frameworks.utils.plot_utils import add_patch_outline_to_view_finder
+from tbp.monty.frameworks.utils.live_plotter import LivePlotter
 
 # turn interactive plotting off -- call plt.show() to open all figures
 plt.ioff()
@@ -73,6 +73,9 @@ class MontyExperiment:
         self.config = config
 
         self.unpack_experiment_args(config["experiment_args"])
+
+        if self.show_sensor_output:
+            self.live_plotter = LivePlotter()
 
     def setup_experiment(self, config: Dict[str, Any]) -> None:
         """Set up the basic elements of a Monty experiment and initialize counters.
@@ -490,7 +493,7 @@ class MontyExperiment:
         self.logger_handler.pre_episode(self.logger_args)
 
         if self.show_sensor_output:
-            self.initialize_online_plotting()
+            self.live_plotter.initialize_online_plotting()
 
     def post_episode(self, steps):
         """Call post_episode on elements in experiment and increment counters.
@@ -663,113 +666,3 @@ class MontyExperiment:
         """
         self.close()
         return False  # don't silence exceptions inside the with block
-
-    ####
-    # Live plotting
-    ####
-
-    def initialize_online_plotting(self):
-        self.fig, self.ax = plt.subplots(
-            1, 2, figsize=(9, 6), gridspec_kw={"width_ratios": [1, 0.8]}
-        )
-        self.fig.subplots_adjust(top=1.1)
-        # self.colorbar = self.fig.colorbar(None, fraction=0.046, pad=0.04)
-        self.setup_camera_ax()
-        self.setup_sensor_ax()
-
-    def show_observations(self, observation, step: int) -> None:
-        self.fig.suptitle(f"Observation at step {step}")
-        self.show_view_finder(observation, step)
-        self.show_patch(observation)
-        plt.pause(0.00001)
-
-    def show_view_finder(self, observation, step, sensor_id="view_finder"):
-        if self.camera_image:
-            self.camera_image.remove()
-
-        view_finder_image = observation[self.model.motor_system._policy.agent_id][
-            sensor_id
-        ]["rgba"]
-        if isinstance(self.dataloader, SaccadeOnImageDataLoader):
-            center_pixel_id = np.array([200, 200])
-            patch_size = np.array(
-                observation[self.model.motor_system._policy.agent_id]["patch"]["depth"]
-            ).shape[0]
-            raw_obs = self.model.sensor_modules[0].raw_observations
-            if len(raw_obs) > 0:
-                center_pixel_id = np.array(raw_obs[-1]["pixel_loc"])
-                view_finder_image = add_patch_outline_to_view_finder(
-                    view_finder_image, center_pixel_id, patch_size
-                )
-            self.camera_image = self.ax[0].imshow(view_finder_image, zorder=-99)
-        else:
-            self.camera_image = self.ax[0].imshow(
-                view_finder_image,
-                zorder=-99,
-            )
-            # Show a square in the middle as a rough estimate of where the patch is
-            if step == 0:
-                image_shape = observation[self.model.motor_system._policy.agent_id][
-                    sensor_id
-                ]["rgba"].shape
-                square = plt.Rectangle(
-                    (image_shape[1] * 4.5 // 10, image_shape[0] * 4.5 // 10),
-                    image_shape[1] / 10,
-                    image_shape[0] / 10,
-                    fc="none",
-                    ec="white",
-                )
-                self.ax[0].add_patch(square)
-        if hasattr(self.model.learning_modules[0].graph_memory, "current_mlh"):
-            mlh = self.model.learning_modules[0].get_current_mlh()
-            if mlh is not None:
-                self.add_text(mlh, pos=view_finder_image.shape[0])
-
-    def show_patch(self, observation, sensor_id="patch"):
-        if self.depth_image:
-            self.depth_image.remove()
-        self.depth_image = self.ax[1].imshow(
-            observation[self.model.motor_system._policy.agent_id][sensor_id]["depth"],
-            cmap="viridis_r",
-        )
-        # self.colorbar.update_normal(self.depth_image)
-
-    def add_text(self, mlh, pos):
-        if self.text:
-            self.text.remove()
-        new_text = r"MLH: "
-        mlh_id = mlh["graph_id"].split("_")
-        for word in mlh_id:
-            new_text += r"$\bf{" + word + "}$ "
-        new_text += f"with evidence {np.round(mlh['evidence'], 2)}\n\n"
-        pms = self.model.learning_modules[0].get_possible_matches()
-        graph_ids, evidences = self.model.learning_modules[
-            0
-        ].graph_memory.get_evidence_for_each_graph()
-
-        # Highlight 2nd MLH if present
-        if len(evidences) > 1:
-            top_indices = np.flip(np.argsort(evidences))[0:2]
-            second_id = graph_ids[top_indices[1]].split("_")
-            new_text += "2nd MLH: "
-            for word in second_id:
-                new_text += r"$\bf{" + word + "}$ "
-            new_text += f"with evidence {np.round(evidences[top_indices[1]], 2)}\n\n"
-
-        new_text += r"$\bf{Possible}$ $\bf{matches:}$"
-        for gid, ev in zip(graph_ids, evidences):
-            if gid in pms:
-                new_text += f"\n{gid}: {np.round(ev, 1)}"
-
-        self.text = self.ax[0].text(0, pos + 30, new_text, va="top")
-
-    def setup_camera_ax(self):
-        self.ax[0].set_title("Camera image")
-        self.ax[0].set_axis_off()
-        self.camera_image = None
-        self.text = None
-
-    def setup_sensor_ax(self):
-        self.ax[1].set_title("Sensor depth image")
-        self.ax[1].set_axis_off()
-        self.depth_image = None

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -16,7 +16,6 @@ import os
 import pprint
 from typing import Any, Dict, Literal
 
-import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from typing_extensions import Self
@@ -45,9 +44,6 @@ from tbp.monty.frameworks.utils.dataclass_utils import (
     get_subset_of_args,
 )
 from tbp.monty.frameworks.utils.live_plotter import LivePlotter
-
-# turn interactive plotting off -- call plt.show() to open all figures
-plt.ioff()
 
 __all__ = ["MontyExperiment"]
 

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -16,6 +16,7 @@ import os
 import pprint
 from typing import Any, Dict, Literal
 
+import matplotlib.pyplot as plt
 import numpy as np
 import torch
 from typing_extensions import Self
@@ -43,6 +44,10 @@ from tbp.monty.frameworks.utils.dataclass_utils import (
     config_to_dict,
     get_subset_of_args,
 )
+from tbp.monty.frameworks.utils.plot_utils import add_patch_outline_to_view_finder
+
+# turn interactive plotting off -- call plt.show() to open all figures
+plt.ioff()
 
 __all__ = ["MontyExperiment"]
 
@@ -484,6 +489,9 @@ class MontyExperiment:
 
         self.logger_handler.pre_episode(self.logger_args)
 
+        if self.show_sensor_output:
+            self.initialize_online_plotting()
+
     def post_episode(self, steps):
         """Call post_episode on elements in experiment and increment counters.
 
@@ -655,3 +663,113 @@ class MontyExperiment:
         """
         self.close()
         return False  # don't silence exceptions inside the with block
+
+    ####
+    # Live plotting
+    ####
+
+    def initialize_online_plotting(self):
+        self.fig, self.ax = plt.subplots(
+            1, 2, figsize=(9, 6), gridspec_kw={"width_ratios": [1, 0.8]}
+        )
+        self.fig.subplots_adjust(top=1.1)
+        # self.colorbar = self.fig.colorbar(None, fraction=0.046, pad=0.04)
+        self.setup_camera_ax()
+        self.setup_sensor_ax()
+
+    def show_observations(self, observation, step: int) -> None:
+        self.fig.suptitle(f"Observation at step {step}")
+        self.show_view_finder(observation, step)
+        self.show_patch(observation)
+        plt.pause(0.00001)
+
+    def show_view_finder(self, observation, step, sensor_id="view_finder"):
+        if self.camera_image:
+            self.camera_image.remove()
+
+        view_finder_image = observation[self.model.motor_system._policy.agent_id][
+            sensor_id
+        ]["rgba"]
+        if isinstance(self.dataloader, SaccadeOnImageDataLoader):
+            center_pixel_id = np.array([200, 200])
+            patch_size = np.array(
+                observation[self.model.motor_system._policy.agent_id]["patch"]["depth"]
+            ).shape[0]
+            raw_obs = self.model.sensor_modules[0].raw_observations
+            if len(raw_obs) > 0:
+                center_pixel_id = np.array(raw_obs[-1]["pixel_loc"])
+                view_finder_image = add_patch_outline_to_view_finder(
+                    view_finder_image, center_pixel_id, patch_size
+                )
+            self.camera_image = self.ax[0].imshow(view_finder_image, zorder=-99)
+        else:
+            self.camera_image = self.ax[0].imshow(
+                view_finder_image,
+                zorder=-99,
+            )
+            # Show a square in the middle as a rough estimate of where the patch is
+            if step == 0:
+                image_shape = observation[self.model.motor_system._policy.agent_id][
+                    sensor_id
+                ]["rgba"].shape
+                square = plt.Rectangle(
+                    (image_shape[1] * 4.5 // 10, image_shape[0] * 4.5 // 10),
+                    image_shape[1] / 10,
+                    image_shape[0] / 10,
+                    fc="none",
+                    ec="white",
+                )
+                self.ax[0].add_patch(square)
+        if hasattr(self.model.learning_modules[0].graph_memory, "current_mlh"):
+            mlh = self.model.learning_modules[0].get_current_mlh()
+            if mlh is not None:
+                self.add_text(mlh, pos=view_finder_image.shape[0])
+
+    def show_patch(self, observation, sensor_id="patch"):
+        if self.depth_image:
+            self.depth_image.remove()
+        self.depth_image = self.ax[1].imshow(
+            observation[self.model.motor_system._policy.agent_id][sensor_id]["depth"],
+            cmap="viridis_r",
+        )
+        # self.colorbar.update_normal(self.depth_image)
+
+    def add_text(self, mlh, pos):
+        if self.text:
+            self.text.remove()
+        new_text = r"MLH: "
+        mlh_id = mlh["graph_id"].split("_")
+        for word in mlh_id:
+            new_text += r"$\bf{" + word + "}$ "
+        new_text += f"with evidence {np.round(mlh['evidence'], 2)}\n\n"
+        pms = self.model.learning_modules[0].get_possible_matches()
+        graph_ids, evidences = self.model.learning_modules[
+            0
+        ].graph_memory.get_evidence_for_each_graph()
+
+        # Highlight 2nd MLH if present
+        if len(evidences) > 1:
+            top_indices = np.flip(np.argsort(evidences))[0:2]
+            second_id = graph_ids[top_indices[1]].split("_")
+            new_text += "2nd MLH: "
+            for word in second_id:
+                new_text += r"$\bf{" + word + "}$ "
+            new_text += f"with evidence {np.round(evidences[top_indices[1]], 2)}\n\n"
+
+        new_text += r"$\bf{Possible}$ $\bf{matches:}$"
+        for gid, ev in zip(graph_ids, evidences):
+            if gid in pms:
+                new_text += f"\n{gid}: {np.round(ev, 1)}"
+
+        self.text = self.ax[0].text(0, pos + 30, new_text, va="top")
+
+    def setup_camera_ax(self):
+        self.ax[0].set_title("Camera image")
+        self.ax[0].set_axis_off()
+        self.camera_image = None
+        self.text = None
+
+    def setup_sensor_ax(self):
+        self.ax[1].set_title("Sensor depth image")
+        self.ax[1].set_axis_off()
+        self.depth_image = None

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -81,8 +81,7 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
                     self.dataloader, SaccadeOnImageDataLoader
                 )
                 self.live_plotter.show_observations(
-                    observation,
-                    self.model,
+                    *self.live_plotter.hardcoded_assumptions(observation, self.model),
                     loader_step,
                     is_saccade_on_image_data_loader,
                 )

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -11,17 +11,9 @@
 import logging
 import os
 
-import matplotlib.pyplot as plt
-import numpy as np
 import torch
 
-from tbp.monty.frameworks.environments.embodied_data import SaccadeOnImageDataLoader
-from tbp.monty.frameworks.utils.plot_utils import add_patch_outline_to_view_finder
-
 from .monty_experiment import MontyExperiment
-
-# turn interactive plotting off -- call plt.show() to open all figures
-plt.ioff()
 
 logger = logging.getLogger(__name__)
 
@@ -115,115 +107,6 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
         # handle case where spiral policy calls StopIterator in motor policy
         self.model.set_is_done()
         return loader_step
-
-    def initialize_online_plotting(self):
-        self.fig, self.ax = plt.subplots(
-            1, 2, figsize=(9, 6), gridspec_kw={"width_ratios": [1, 0.8]}
-        )
-        self.fig.subplots_adjust(top=1.1)
-        # self.colorbar = self.fig.colorbar(None, fraction=0.046, pad=0.04)
-        self.setup_camera_ax()
-        self.setup_sensor_ax()
-
-    def show_observations(self, observation, step: int) -> None:
-        self.fig.suptitle(
-            f"Observation at step {step}"
-            + ("" if step == 0 else f"\n{self.dataloader._action.name}")
-        )
-        self.show_view_finder(observation, step)
-        self.show_patch(observation)
-        plt.pause(0.00001)
-
-    def show_view_finder(self, observation, step, sensor_id="view_finder"):
-        if self.camera_image:
-            self.camera_image.remove()
-
-        view_finder_image = observation[self.model.motor_system._policy.agent_id][
-            sensor_id
-        ]["rgba"]
-        if isinstance(self.dataloader, SaccadeOnImageDataLoader):
-            center_pixel_id = np.array([200, 200])
-            patch_size = np.array(
-                observation[self.model.motor_system._policy.agent_id]["patch"]["depth"]
-            ).shape[0]
-            raw_obs = self.model.sensor_modules[0].raw_observations
-            if len(raw_obs) > 0:
-                center_pixel_id = np.array(raw_obs[-1]["pixel_loc"])
-                view_finder_image = add_patch_outline_to_view_finder(
-                    view_finder_image, center_pixel_id, patch_size
-                )
-            self.camera_image = self.ax[0].imshow(view_finder_image, zorder=-99)
-        else:
-            self.camera_image = self.ax[0].imshow(
-                view_finder_image,
-                zorder=-99,
-            )
-            # Show a square in the middle as a rough estimate of where the patch is
-            if step == 0:
-                image_shape = observation[self.model.motor_system._policy.agent_id][
-                    sensor_id
-                ]["rgba"].shape
-                square = plt.Rectangle(
-                    (image_shape[1] * 4.5 // 10, image_shape[0] * 4.5 // 10),
-                    image_shape[1] / 10,
-                    image_shape[0] / 10,
-                    fc="none",
-                    ec="white",
-                )
-                self.ax[0].add_patch(square)
-        if hasattr(self.model.learning_modules[0].graph_memory, "current_mlh"):
-            mlh = self.model.learning_modules[0].get_current_mlh()
-            if mlh is not None:
-                self.add_text(mlh, pos=view_finder_image.shape[0])
-
-    def show_patch(self, observation, sensor_id="patch"):
-        if self.depth_image:
-            self.depth_image.remove()
-        self.depth_image = self.ax[1].imshow(
-            observation[self.model.motor_system._policy.agent_id][sensor_id]["depth"],
-            cmap="viridis_r",
-        )
-        # self.colorbar.update_normal(self.depth_image)
-
-    def add_text(self, mlh, pos):
-        if self.text:
-            self.text.remove()
-        new_text = r"MLH: "
-        mlh_id = mlh["graph_id"].split("_")
-        for word in mlh_id:
-            new_text += r"$\bf{" + word + "}$ "
-        new_text += f"with evidence {np.round(mlh['evidence'], 2)}\n\n"
-        pms = self.model.learning_modules[0].get_possible_matches()
-        graph_ids, evidences = self.model.learning_modules[
-            0
-        ].graph_memory.get_evidence_for_each_graph()
-
-        # Highlight 2nd MLH if present
-        if len(evidences) > 1:
-            top_indices = np.flip(np.argsort(evidences))[0:2]
-            second_id = graph_ids[top_indices[1]].split("_")
-            new_text += "2nd MLH: "
-            for word in second_id:
-                new_text += r"$\bf{" + word + "}$ "
-            new_text += f"with evidence {np.round(evidences[top_indices[1]], 2)}\n\n"
-
-        new_text += r"$\bf{Possible}$ $\bf{matches:}$"
-        for gid, ev in zip(graph_ids, evidences):
-            if gid in pms:
-                new_text += f"\n{gid}: {np.round(ev, 1)}"
-
-        self.text = self.ax[0].text(0, pos + 30, new_text, va="top")
-
-    def setup_camera_ax(self):
-        self.ax[0].set_title("Camera image")
-        self.ax[0].set_axis_off()
-        self.camera_image = None
-        self.text = None
-
-    def setup_sensor_ax(self):
-        self.ax[1].set_title("Sensor depth image")
-        self.ax[1].set_axis_off()
-        self.depth_image = None
 
 
 class MontyGeneralizationExperiment(MontyObjectRecognitionExperiment):

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -13,6 +13,8 @@ import os
 
 import torch
 
+from tbp.monty.frameworks.environments.embodied_data import SaccadeOnImageDataLoader
+
 from .monty_experiment import MontyExperiment
 
 logger = logging.getLogger(__name__)
@@ -61,7 +63,7 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
         self.logger_handler.pre_episode(self.logger_args)
 
         if self.show_sensor_output:
-            self.initialize_online_plotting()
+            self.live_plotter.initialize_online_plotting()
 
     def run_episode_steps(self):
         """Runs one episode of the experiment.
@@ -75,7 +77,15 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
         """
         for loader_step, observation in enumerate(self.dataloader):
             if self.show_sensor_output:
-                self.show_observations(observation, loader_step)
+                is_saccade_on_image_data_loader = isinstance(
+                    self.dataloader, SaccadeOnImageDataLoader
+                )
+                self.live_plotter.show_observations(
+                    observation,
+                    self.model,
+                    loader_step,
+                    is_saccade_on_image_data_loader,
+                )
 
             if self.model.check_reached_max_matching_steps(self.max_steps):
                 logger.info(

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -91,7 +91,9 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
                     self.dataloader, SaccadeOnImageDataLoader
                 )
                 self.live_plotter.show_observations(
-                    observation, self.model, num_steps, is_saccade_on_image_data_loader
+                    *self.live_plotter.hardcoded_assumptions(observation, self.model),
+                    num_steps,
+                    is_saccade_on_image_data_loader,
                 )
             self.model.step(observation)
             if self.model.is_done:

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -82,6 +82,8 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
         num_steps = 0
         for observation in self.dataloader:
             num_steps += 1
+            if self.show_sensor_output:
+                self.show_observations(observation, num_steps)
             self.model.step(observation)
             if self.model.is_done:
                 break
@@ -114,6 +116,9 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
         self.max_steps = self.max_train_steps  # no eval mode here
 
         self.logger_handler.pre_episode(self.logger_args)
+
+        if self.show_sensor_output:
+            self.initialize_online_plotting()
 
     def post_epoch(self):
         """Post epoch without saving state_dict."""

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -14,6 +14,7 @@ import os
 import numpy as np
 from scipy.spatial.transform import Rotation
 
+from tbp.monty.frameworks.environments.embodied_data import SaccadeOnImageDataLoader
 from tbp.monty.frameworks.utils.dataclass_utils import config_to_dict
 
 from .monty_experiment import MontyExperiment
@@ -83,7 +84,12 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
         for observation in self.dataloader:
             num_steps += 1
             if self.show_sensor_output:
-                self.show_observations(observation, num_steps)
+                is_saccade_on_image_data_loader = isinstance(
+                    self.dataloader, SaccadeOnImageDataLoader
+                )
+                self.live_plotter.show_observations(
+                    observation, self.model, num_steps, is_saccade_on_image_data_loader
+                )
             self.model.step(observation)
             if self.model.is_done:
                 break
@@ -118,7 +124,7 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
         self.logger_handler.pre_episode(self.logger_args)
 
         if self.show_sensor_output:
-            self.initialize_online_plotting()
+            self.live_plotter.initialize_online_plotting()
 
     def post_epoch(self):
         """Post epoch without saving state_dict."""

--- a/src/tbp/monty/frameworks/utils/live_plotter.py
+++ b/src/tbp/monty/frameworks/utils/live_plotter.py
@@ -1,0 +1,133 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from tbp.monty.frameworks.utils.plot_utils import add_patch_outline_to_view_finder
+
+
+class LivePlotter:
+    def __init__(self):
+        pass
+
+    def initialize_online_plotting(self):
+        self.fig, self.ax = plt.subplots(
+            1, 2, figsize=(9, 6), gridspec_kw={"width_ratios": [1, 0.8]}
+        )
+        self.fig.subplots_adjust(top=1.1)
+        # self.colorbar = self.fig.colorbar(None, fraction=0.046, pad=0.04)
+        self.setup_camera_ax()
+        self.setup_sensor_ax()
+
+    def show_observations(
+        self, observation, model, step: int, is_saccade_on_image_data_loader=False
+    ) -> None:
+        self.fig.suptitle(f"Observation at step {step}")
+        self.show_view_finder(observation, model, step, is_saccade_on_image_data_loader)
+        self.show_patch(observation, model)
+        plt.pause(0.00001)
+
+    def show_view_finder(
+        self,
+        observation,
+        model,
+        step,
+        is_saccade_on_image_data_loader,
+        sensor_id="view_finder",
+    ):
+        if self.camera_image:
+            self.camera_image.remove()
+
+        view_finder_image = observation[model.motor_system._policy.agent_id][sensor_id][
+            "rgba"
+        ]
+        if is_saccade_on_image_data_loader:
+            center_pixel_id = np.array([200, 200])
+            patch_size = np.array(
+                observation[model.motor_system._policy.agent_id]["patch"]["depth"]
+            ).shape[0]
+            raw_obs = model.sensor_modules[0].raw_observations
+            if len(raw_obs) > 0:
+                center_pixel_id = np.array(raw_obs[-1]["pixel_loc"])
+                view_finder_image = add_patch_outline_to_view_finder(
+                    view_finder_image, center_pixel_id, patch_size
+                )
+            self.camera_image = self.ax[0].imshow(view_finder_image, zorder=-99)
+        else:
+            self.camera_image = self.ax[0].imshow(
+                view_finder_image,
+                zorder=-99,
+            )
+            # Show a square in the middle as a rough estimate of where the patch is
+            # Note: This isn't exactly the size that the patch actually is.
+            image_shape = observation[model.motor_system._policy.agent_id][sensor_id][
+                "rgba"
+            ].shape
+            square = plt.Rectangle(
+                (image_shape[1] * 4.5 // 10, image_shape[0] * 4.5 // 10),
+                image_shape[1] / 10,
+                image_shape[0] / 10,
+                fc="none",
+                ec="white",
+            )
+            self.ax[0].add_patch(square)
+        if hasattr(model.learning_modules[0].graph_memory, "current_mlh"):
+            mlh = model.learning_modules[0].get_current_mlh()
+            if mlh is not None:
+                self.add_text(mlh, pos=view_finder_image.shape[0], model=model)
+
+    def show_patch(self, observation, model, sensor_id="patch"):
+        if self.depth_image:
+            self.depth_image.remove()
+        self.depth_image = self.ax[1].imshow(
+            observation[model.motor_system._policy.agent_id][sensor_id]["depth"],
+            cmap="viridis_r",
+        )
+        # self.colorbar.update_normal(self.depth_image)
+
+    def add_text(self, mlh, pos, model):
+        if self.text:
+            self.text.remove()
+        new_text = r"MLH: "
+        mlh_id = mlh["graph_id"].split("_")
+        for word in mlh_id:
+            new_text += r"$\bf{" + word + "}$ "
+        new_text += f"with evidence {np.round(mlh['evidence'], 2)}\n\n"
+        pms = model.learning_modules[0].get_possible_matches()
+        graph_ids, evidences = model.learning_modules[
+            0
+        ].graph_memory.get_evidence_for_each_graph()
+
+        # Highlight 2nd MLH if present
+        if len(evidences) > 1:
+            top_indices = np.flip(np.argsort(evidences))[0:2]
+            second_id = graph_ids[top_indices[1]].split("_")
+            new_text += "2nd MLH: "
+            for word in second_id:
+                new_text += r"$\bf{" + word + "}$ "
+            new_text += f"with evidence {np.round(evidences[top_indices[1]], 2)}\n\n"
+
+        new_text += r"$\bf{Possible}$ $\bf{matches:}$"
+        for gid, ev in zip(graph_ids, evidences):
+            if gid in pms:
+                new_text += f"\n{gid}: {np.round(ev, 1)}"
+
+        self.text = self.ax[0].text(0, pos + 30, new_text, va="top")
+
+    def setup_camera_ax(self):
+        self.ax[0].set_title("Camera image")
+        self.ax[0].set_axis_off()
+        self.camera_image = None
+        self.text = None
+
+    def setup_sensor_ax(self):
+        self.ax[1].set_title("Sensor depth image")
+        self.ax[1].set_axis_off()
+        self.depth_image = None

--- a/src/tbp/monty/frameworks/utils/live_plotter.py
+++ b/src/tbp/monty/frameworks/utils/live_plotter.py
@@ -17,6 +17,18 @@ plt.ioff()
 
 
 class LivePlotter:
+    """Class for plotting sensor observations during an experiment.
+
+    Set the `show_sensor_output` flag in the experiment config to True to enable live
+    plotting.
+
+    WARNING: This plotter makes a bunch of assumptions right now. For example, it
+    assumes that
+    - sensor with ID "view_finder" exists
+    - sensor with ID "patch" exists
+    - "rgba" modality in "view_finder" sensor observation
+    - "depth" modality in "patch" sensor observation
+    """
     def __init__(self):
         pass
 

--- a/src/tbp/monty/frameworks/utils/live_plotter.py
+++ b/src/tbp/monty/frameworks/utils/live_plotter.py
@@ -29,6 +29,7 @@ class LivePlotter:
     - "rgba" modality in "view_finder" sensor observation
     - "depth" modality in "patch" sensor observation
     """
+
     def __init__(self):
         pass
 

--- a/src/tbp/monty/frameworks/utils/live_plotter.py
+++ b/src/tbp/monty/frameworks/utils/live_plotter.py
@@ -12,6 +12,9 @@ import numpy as np
 
 from tbp.monty.frameworks.utils.plot_utils import add_patch_outline_to_view_finder
 
+# turn interactive plotting off -- call plt.show() to open all figures
+plt.ioff()
+
 
 class LivePlotter:
     def __init__(self):


### PR DESCRIPTION
Previously the `show_sensor_output` option only worked for instances of `MontyObjectRecognitionExperiment`. However, there is nothing that prevents us from using the same feature in other `MontyExperiment` instances such as `MontySupervisedObjectPretrainingExperiment`. I moved the plotting code to the parent class and added the corresponding init and plot calls to `MontySupervisedObjectPretrainingExperiment`.