### PR TITLE
feat!: add locations to resampling telemetry

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching/resampling_hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/resampling_hypotheses_updater.py
@@ -312,6 +312,9 @@ class ResamplingHypothesesUpdater:
             )
             hypotheses_updates.append(channel_hypotheses)
 
+            # Update tracker evidence
+            tracker.update(channel_hypotheses.evidence, input_channel)
+
             if self.include_telemetry:
                 resampling_telemetry[input_channel] = asdict(
                     ChannelHypothesesResamplingTelemetry(
@@ -327,9 +330,6 @@ class ResamplingHypothesesUpdater:
                         removed_ids=remove_ids,
                     )
                 )
-
-            # Update tracker evidence
-            tracker.update(channel_hypotheses.evidence, input_channel)
 
         return (
             hypotheses_updates,

--- a/src/tbp/monty/frameworks/models/mixins/no_reset_evidence.py
+++ b/src/tbp/monty/frameworks/models/mixins/no_reset_evidence.py
@@ -39,6 +39,9 @@ class HypothesesUpdaterChannelTelemetry:
 
     Note that the buffer encoder will encode those as euler "xyz" rotations in degrees.
     """
+    locations: npt.NDArray[np.float64]
+    """Locations of the hypotheses."""
+
     pose_errors: npt.NDArray[np.float64]
     """Rotation errors relative to the target pose."""
 
@@ -137,11 +140,15 @@ class TheoreticalLimitLMLoggingMixin:
         channel_rotations = mapper.extract(self.possible_poses[graph_id], input_channel)
         channel_rotations_inv = Rotation.from_matrix(channel_rotations).inv()
         channel_evidence = mapper.extract(self.evidence[graph_id], input_channel)
+        channel_locations = mapper.extract(
+            self.possible_locations[graph_id], input_channel
+        )
 
         return HypothesesUpdaterChannelTelemetry(
             hypotheses_updater=channel_telemetry.copy(),
             evidence=channel_evidence,
             rotations=channel_rotations_inv,
+            locations=channel_locations,
             pose_errors=cast(
                 npt.NDArray[np.float64],
                 compute_pose_errors(

--- a/tests/unit/frameworks/models/mixins/no_reset_evidence_test.py
+++ b/tests/unit/frameworks/models/mixins/no_reset_evidence_test.py
@@ -44,6 +44,7 @@ class HypothesesUpdaterChannelTelemetryTest(TestCase):
             hypotheses_updater={},
             evidence=np.array([0, 1]),
             rotations=np.array([0, 1]),
+            locations=np.array([0, 1]),
             pose_errors=np.array([0, 1]),
         )
         encoded = json.loads(json.dumps(telemetry, cls=BufferEncoder))
@@ -53,6 +54,7 @@ class HypothesesUpdaterChannelTelemetryTest(TestCase):
                 "hypotheses_updater": {},
                 "evidence": [0, 1],
                 "rotations": [0, 1],
+                "locations": [0, 1],
                 "pose_errors": [0, 1],
             },
         )


### PR DESCRIPTION
This PR adds channel locations to the resampling telemetry in [eda1063dcf6a](https://github.com/ramyamounir/tbp.monty/commit/eda1063dcf6a780c575b8690ffe9864cb60f8764). We need this information to show the hypotheses sensor locations in the interactive plots.

The PR also introduces a breaking fix in [33e2c2f31856](https://github.com/ramyamounir/tbp.monty/commit/33e2c2f3185671c9a097353e56941937c86711d8) that moves telemetry collection until after the tracker updates. Now the evidence slopes make more sense as they make use of the latest evidence scores at every step.