### PR TITLE
docs: update benchmark results after pytorch upgrade

### DIFF
--- a/benchmarks/results/ycb_10objs.csv
+++ b/benchmarks/results/ycb_10objs.csv
@@ -1,13 +1,13 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
 base_config_10distinctobj_dist_agent,100.00,0.00,37,16.20,2,8
 base_config_10distinctobj_surf_agent,100.00,0.00,28,14.01,2,11
-randrot_noise_10distinctobj_dist_agent,100.00,3.00,55,22.49,3,20
-randrot_noise_10distinctobj_dist_on_distm,99.00,1.00,38,12.15,3,18
+randrot_noise_10distinctobj_dist_agent,100.00,3.00,55,22.49,3,21
+randrot_noise_10distinctobj_dist_on_distm,99.00,1.00,38,12.15,2,17
 randrot_noise_10distinctobj_surf_agent,100.00,1.00,29,20.42,3,21
 randrot_10distinctobj_surf_agent,100.00,0.00,28,17.23,2,10
-randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.48,5,40
-base_10simobj_surf_agent,93.57,8.57,70,13.98,6,27
-randrot_noise_10simobj_dist_agent,84.00,40.00,237,35.01,11,93
-randrot_noise_10simobj_surf_agent,93.00,34.00,172,20.94,16,137
+randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,57,45.48,5,45
+base_10simobj_surf_agent,93.57,8.57,70,13.98,5,25
+randrot_noise_10simobj_dist_agent,84.00,40.00,237,35.01,11,91
+randrot_noise_10simobj_surf_agent,93.00,34.00,172,20.94,16,135
 randomrot_rawnoise_10distinctobj_surf_agent,64.00,77.00,16,106.51,4,7
 base_10multi_distinctobj_dist_agent,79.29,10.71,31,19.84,3,1

--- a/benchmarks/results/ycb_77objs.csv
+++ b/benchmarks/results/ycb_77objs.csv
@@ -1,6 +1,6 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
-base_77obj_dist_agent,93.51,12.99,108,15.86,21,71
-base_77obj_surf_agent,98.70,6.49,56,12.94,12,34
-randrot_noise_77obj_dist_agent,89.61,22.51,152,37.47,31,112
-randrot_noise_77obj_surf_agent,93.94,23.38,115,34.80,32,113
-randrot_noise_77obj_5lms_dist_agent,88.31,0.00,70,58.25,10,99
+base_77obj_dist_agent,93.51,12.99,108,15.86,22,72
+base_77obj_surf_agent,98.70,6.49,56,12.94,13,37
+randrot_noise_77obj_dist_agent,89.61,22.51,152,37.47,34,123
+randrot_noise_77obj_surf_agent,93.94,23.38,114,35.36,31,112
+randrot_noise_77obj_5lms_dist_agent,88.31,0.00,70,58.25,9,93

--- a/benchmarks/results/ycb_unsupervised_inference.csv
+++ b/benchmarks/results/ycb_unsupervised_inference.csv
@@ -1,3 +1,3 @@
 Experiment,Correct (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
-unsupervised_inference_distinctobj_dist_agent,96.00,100,26,16
-unsupervised_inference_distinctobj_surf_agent,94.00,99,19,11
+unsupervised_inference_distinctobj_dist_agent,98.00,99,25,15
+unsupervised_inference_distinctobj_surf_agent,95.00,100,23,14


### PR DESCRIPTION
This updates the benchmark results to the latest. More context can be found in [PR#457](https://github.com/thousandbrainsproject/tbp.monty/pull/457).

### Benchmark changes


### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 37 | 37 | 0 | ⬜ |
| rotation_error (deg) | 16.2 | 16.2 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 8 | 8 | 0 | ⬜ |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 14.01 | 14.01 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 11 | 11 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 3 | 3 | 0 | ⬜ |
| match_steps | 55 | 55 | 0 | ⬜ |
| rotation_error (deg) | 22.49 | 22.49 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 20 | 21 | 1 | ❌ |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99 | 99 | 0 | ⬜ |
| used_mlh (%) | 1 | 1 | 0 | ⬜ |
| match_steps | 38 | 38 | 0 | ⬜ |
| rotation_error (deg) | 12.15 | 12.15 | 0 | ⬜ |
| runtime (min) | 3 | 2 | -1 | ✅ |
| episode_runtime (sec) | 18 | 17 | -1 | ✅ |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 1 | 1 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 20.42 | 20.42 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 21 | 21 | 0 | ⬜ |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 17.23 | 17.23 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 10 | 10 | 0 | ⬜ |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 57 | 57 | 0 | ⬜ |
| rotation_error (deg) | 45.48 | 45.48 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 40 | 45 | 5 | ❌ |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 93.57 | 93.57 | 0 | ⬜ |
| used_mlh (%) | 9 | 9 | 0 | ⬜ |
| match_steps | 70 | 70 | 0 | ⬜ |
| rotation_error (deg) | 13.98 | 13.98 | 0 | ⬜ |
| runtime (min) | 6 | 5 | -1 | ✅ |
| episode_runtime (sec) | 27 | 25 | -2 | ✅ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 84 | 84 | 0 | ⬜ |
| used_mlh (%) | 40 | 40 | 0 | ⬜ |
| match_steps | 237 | 237 | 0 | ⬜ |
| rotation_error (deg) | 35.01 | 35.01 | 0 | ⬜ |
| runtime (min) | 11 | 11 | 0 | ⬜ |
| episode_runtime (sec) | 93 | 91 | -2 | ✅ |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 93 | 93 | 0 | ⬜ |
| used_mlh (%) | 34 | 34 | 0 | ⬜ |
| match_steps | 172 | 172 | 0 | ⬜ |
| rotation_error (deg) | 20.94 | 20.94 | 0 | ⬜ |
| runtime (min) | 16 | 16 | 0 | ⬜ |
| episode_runtime (sec) | 137 | 135 | -2 | ✅ |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 64 | 64 | 0 | ⬜ |
| used_mlh (%) | 77 | 77 | 0 | ⬜ |
| match_steps | 16 | 16 | 0 | ⬜ |
| rotation_error (deg) | 106.51 | 106.51 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 7 | 0 | ⬜ |

### base_10multi_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 79.29 | 79.29 | 0 | ⬜ |
| used_mlh (%) | 11 | 11 | 0 | ⬜ |
| match_steps | 31 | 31 | 0 | ⬜ |
| rotation_error (deg) | 19.84 | 19.84 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 1 | 1 | 0 | ⬜ |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 93.51 | 93.51 | 0 | ⬜ |
| used_mlh (%) | 13 | 13 | 0 | ⬜ |
| match_steps | 108 | 108 | 0 | ⬜ |
| rotation_error (deg) | 15.86 | 15.86 | 0 | ⬜ |
| runtime (min) | 21 | 22 | 1 | ❌ |
| episode_runtime (sec) | 71 | 72 | 1 | ❌ |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.7 | 98.7 | 0 | ⬜ |
| used_mlh (%) | 6 | 6 | 0 | ⬜ |
| match_steps | 56 | 56 | 0 | ⬜ |
| rotation_error (deg) | 12.94 | 12.94 | 0 | ⬜ |
| runtime (min) | 12 | 13 | 1 | ❌ |
| episode_runtime (sec) | 34 | 37 | 3 | ❌ |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 89.61 | 89.61 | 0 | ⬜ |
| used_mlh (%) | 23 | 23 | 0 | ⬜ |
| match_steps | 152 | 152 | 0 | ⬜ |
| rotation_error (deg) | 37.47 | 37.47 | 0 | ⬜ |
| runtime (min) | 31 | 34 | 3 | ❌ |
| episode_runtime (sec) | 112 | 123 | 11 | ❌ |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 93.94 | 93.94 | 0 | ⬜ |
| used_mlh (%) | 23 | 23 | 0 | ⬜ |
| match_steps | 115 | 114 | -1 | ✅ |
| rotation_error (deg) | 34.8 | 35.36 | 0.56 | ❌ |
| runtime (min) | 32 | 31 | -1 | ✅ |
| episode_runtime (sec) | 113 | 112 | -1 | ✅ |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 88.31 | 88.31 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 70 | 70 | 0 | ⬜ |
| rotation_error (deg) | 58.25 | 58.25 | 0 | ⬜ |
| runtime (min) | 10 | 9 | -1 | ✅ |
| episode_runtime (sec) | 99 | 93 | -6 | ✅ |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96 | 98 | 2 | ✅ |
| match_steps | 100 | 99 | -1 | ✅ |
| runtime (min) | 26 | 25 | -1 | ✅ |
| episode_runtime (sec) | 16 | 15 | -1 | ✅ |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 94 | 95 | 1 | ✅ |
| match_steps | 99 | 100 | 1 | ❌ |
| runtime (min) | 19 | 23 | 4 | ❌ |
| episode_runtime (sec) | 11 | 14 | 3 | ❌ |
