### PR TITLE
refactor!: ensure update of "all" hypotheses with ResamplingHypothesesUpdater

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
@@ -82,6 +82,7 @@ class DefaultHypothesesUpdater:
         graph_memory: EvidenceGraphMemory,
         max_match_distance: float,
         tolerances: dict,
+        evidence_threshold_config: float | str = "all",
         feature_evidence_calculator: type[FeatureEvidenceCalculator] = (
             DefaultFeatureEvidenceCalculator
         ),
@@ -108,6 +109,15 @@ class DefaultHypothesesUpdater:
                 to be matched.
             tolerances: How much can each observed feature deviate from the
                 stored features to still be considered a match.
+            evidence_threshold_config: How to decide which hypotheses
+                should be updated. When this parameter is either '[int]%' or
+                'x_percent_threshold', then this parameter is applied to the evidence
+                for the Most Likely Hypothesis (MLH) to determine a minimum evidence
+                threshold in order for other hypotheses to be updated. Any hypotheses
+                falling below the resulting evidence threshold do not get updated. The
+                other options set a fixed threshold that does not take MLH evidence into
+                account. In [int, float, '[int]%', 'mean', 'median', 'all',
+                'x_percent_threshold']. Defaults to 'all'.
             feature_evidence_calculator: Class to
                 calculate feature evidence for all nodes. Defaults to the default
                 calculator.

--- a/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
@@ -243,6 +243,7 @@ class EvidenceGraphLM(GraphLM):
         # either constructed or edited in the constructor, or they are shared with the
         # learning module.
         hypotheses_updater_args.update(
+            evidence_threshold_config=self.evidence_threshold_config,
             feature_evidence_increment=self.feature_evidence_increment,
             feature_weights=self.feature_weights,
             graph_memory=self.graph_memory,

--- a/src/tbp/monty/frameworks/models/evidence_matching/resampling_hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/resampling_hypotheses_updater.py
@@ -41,6 +41,7 @@ from tbp.monty.frameworks.models.evidence_matching.hypotheses_updater import (
 from tbp.monty.frameworks.utils.evidence_matching import (
     ChannelMapper,
     EvidenceSlopeTracker,
+    InvalidEvidenceThresholdConfig,
 )
 from tbp.monty.frameworks.utils.graph_matching_utils import (
     get_initial_possible_poses,
@@ -101,6 +102,7 @@ class ResamplingHypothesesUpdater:
         graph_memory: EvidenceGraphMemory,
         max_match_distance: float,
         tolerances: dict,
+        evidence_threshold_config: Literal["all"],
         feature_evidence_calculator: Type[FeatureEvidenceCalculator] = (
             DefaultFeatureEvidenceCalculator
         ),
@@ -130,6 +132,10 @@ class ResamplingHypothesesUpdater:
                 to be matched.
             tolerances: How much can each observed feature deviate from the
                 stored features to still be considered a match.
+            evidence_threshold_config: How to decide which hypotheses
+                should be updated. In the `ResamplingHypothesesUpdater` we always
+                update 'all' hypotheses. Hypotheses with decreasing evidence are deleted
+                instead of excluded from updating. Must be set to 'all'.
             feature_evidence_calculator: Class to calculate feature evidence for all
                 nodes. Defaults to the default calculator.
             feature_evidence_increment: Feature evidence (between 0 and 1) is
@@ -166,7 +172,18 @@ class ResamplingHypothesesUpdater:
             umbilical_num_poses: Number of sampled rotations in the direction of
                 the plane perpendicular to the surface normal. These are sampled at
                 umbilical points (i.e., points where PC directions are undefined).
+
+        Raises:
+            InvalidEvidenceThresholdConfig: If `evidence_threshold_config` is not
+                set to "all".
+
         """
+        if evidence_threshold_config != "all":
+            raise InvalidEvidenceThresholdConfig(
+                "evidence_threshold_config must be "
+                "'all' for `ResamplingHypothesesUpdater`"
+            )
+
         self.feature_evidence_calculator = feature_evidence_calculator
         self.feature_evidence_increment = feature_evidence_increment
         self.feature_weights = feature_weights


### PR DESCRIPTION
Until now we've allowed `ResamplingHypothesesUpdater` to use any `evidence_threshold_config`. This should not be allowed when resampling. During resampling, hypotheses are deleted instead of being excluded from updating. This PR ensures that the config specifies `evidence_threshold_config="all"` when the `ResamplingHypothesesUpdater` is being used. Otherwise, `InvalidEvidenceThresholdConfig` exception is raised.