### PR TITLE
refactor!: return list of GoalStates instead of one or None

### DIFF
--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -192,8 +192,8 @@ class LearningModule(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def propose_goal_state(self) -> GoalState | None:
-        """Return the goal-state proposed by this LM's GSG if it exists."""
+    def propose_goal_states(self) -> list[GoalState]:
+        """Return the goal-states proposed by this LM's GSG if they exist."""
         pass
 
     @abc.abstractmethod
@@ -278,8 +278,8 @@ class GoalStateGenerator(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def get_output_goal_state(self):
-        """Return current output goal-state."""
+    def output_goal_states(self) -> list[GoalState]:
+        """Return output goal-states."""
         pass
 
     @abc.abstractmethod

--- a/src/tbp/monty/frameworks/models/goal_state_generation.py
+++ b/src/tbp/monty/frameworks/models/goal_state_generation.py
@@ -124,15 +124,15 @@ class GraphGoalStateGenerator(GoalStateGenerator):
 
         self.driving_goal_state = received_goal_state
 
-    def get_output_goal_state(self) -> GoalState | None:
-        """Retrieve the output goal-state of the GSG.
+    def output_goal_states(self) -> list[GoalState]:
+        """Retrieve the output goal-states of the GSG.
 
         This is the goal-state projected to other LM's GSGs +/- motor-actuators.
 
         Returns:
-            Output goal-state of the GSG if it exists, otherwise None.
+            Output goal-states of the GSG if it exists, otherwise empty list.
         """
-        return self.output_goal_state
+        return [self.output_goal_state] if self.output_goal_state else []
 
     # ------------------- Main Algorithm -----------------------
 

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -721,15 +721,15 @@ class GraphLM(LearningModule):
         """
         pass
 
-    def propose_goal_state(self) -> GoalState | None:
-        """Return the goal-state proposed by this LM's GSG.
+    def propose_goal_states(self) -> list[GoalState]:
+        """Return the goal-states proposed by this LM's GSG.
 
-        Only returned if the LM/GSG was stepped, otherwise returns None goal-state.
+        Only returned if the LM/GSG was stepped, otherwise returns empty list.
         """
         if self.buffer.get_last_obs_processed() and self.gsg is not None:
-            return self.gsg.get_output_goal_state()
+            return self.gsg.output_goal_states()
         else:
-            return None
+            return []
 
     def update_terminal_condition(self):
         """Check if we have reached a terminal condition for this episode.

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -284,9 +284,8 @@ class MontyBase(Monty):
         # Currently only use GSG outputs at inference
         if self.step_type == "matching_step":
             for lm in self.learning_modules:
-                goal_state = lm.propose_goal_state()
-                if goal_state is not None:
-                    self.gsg_outputs.append(goal_state)
+                goal_states = lm.propose_goal_states()
+                self.gsg_outputs.extend(goal_states)
 
     def _pass_infos_to_motor_system(self):
         """Pass input observations and goal states to the motor system."""

--- a/tests/unit/frameworks/models/fakes/learning_modules.py
+++ b/tests/unit/frameworks/models/fakes/learning_modules.py
@@ -51,8 +51,8 @@ class FakeLearningModule(LearningModule):
     def set_experiment_mode(self, inputs):
         pass
 
-    def propose_goal_state(self) -> GoalState | None:
-        pass
+    def propose_goal_states(self) -> list[GoalState]:
+        return []
 
     def get_output(self):
         pass


### PR DESCRIPTION
In preparation for the Sensor Module Goal State Generator, update the Goal State Generator and Learning Module API to return a list of GoalStates instead of expecting one or None.