### PR TITLE
fix: "no attribute 'geoms'" error after `pip install mujoco`

### DIFF
--- a/tests/unit/simulators/mujoco/mujoco_simulator_test.py
+++ b/tests/unit/simulators/mujoco/mujoco_simulator_test.py
@@ -107,7 +107,8 @@ class MuJoCoSimulatorTestCase(ParametrizedTestCase):
     def assert_counts_equal(sim: MuJoCoSimulator, count: int) -> None:
         assert sim.model.ngeom == count
         assert sim.num_objects == count
-        assert len(sim.spec.geoms) == count
+        if hasattr(sim.spec, "geoms"):  # only in MuJoCo v3.2.5+
+            assert len(sim.spec.geoms) == count
 
     @staticmethod
     def parse_spec_geoms(spec: MjSpec) -> List[Element]:


### PR DESCRIPTION
In the `tbp.monty` conda env, pip installs MuJoCo v3.2.3, but `geoms` is only present in v3.2.5+, thus raising an `AttributeError: 'mujoco._specs.MjSpec' object has no attribute 'geoms'`