### PR TITLE
refactor!: remove unused union_of_possible_matches

### DIFF
--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -399,13 +399,13 @@ class MontyForGraphMatching(MontyBase):
                 self.update_stats_after_vote(self.learning_modules[i])
 
         # Log possible matches
-        for i, lm in enumerate(self.learning_modules):
+        for lm in self.learning_modules:
             pm = (
                 lm.get_possible_matches()
                 if lm.buffer.get_num_observations_on_object()
                 else []
             )
-            logger.info(f"Possible matches for LM {i}: {pm}")
+            logger.info(f"Possible matches for {lm.learning_module_id}: {pm}")
 
     def _pass_infos_to_motor_system(self):
         """Pass input observations to the motor system.


### PR DESCRIPTION
In `MontyForGraphMatching._vote()` we have a call to a function that sets a `union_of_possible_matches` state. It doesn't look like this state is doing anything. Terminal condition checks do not use it and 5lm experiments run the same without it. 

I'm proposing to remove the function and other references to this state. I'm marking it as a breaking change just in case someone is using it in their fork or code outside of `tbp.monty`, but I'm not sure if it is a breaking change.