### PR TITLE
refactor!: remove **kwargs from ActionSampler subclasses

### DIFF
--- a/src/tbp/monty/frameworks/actions/action_samplers.py
+++ b/src/tbp/monty/frameworks/actions/action_samplers.py
@@ -9,7 +9,7 @@
 # https://opensource.org/licenses/MIT.
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Callable
 
 import quaternion as qt
 from numpy import cos, pi, sin, sqrt
@@ -98,7 +98,6 @@ class ConstantSampler(ActionSampler):
         rotation_degrees: float = 5.0,
         rotation_quat: QuaternionWXYZ | None = None,
         translation_distance: float = 0.004,
-        **kwargs: Any,  # Accept arbitrary keyword arguments for compatibility
     ) -> None:
         super().__init__(actions=actions, rng=rng)
         self.absolute_degrees = absolute_degrees
@@ -192,7 +191,6 @@ class UniformlyDistributedSampler(ActionSampler):
         max_translation: float = 0.05,
         min_translation: float = 0.05,
         rng: Generator | None = None,
-        **kwargs: Any,  # Accept arbitrary keyword arguments for compatibility
     ):
         super().__init__(actions=actions, rng=rng)
         self.max_absolute_degrees = max_absolute_degrees

--- a/tests/unit/frameworks/actions/action_samplers_test.py
+++ b/tests/unit/frameworks/actions/action_samplers_test.py
@@ -155,18 +155,6 @@ class ConstantSamplerTest(unittest.TestCase):
             translation_distance=self.translation_distance,
         )
 
-    def test_accepts_arbitrary_additional_init_params(self) -> None:
-        ConstantSampler(
-            absolute_degrees=self.absolute_degrees,
-            direction=self.direction,
-            location=self.location,
-            rng=default_rng(RNG_SEED),
-            rotation_quat=self.rotation_quat,
-            rotation_degrees=self.rotation_degrees,
-            translation_distance=self.translation_distance,
-            additional_param="additional_param",
-        )
-
     def test_samples_look_down_with_constant_params(self) -> None:
         action1 = self.sampler.sample_look_down("agent1")
         action2 = self.sampler.sample_look_down("agent2")
@@ -317,18 +305,6 @@ class UniformlyDistributedSamplerTest(unittest.TestCase):
             min_rotation_degrees=self.min_rotation_degrees,
             max_translation=self.max_translation,
             min_translation=self.min_translation,
-        )
-
-    def test_accepts_arbitrary_additional_init_params(self) -> None:
-        UniformlyDistributedSampler(
-            max_absolute_degrees=self.max_absolute_degrees,
-            min_absolute_degrees=self.min_absolute_degrees,
-            rng=default_rng(RNG_SEED),
-            max_rotation_degrees=self.max_rotation_degrees,
-            min_rotation_degrees=self.min_rotation_degrees,
-            max_translation=self.max_translation,
-            min_translation=self.min_translation,
-            additional_param="additional_param",
         )
 
     def test_samples_look_down_with_sampled_params(self) -> None:


### PR DESCRIPTION
These seem unused, and are causing failures in the ruff rule ARG002.

Peeled off from #541 

@tristanls-tbp recommended breaking the PR into smaller chunks. This change in particular was mentioned to run tests against.