### PR TITLE
refactor!: remove object_scale from graph matching

### DIFF
--- a/src/tbp/monty/frameworks/models/buffer.py
+++ b/src/tbp/monty/frameworks/models/buffer.py
@@ -427,7 +427,6 @@ class FeatureAtLocationBuffer:
             features=self.get_all_features_on_object(),
             object_location_rel_body=self.stats["detected_location_rel_body"],
             location_rel_model=self.stats["detected_location_on_model"],
-            object_scale=self.stats["detected_scale"],
         )
 
     def get_first_sensory_input_channel(self):

--- a/src/tbp/monty/frameworks/models/evidence_matching/graph_memory.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/graph_memory.py
@@ -161,7 +161,6 @@ class EvidenceGraphMemory(GraphMemory):
         object_location_rel_body,
         location_rel_model,
         object_rotation,
-        object_scale,
     ):
         """Add new observations into an existing graph.
 
@@ -173,7 +172,6 @@ class EvidenceGraphMemory(GraphMemory):
             object_location_rel_body: location of the sensor in body reference frame
             location_rel_model: location of sensor in model reference frame
             object_rotation: rotation of the sensed object relative to the model
-            object_scale: scale of the object relative to the model of it
         """
         logger.info(f"Updating existing graph for {graph_id}")
 

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -1137,7 +1137,6 @@ class GraphMemory(LMMemory):
         object_location_rel_body,
         location_rel_model,
         object_rotation,
-        object_scale,
     ):
         """Determine how to update memory and call corresponding function."""
         if graph_id is None:
@@ -1166,7 +1165,6 @@ class GraphMemory(LMMemory):
                         object_location_rel_body,
                         location_rel_model,
                         object_rotation,
-                        object_scale=object_scale,
                     )
                 else:
                     logger.info(f"{graph_id} not in memory ({self.get_memory_ids()})")
@@ -1385,7 +1383,6 @@ class GraphMemory(LMMemory):
         object_location_rel_body,
         location_rel_model,
         object_rotation,
-        object_scale,
     ):
         """Add new observations into an existing graph.
 
@@ -1397,7 +1394,6 @@ class GraphMemory(LMMemory):
             object_location_rel_body: location of object relative to body.
             location_rel_model: location of last observation relative to object model
             object_rotation: detected rotation of object model relative to world.
-            object_scale: detected scale of object model relative to world. Not used.
         """
         logger.info(f"Updating existing graph for {graph_id}")
 


### PR DESCRIPTION
The value is ignored. This is in preparation for enabling ruff's arg002

Split from #541 