### PR TITLE
fix: change AttributeError to KeyError in prediction error logging

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
@@ -1216,7 +1216,7 @@ class EvidenceGraphLM(GraphLM):
                 ]
                 channel_prediction_error = displacer_telemetry["mlh_prediction_error"]
                 prediction_errors.append(channel_prediction_error)
-            except AttributeError:
+            except KeyError:
                 # channel_telemetry was missing needed attributes,
                 # so skip adding prediction errors
                 pass


### PR DESCRIPTION
[PR#552](https://github.com/thousandbrainsproject/tbp.monty/pull/552) converts telemetry to a dictionary, so parsing errors now raise a `KeyError` instead of `AttributeError`.