### PR TITLE
chore: stable wandb import sorts after local run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# wandb local configs
+wandb/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,6 +309,13 @@ allow-dict-calls-with-keyword-arguments = true
 [tool.ruff.lint.flake8-copyright]
 author = "Thousand Brains Project"
 
+[tool.ruff.lint.isort]
+# wandb creates a folder called 'wandb' during local runs (not logged in)
+# this needs to be added to prevent isort from incorrectly sorting
+# It can be removed when a fix for this is released:
+# https://github.com/astral-sh/ruff/issues/10519
+known-third-party = ["wandb"]
+
 [tool.ruff.lint.mccabe]
 max-complexity = 18
 


### PR DESCRIPTION
Sometimes after running a benchmark, wandb creates a local folder in the project root.

This confuses isort/ruff into thinking that wandb is a local python module, and it tries to move the import line down into the first party modules section.

By forcing ruff to recognize wandb as a third party module, the import grouping is always consistent.

See https://github.com/astral-sh/ruff/issues/10519 for more discussion