### PR TITLE
feat: add speedrun option for benchmarks

### DIFF
--- a/benchmarks/run.py
+++ b/benchmarks/run.py
@@ -22,6 +22,7 @@ sys.path.insert(
 
 from benchmarks.configs.load import load_configs
 from benchmarks.configs.names import NAMES
+from tbp.monty.frameworks.config_utils import shrink_config
 from tbp.monty.frameworks.config_utils.cmd_parser import create_cmd_parser
 from tbp.monty.frameworks.run_env import setup_env
 
@@ -41,4 +42,13 @@ if __name__ == "__main__":
 
     CONFIGS = load_configs(experiments)
 
-    main(all_configs=CONFIGS, experiments=cmd_args.experiments)
+    if cmd_args.speedrun:
+        configs = {
+            env: shrink_config(config)
+            for env, config in CONFIGS.items()
+            if env in experiments
+        }
+    else:
+        configs = CONFIGS
+
+    main(all_configs=configs, experiments=cmd_args.experiments)

--- a/src/tbp/monty/frameworks/config_utils/__init__.py
+++ b/src/tbp/monty/frameworks/config_utils/__init__.py
@@ -7,3 +7,45 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
+import copy
+
+
+def shrink_config(config: dict) -> dict:
+    """Shrink the run size of a given experiment configuration.
+
+    Reduce the number of epochs, objects, etc. to speed up an experiment. This
+    is useful for testing.
+
+    Args:
+        config: The configuration dictionary to shrink.
+
+    Returns:
+        The shrunk configuration dictionary.
+    """
+    new_config = copy.deepcopy(config)
+
+    new_config["experiment_args"].update(
+        n_eval_epochs=1,
+        n_train_epochs=1,
+        max_train_steps=1,
+        max_eval_steps=1,
+        max_total_steps=2,
+    )
+
+    new_config["monty_config"]["monty_args"]["num_exploratory_steps"] = 1
+
+    object_names = new_config["eval_env_interface_args"]["object_names"]
+    if isinstance(object_names, list):
+        _shrink_config_list(new_config["eval_env_interface_args"], "object_names")
+    else:
+        _shrink_config_list(object_names, "source_object_list")
+        _shrink_config_list(object_names, "targets_list")
+        object_names["num_distractors"] = 1
+
+    return new_config
+
+
+def _shrink_config_list(config, key, max_length=2):
+    """Mutating helper to shrink lists in config dicts."""
+    if key in config:
+        config[key] = config[key][:max_length]

--- a/src/tbp/monty/frameworks/config_utils/cmd_parser.py
+++ b/src/tbp/monty/frameworks/config_utils/cmd_parser.py
@@ -41,6 +41,13 @@ def create_cmd_parser(experiments: list[str]):
         help="Set logging levels in habitat to quiet",
     )
     parser.add_argument(
+        "-s",
+        "--speedrun",
+        action="store_true",
+        default=False,
+        help="Run a quick version of the experiment for testing purposes",
+    )
+    parser.add_argument(
         "-p",
         "--print_config",
         action="store_true",


### PR DESCRIPTION
When debugging a benchmark failure, it's very nice to have a quick response whether it succeeds or fails.

This PR adds a `--speedrun` (and `-s`) flag to the benchmark runner, which shrinks the configured number of objects, epochs, etc in a predifined configuration.

Timing on my development machine:
- `python benchmarks/run.py -e base_10multi_distinctobj_dist_agent` takes ~42 minutes
- `python benchmarks/run.py -e base_10multi_distinctobj_dist_agent --speedrun` takes ~6 seconds

This makes it feasible to include some benchmark speedruns in CI.

I only ran the speedrun against that one benchmark, it's probably slow against some/all of the others. But support could be added incrementally from here.

This came up while debugging #541