### PR TITLE
feat: add sensor_module_id accessor for HabitatSalienceSM

### DIFF
--- a/src/tbp/monty/frameworks/models/salience/sensor_module.py
+++ b/src/tbp/monty/frameworks/models/salience/sensor_module.py
@@ -54,6 +54,10 @@ class HabitatSalienceSM(SensorModule):
         # TODO: Goes away once experiment code is extracted
         self.is_exploring = False
 
+    @property
+    def sensor_module_id(self) -> str:
+        return self._sensor_module_id
+
     def state_dict(self):
         return self._snapshot_telemetry.state_dict()
 


### PR DESCRIPTION
`sensor_module_id` is Python-private in `HabitatSalienceSM` (i.e., it is `HabitatSalienceSM._sensor_module_id`). But Monty experiment classes need to be able to access every SM's `sensor_module_id`. This PR just adds the property needed to get it.