### PR TITLE
revert!: follow ruff rule PTH118 (#545)

### DIFF
--- a/benchmarks/configs/defaults.py
+++ b/benchmarks/configs/defaults.py
@@ -8,7 +8,6 @@
 # https://opensource.org/licenses/MIT.
 
 import os
-from pathlib import Path
 
 import numpy as np
 
@@ -117,11 +116,13 @@ default_evidence_1lm_config = dict(learning_module_0=default_evidence_lm_config)
 # on the first few points.
 min_eval_steps = 20
 
-monty_models_dir = Path(os.getenv("MONTY_MODELS"))
+monty_models_dir = os.getenv("MONTY_MODELS")
 
 # v6 : Using TLS for surface normal estimation
 # v7 : Updated for State class support + using new feature names like pose_vectors
 # v8 : Using separate graph per input channel
 # v9 : Using models trained on 14 unique rotations
 # v10 : Using models trained without the semantic sensor
-pretrained_dir = monty_models_dir.expanduser() / "pretrained_ycb_v10"
+pretrained_dir = os.path.expanduser(
+    os.path.join(monty_models_dir, "pretrained_ycb_v10")
+)

--- a/benchmarks/configs/infer_compositional_objects.py
+++ b/benchmarks/configs/infer_compositional_objects.py
@@ -10,7 +10,6 @@
 import copy
 import os
 from dataclasses import asdict
-from pathlib import Path
 
 import numpy as np
 
@@ -61,40 +60,34 @@ N_EVAL_EPOCHS = len(test_rotations_all)
 
 # For an explanation of the different levels of difficulty, see logos_on_objs.py
 
-model_path_monolithic_models_lvl1 = (
-    pretrained_dir
-    / "supervised_pre_training_objects_with_logos_lvl1_monolithic_models"
-    / "pretrained"
+model_path_monolithic_models_lvl1 = os.path.join(
+    pretrained_dir,
+    "supervised_pre_training_objects_with_logos_lvl1_monolithic_models/pretrained/",
 )
 
-model_path_compositional_models_lvl1 = (
-    pretrained_dir
-    / "supervised_pre_training_objects_with_logos_lvl1_comp_models"
-    / "pretrained"
+model_path_compositional_models_lvl1 = os.path.join(
+    pretrained_dir,
+    "supervised_pre_training_objects_with_logos_lvl1_comp_models/pretrained/",
 )
 
-model_path_compositional_models_lvl1_resampling = (
-    pretrained_dir
-    / "supervised_pre_training_objects_with_logos_lvl1_comp_models_resampling"
-    / "pretrained"
+model_path_compositional_models_lvl1_resampling = os.path.join(
+    pretrained_dir,
+    "supervised_pre_training_objects_with_logos_lvl1_comp_models_resampling/pretrained/",
 )
 
-model_path_compositional_models_lvl2 = (
-    pretrained_dir
-    / "supervised_pre_training_objects_with_logos_lvl2_comp_models"
-    / "pretrained"
+model_path_compositional_models_lvl2 = os.path.join(
+    pretrained_dir,
+    "supervised_pre_training_objects_with_logos_lvl2_comp_models/pretrained/",
 )
 
-model_path_compositional_models_lvl3 = (
-    pretrained_dir
-    / "supervised_pre_training_objects_with_logos_lvl3_comp_models"
-    / "pretrained"
+model_path_compositional_models_lvl3 = os.path.join(
+    pretrained_dir,
+    "supervised_pre_training_objects_with_logos_lvl3_comp_models/pretrained/",
 )
 
-model_path_compositional_models_lvl4 = (
-    pretrained_dir
-    / "supervised_pre_training_objects_with_logos_lvl4_comp_models"
-    / "pretrained"
+model_path_compositional_models_lvl4 = os.path.join(
+    pretrained_dir,
+    "supervised_pre_training_objects_with_logos_lvl4_comp_models/pretrained/",
 )
 
 
@@ -188,7 +181,7 @@ infer_comp_base_config = dict(
     ),
     env_interface_config=TwoLMStackedDistantMountHabitatEnvInterfaceConfig(
         env_init_args=EnvInitArgsTwoLMDistantStackedMount(
-            data_path=Path(os.environ["MONTY_DATA"]) / "compositional_objects"
+            data_path=os.path.join(os.environ["MONTY_DATA"], "compositional_objects")
         ).__dict__,
     ),
     eval_env_interface_class=ED.InformedEnvironmentInterface,

--- a/benchmarks/configs/learn_compositional_objects.py
+++ b/benchmarks/configs/learn_compositional_objects.py
@@ -10,7 +10,6 @@
 import copy
 import os
 from dataclasses import asdict
-from pathlib import Path
 
 import numpy as np
 
@@ -60,9 +59,11 @@ from tbp.monty.simulators.habitat.configs import (
 train_rotations_all = get_cube_face_and_corner_views_rotations()
 N_TRAIN_EPOCHS = len(train_rotations_all)
 
-monty_models_dir = Path(os.getenv("MONTY_MODELS", ""))
+monty_models_dir = os.getenv("MONTY_MODELS", "")
 
-fe_pretrain_dir = monty_models_dir.expanduser() / "pretrained_ycb_v10"
+fe_pretrain_dir = os.path.expanduser(
+    os.path.join(monty_models_dir, "pretrained_ycb_v10")
+)
 
 two_stacked_constrained_lms_config = dict(
     learning_module_0=dict(
@@ -157,7 +158,7 @@ supervised_pre_training_flat_objects_wo_logos.update(
     ),
     env_interface_config=TwoLMStackedDistantMountHabitatEnvInterfaceConfig(
         env_init_args=EnvInitArgsTwoLMDistantStackedMount(
-            data_path=Path(os.environ["MONTY_DATA"]) / "compositional_objects"
+            data_path=os.path.join(os.environ["MONTY_DATA"], "compositional_objects")
         ).__dict__,
     ),
     train_env_interface_args=EnvironmentInterfacePerObjectArgs(
@@ -183,10 +184,9 @@ supervised_pre_training_logos_after_flat_objects.update(
     experiment_args=SupervisedPretrainingExperimentArgs(
         n_train_epochs=len(LOGO_POSITIONS) * len(LOGO_ROTATIONS),
         supervised_lm_ids=["learning_module_0"],
-        model_name_or_path=(
-            fe_pretrain_dir
-            / "supervised_pre_training_flat_objects_wo_logos"
-            / "pretrained"
+        model_name_or_path=os.path.join(
+            fe_pretrain_dir,
+            "supervised_pre_training_flat_objects_wo_logos/pretrained/",
         ),
     ),
     monty_config=TwoLMStackedMontyConfig(
@@ -218,10 +218,9 @@ supervised_pre_training_curved_objects_after_flat_and_logo.update(
     experiment_args=SupervisedPretrainingExperimentArgs(
         n_train_epochs=N_TRAIN_EPOCHS,
         supervised_lm_ids=["learning_module_0"],
-        model_name_or_path=(
-            fe_pretrain_dir
-            / "supervised_pre_training_logos_after_flat_objects"
-            / "pretrained"
+        model_name_or_path=os.path.join(
+            fe_pretrain_dir,
+            "supervised_pre_training_logos_after_flat_objects/pretrained/",
         ),
     ),
     train_env_interface_args=EnvironmentInterfacePerObjectArgs(
@@ -249,10 +248,9 @@ supervised_pre_training_objects_with_logos_lvl1_monolithic_models.update(
     # We load the model trained on the individual objects
     experiment_args=SupervisedPretrainingExperimentArgs(
         n_train_epochs=N_TRAIN_EPOCHS,
-        model_name_or_path=(
-            fe_pretrain_dir
-            / "supervised_pre_training_logos_after_flat_objects"
-            / "pretrained"
+        model_name_or_path=os.path.join(
+            fe_pretrain_dir,
+            "supervised_pre_training_logos_after_flat_objects/pretrained/",
         ),
     ),
     train_env_interface_args=EnvironmentInterfacePerObjectArgs(
@@ -272,10 +270,9 @@ supervised_pre_training_objects_with_logos_lvl1_comp_models = copy.deepcopy(
 supervised_pre_training_objects_with_logos_lvl1_comp_models.update(
     experiment_args=SupervisedPretrainingExperimentArgs(
         n_train_epochs=N_TRAIN_EPOCHS,
-        model_name_or_path=(
-            fe_pretrain_dir
-            / "supervised_pre_training_logos_after_flat_objects"
-            / "pretrained"
+        model_name_or_path=os.path.join(
+            fe_pretrain_dir,
+            "supervised_pre_training_logos_after_flat_objects/pretrained/",
         ),
         supervised_lm_ids=["learning_module_1"],
         min_lms_match=2,
@@ -316,10 +313,9 @@ supervised_pre_training_objects_with_logos_lvl1_comp_models_resampling.update(
     ),
 )
 
-MODEL_PATH_WITH_ALL_CHILD_OBJECTS = (
-    fe_pretrain_dir
-    / "supervised_pre_training_curved_objects_after_flat_and_logo"
-    / "pretrained"
+MODEL_PATH_WITH_ALL_CHILD_OBJECTS = os.path.join(
+    fe_pretrain_dir,
+    "supervised_pre_training_curved_objects_after_flat_and_logo/pretrained/",
 )
 
 supervised_pre_training_objects_with_logos_lvl2_comp_models = copy.deepcopy(

--- a/benchmarks/configs/monty_world_experiments.py
+++ b/benchmarks/configs/monty_world_experiments.py
@@ -9,6 +9,7 @@
 # https://opensource.org/licenses/MIT.
 
 import copy
+import os
 from dataclasses import asdict
 
 import numpy as np
@@ -51,8 +52,9 @@ NOTE these experiments do not currently support running with multi-processing,
 therefore ensure you omit the -m flag when running these
 """
 
-model_path_numenta_lab_obj = (
-    pretrained_dir / "surf_agent_1lm_numenta_lab_obj" / "pretrained"
+model_path_numenta_lab_obj = os.path.join(
+    pretrained_dir,
+    "surf_agent_1lm_numenta_lab_obj/pretrained/",
 )
 
 # Evaluation on real-world depth data, but trained on photogrammetry scanned objects

--- a/benchmarks/configs/monty_world_habitat_experiments.py
+++ b/benchmarks/configs/monty_world_habitat_experiments.py
@@ -8,6 +8,7 @@
 # https://opensource.org/licenses/MIT.
 
 
+import os
 from dataclasses import asdict
 
 from benchmarks.configs.defaults import (
@@ -41,8 +42,9 @@ from tbp.monty.simulators.habitat.configs import (
 
 test_rotations_one = [[0, 0, 0]]
 
-model_path_numenta_lab_obj = (
-    pretrained_dir / "surf_agent_1lm_numenta_lab_obj" / "pretrained"
+model_path_numenta_lab_obj = os.path.join(
+    pretrained_dir,
+    "surf_agent_1lm_numenta_lab_obj/pretrained/",
 )
 
 # More challenging evaluation on photogrammetry objects; serves as a baseline

--- a/benchmarks/configs/pretraining_experiments.py
+++ b/benchmarks/configs/pretraining_experiments.py
@@ -11,7 +11,6 @@
 import copy
 import os
 from dataclasses import asdict
-from pathlib import Path
 
 import numpy as np
 
@@ -62,12 +61,14 @@ from tbp.monty.simulators.habitat.configs import (
 # FOR SUPERVISED PRETRAINING: 14 unique rotations that give good views of the object.
 train_rotations_all = get_cube_face_and_corner_views_rotations()
 
-monty_models_dir = Path(os.getenv("MONTY_MODELS", ""))
+monty_models_dir = os.getenv("MONTY_MODELS", "")
 
-fe_pretrain_dir = monty_models_dir.expanduser() / "pretrained_ycb_v10"
+fe_pretrain_dir = os.path.expanduser(
+    os.path.join(monty_models_dir, "pretrained_ycb_v10")
+)
 
-pre_surf_agent_visual_training_model_path = (
-    fe_pretrain_dir / "supervised_pre_training_all_objects" / "pretrained"
+pre_surf_agent_visual_training_model_path = os.path.join(
+    fe_pretrain_dir, "supervised_pre_training_all_objects/pretrained/"
 )
 
 supervised_pre_training_base = dict(

--- a/benchmarks/configs/ycb_experiments.py
+++ b/benchmarks/configs/ycb_experiments.py
@@ -9,6 +9,7 @@
 # https://opensource.org/licenses/MIT.
 
 import copy
+import os
 from dataclasses import asdict
 
 import numpy as np
@@ -114,24 +115,34 @@ test_rotations_all = get_cube_face_and_corner_views_rotations()
 # runs with all 77 YCB objects.
 test_rotations_3 = test_rotations_all[:3]
 
-model_path_10distinctobj = (
-    pretrained_dir / "surf_agent_1lm_10distinctobj" / "pretrained"
+model_path_10distinctobj = os.path.join(
+    pretrained_dir,
+    "surf_agent_1lm_10distinctobj/pretrained/",
 )
 
-dist_agent_model_path_10distinctobj = (
-    pretrained_dir / "supervised_pre_training_base" / "pretrained"
+dist_agent_model_path_10distinctobj = os.path.join(
+    pretrained_dir,
+    "supervised_pre_training_base/pretrained/",
 )
 
-model_path_10simobj = pretrained_dir / "surf_agent_1lm_10similarobj" / "pretrained"
-
-model_path_5lms_10distinctobj = (
-    pretrained_dir / "supervised_pre_training_5lms" / "pretrained"
+model_path_10simobj = os.path.join(
+    pretrained_dir,
+    "surf_agent_1lm_10similarobj/pretrained/",
 )
 
-model_path_1lm_77obj = pretrained_dir / "surf_agent_1lm_77obj" / "pretrained"
+model_path_5lms_10distinctobj = os.path.join(
+    pretrained_dir,
+    "supervised_pre_training_5lms/pretrained/",
+)
 
-model_path_5lms_77obj = (
-    pretrained_dir / "supervised_pre_training_5lms_all_objects" / "pretrained"
+model_path_1lm_77obj = os.path.join(
+    pretrained_dir,
+    "surf_agent_1lm_77obj/pretrained/",
+)
+
+model_path_5lms_77obj = os.path.join(
+    pretrained_dir,
+    "supervised_pre_training_5lms_all_objects/pretrained/",
 )
 
 # Default configs for surface policy which has a different desired object distance

--- a/benchmarks/make_detailed_follow_up_configs.py
+++ b/benchmarks/make_detailed_follow_up_configs.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
 
     if not rerun_episodes:
         # Find all episodes that failed (e.g. time out, confused, not recognized)
-        eval_stats_file = output_dir / "eval_stats.csv"
+        eval_stats_file = os.path.join(output_dir, "eval_stats.csv")
         if not os.path.exists(eval_stats_file):
             raise FileNotFoundError(
                 f"Could not find eval_stats.csv at location {eval_stats_file}"
@@ -92,9 +92,9 @@ if __name__ == "__main__":
     )
 
     # Pickle these configs in the follow_ups directory
-    follow_up_dir = pathlib.Path(__file__).parent / "configs" / "follow_ups"
+    follow_up_dir = pathlib.Path(__file__).parent / "configs/follow_ups"
     follow_up_name = f"{experiment}_{follow_up_suffix}"
-    file_path = follow_up_dir / f"{follow_up_name}.pkl"
+    file_path = os.path.join(follow_up_dir, follow_up_name + ".pkl")
     with open(file_path, "wb") as f:
         pickle.dump(follow_up_config, f)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,6 +263,7 @@ ignore = [
     "PTH107", # PTH107: `os.remove()` should be replaced by `Path.unlink()`
     "PTH110", # PTH110: `os.path.exists()` should be replaced by `Path.exists()`
     "PTH111", # PTH111: `os.path.expanduser()` should be replaced by `Path.expanduser()`
+    "PTH118", # PTH118: `os.path.join()` should be replaced by `Path` with `/` operator
     "PTH119", # PTH119: `os.path.basename()` should be replaced by `Path.name`
     "PTH120", # PTH120: `os.path.dirname()` should be replaced by `Path.parent`
     "PTH123", # PTH123: `open()` should be replaced by `Path.open()`

--- a/src/tbp/monty/frameworks/config_utils/config_args.py
+++ b/src/tbp/monty/frameworks/config_utils/config_args.py
@@ -13,7 +13,6 @@ import copy
 import os
 from dataclasses import dataclass, field
 from itertools import product
-from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Iterable, Mapping
 
 import numpy as np
@@ -72,7 +71,7 @@ if TYPE_CHECKING:
 # Monty Configurations
 # -----------------------
 
-monty_logs_dir = Path(os.getenv("MONTY_LOGS")).expanduser()
+monty_logs_dir = os.getenv("MONTY_LOGS")
 
 
 @dataclass
@@ -89,7 +88,9 @@ class LoggingConfig:
     python_log_level: str = "INFO"
     python_log_to_file: bool = True
     python_log_to_stderr: bool = True
-    output_dir: Path = monty_logs_dir / "projects" / "monty_runs"
+    output_dir: str = os.path.expanduser(
+        os.path.join(monty_logs_dir, "projects/monty_runs/")
+    )
     run_name: str = ""
     resume_wandb_run: bool | str = False
     wandb_id: str = field(default_factory=wandb.util.generate_id)
@@ -146,7 +147,9 @@ class DetailedWandbLoggingConfig(LoggingConfig):
 
 @dataclass
 class EvalLoggingConfig(LoggingConfig):
-    output_dir: Path = monty_logs_dir / "projects" / "feature_eval_runs" / "logs"
+    output_dir: str = os.path.expanduser(
+        os.path.join(monty_logs_dir, "projects/feature_eval_runs/logs")
+    )
     monty_handlers: list = field(
         default_factory=lambda: [
             BasicCSVStatsHandler,
@@ -166,7 +169,9 @@ class EvalLoggingConfig(LoggingConfig):
 
 @dataclass
 class EvalEvidenceLMLoggingConfig(LoggingConfig):
-    output_dir: Path = monty_logs_dir / "projects" / "evidence_eval_runs" / "logs"
+    output_dir: str = os.path.expanduser(
+        os.path.join(monty_logs_dir, "projects/evidence_eval_runs/logs")
+    )
     monty_handlers: list = field(
         default_factory=lambda: [
             BasicCSVStatsHandler,
@@ -189,7 +194,9 @@ class ParallelEvidenceLMLoggingConfig(LoggingConfig):
     # Config useful for running parallel experiments
     # on lambda-node, i.e. has appropriate wandb flags
     # and parsimonious Python logging
-    output_dir: Path = monty_logs_dir / "projects" / "evidence_eval_runs" / "logs"
+    output_dir: str = os.path.expanduser(
+        os.path.join(monty_logs_dir, "projects/evidence_eval_runs/logs")
+    )
     monty_handlers: list = field(
         default_factory=lambda: [
             BasicCSVStatsHandler,

--- a/src/tbp/monty/frameworks/config_utils/make_env_interface_configs.py
+++ b/src/tbp/monty/frameworks/config_utils/make_env_interface_configs.py
@@ -91,24 +91,30 @@ class SupervisedPretrainingExperimentArgs(ExperimentArgs):
 # Data-set containing RGBD images of real-world objects taken with a mobile device
 @dataclass
 class EnvInitArgsMontyWorldStandardScenes:
-    data_path = Path(os.environ["MONTY_DATA"]) / "worldimages" / "standard_scenes"
+    data_path: str = os.path.join(
+        os.environ["MONTY_DATA"], "worldimages/standard_scenes/"
+    )
 
 
 @dataclass
 class EnvInitArgsMontyWorldBrightScenes:
-    data_path = Path(os.environ["MONTY_DATA"]) / "worldimages" / "bright_scenes"
+    data_path: str = os.path.join(
+        os.environ["MONTY_DATA"], "worldimages/bright_scenes/"
+    )
 
 
 @dataclass
 class EnvInitArgsMontyWorldDarkScenes:
-    data_path = Path(os.environ["MONTY_DATA"]) / "worldimages" / "dark_scenes"
+    data_path: str = os.path.join(os.environ["MONTY_DATA"], "worldimages/dark_scenes/")
 
 
 # Data-set where a hand is prominently visible holding (and thereby partially
 # occluding) the objects
 @dataclass
 class EnvInitArgsMontyWorldHandIntrusionScenes:
-    data_path = Path(os.environ["MONTY_DATA"]) / "worldimages" / "hand_intrusion_scenes"
+    data_path: str = os.path.join(
+        os.environ["MONTY_DATA"], "worldimages/hand_intrusion_scenes/"
+    )
 
 
 # Data-set where there are two objects in the image; the target class is in the centre
@@ -117,7 +123,9 @@ class EnvInitArgsMontyWorldHandIntrusionScenes:
 # as a book if the target is a type of mug)
 @dataclass
 class EnvInitArgsMontyWorldMultiObjectScenes:
-    data_path = Path(os.environ["MONTY_DATA"]) / "worldimages" / "multi_object_scenes"
+    data_path: str = os.path.join(
+        os.environ["MONTY_DATA"], "worldimages/multi_object_scenes/"
+    )
 
 
 @dataclass
@@ -417,9 +425,10 @@ def get_omniglot_train_env_interface(num_versions, alphabet_ids, data_path=None)
         OmniglotEnvironmentInterfaceArgs for training.
     """
     if data_path is None:
-        data_path = Path(os.environ["MONTY_DATA"]) / "omniglot" / "python"
+        data_path = os.path.join(os.environ["MONTY_DATA"], "omniglot/python/")
     if os.path.exists(data_path):
-        images_path = Path(data_path) / "images_background"
+        data_path = Path(data_path)
+        images_path = data_path / "images_background"
         alphabet_folders = sorted(images_path.glob("[!.]*"))
     else:
         # Use placeholder here to pass Circle CI config check.
@@ -463,9 +472,10 @@ def get_omniglot_eval_env_interface(
         OmniglotEnvironmentInterfaceArgs for evaluation.
     """
     if data_path is None:
-        data_path = Path(os.environ["MONTY_DATA"]) / "omniglot" / "python"
+        data_path = os.path.join(os.environ["MONTY_DATA"], "omniglot/python/")
     if os.path.exists(data_path):
-        images_path = Path(data_path) / "images_background"
+        data_path = Path(data_path)
+        images_path = data_path / "images_background"
         alphabet_folders = sorted(images_path.glob("[!.]*"))
     else:
         # Use placeholder here to pass Circle CI config check.

--- a/src/tbp/monty/frameworks/environments/two_d_data.py
+++ b/src/tbp/monty/frameworks/environments/two_d_data.py
@@ -81,11 +81,11 @@ class OmniglotEnvironment(EmbodiedEnvironment):
         self.rotation = qt.from_rotation_vector([np.pi / 2, 0.0, 0.0])
         self.step_num = 0
         self.state = 0
-        if data_path is None:
-            self.data_path = Path(os.environ["MONTY_DATA"]) / "omniglot" / "python"
-        else:
-            self.data_path = Path(data_path)
-        alphabet_path = self.data_path / "images_background"
+        self.data_path = data_path
+        if self.data_path is None:
+            self.data_path = os.path.join(os.environ["MONTY_DATA"], "omniglot/python/")
+        data_path = Path(self.data_path)
+        alphabet_path = data_path / "images_background"
         self.alphabet_names = [a.name for a in sorted(alphabet_path.glob("[!.]*"))]
         self.current_alphabet = self.alphabet_names[0]
         self.character_id = 1
@@ -213,17 +213,17 @@ class OmniglotEnvironment(EmbodiedEnvironment):
         }
 
     def load_new_character_data(self):
-        img_char_dir = (
-            self.data_path
-            / "images_background"
-            / self.current_alphabet
-            / f"character{self.character_id:02d}"
+        img_char_dir = os.path.join(
+            self.data_path,
+            "images_background",
+            self.current_alphabet,
+            "character" + str(self.character_id).zfill(2),
         )
-        stroke_char_dir = (
-            self.data_path
-            / "strokes_background"
-            / self.current_alphabet
-            / f"character{self.character_id:02d}"
+        stroke_char_dir = os.path.join(
+            self.data_path,
+            "strokes_background",
+            self.current_alphabet,
+            "character" + str(self.character_id).zfill(2),
         )
         first_img_char_child = next(Path(img_char_dir).iterdir()).name
         char_img_names = first_img_char_child.split("_")[0]
@@ -283,13 +283,13 @@ class SaccadeOnImageEnvironment(EmbodiedEnvironment):
         # the same. Since we don't use this, value doesn't matter much.
         self.rotation = qt.from_rotation_vector([np.pi / 2, 0.0, 0.0])
         self.state = 0
-        if data_path is None:
-            self.data_path = (
-                Path(os.environ["MONTY_DATA"]) / "worldimages" / "labeled_scenes"
+        self.data_path = data_path
+        if self.data_path is None:
+            self.data_path = os.path.join(
+                os.environ["MONTY_DATA"], "worldimages/labeled_scenes/"
             )
-        else:
-            self.data_path = Path(data_path)
-        self.scene_names = [a.name for a in sorted(self.data_path.glob("[!.]*"))]
+        data_path = Path(self.data_path)
+        self.scene_names = [a.name for a in sorted(data_path.glob("[!.]*"))]
         self.current_scene = self.scene_names[0]
         self.scene_version = 0
 
@@ -474,10 +474,10 @@ class SaccadeOnImageEnvironment(EmbodiedEnvironment):
         """
         # Set data paths
         current_depth_path = (
-            self.data_path / f"{self.current_scene}" / "depth_{self.scene_version}.data"
+            self.data_path + f"{self.current_scene}/depth_{self.scene_version}.data"
         )
         current_rgb_path = (
-            self.data_path / f"{self.current_scene}" / "rgb_{self.scene_version}.png"
+            self.data_path + f"{self.current_scene}/rgb_{self.scene_version}.png"
         )
         # Load & process data
         current_rgb_image = self.load_rgb_data(current_rgb_path)
@@ -694,13 +694,13 @@ class SaccadeOnImageFromStreamEnvironment(SaccadeOnImageEnvironment):
         # Letters are always presented upright
         self.rotation = qt.from_rotation_vector([np.pi / 2, 0.0, 0.0])
         self.state = 0
-        if data_path is None:
-            self.data_path = (
-                Path(os.environ["MONTY_DATA"]) / "worldimages" / "world_data_stream"
+        self.data_path = data_path
+        if self.data_path is None:
+            self.data_path = os.path.join(
+                os.environ["MONTY_DATA"], "worldimages/world_data_stream/"
             )
-        else:
-            self.data_path = Path(data_path)
-        self.scene_names = [a.name for a in sorted(self.data_path.glob("[!.]*"))]
+        data_path = Path(self.data_path)
+        self.scene_names = [a.name for a in sorted(data_path.glob("[!.]*"))]
         self.current_scene = 0
 
         (
@@ -746,8 +746,8 @@ class SaccadeOnImageFromStreamEnvironment(SaccadeOnImageEnvironment):
         ) = self.get_3d_scene_point_cloud()
 
     def load_new_scene_data(self):
-        current_depth_path = self.data_path / f"depth_{self.current_scene}.data"
-        current_rgb_path = self.data_path / f"rgb_{self.current_scene}.png"
+        current_depth_path = self.data_path + f"depth_{self.current_scene}.data"
+        current_rgb_path = self.data_path + f"rgb_{self.current_scene}.png"
         # Load rgb image
         wait_count = 0
         while not os.path.exists(current_rgb_path):

--- a/src/tbp/monty/frameworks/experiments/data_collection_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/data_collection_experiments.py
@@ -8,6 +8,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+import os
 
 import torch
 from tqdm import tqdm
@@ -76,7 +77,7 @@ class DataCollectionExperiment(MontyObjectRecognitionExperiment):
     def post_episode(self):
         torch.save(
             self.model.sensor_modules[0].processed_obs[:-1],
-            self.output_dir / f"observations{self.train_episodes}.pt",
+            os.path.join(self.output_dir, f"observations{self.train_episodes}.pt"),
         )
         self.env_interface.post_episode()
         self.train_episodes += 1

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -9,6 +9,7 @@
 # https://opensource.org/licenses/MIT.
 
 import logging
+import os
 
 import torch
 
@@ -125,8 +126,8 @@ class MontyGeneralizationExperiment(MontyObjectRecognitionExperiment):
 
     def pre_episode(self):
         """Pre episode where we pass target object to the model for logging."""
-        if "model.pt" not in self.model_path.parts:
-            model_path = self.model_path / "model.pt"
+        if "model.pt" not in self.model_path:
+            model_path = os.path.join(self.model_path, "model.pt")
         state_dict = torch.load(model_path)
         print(f"loading models again from {model_path}")
         self.model.load_state_dict(state_dict)

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -9,7 +9,7 @@
 # https://opensource.org/licenses/MIT.
 
 import logging
-from pathlib import Path
+import os
 
 import numpy as np
 from scipy.spatial.transform import Rotation
@@ -41,8 +41,8 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
         # place and models in another. Changing the config ensures every reference to
         # output_dir has "pretrained" added to it
         config = config_to_dict(config)
-        output_dir = Path(config["logging_config"]["output_dir"])
-        config["logging_config"]["output_dir"] = output_dir / "pretrained"
+        output_dir = config["logging_config"]["output_dir"]
+        config["logging_config"]["output_dir"] = os.path.join(output_dir, "pretrained")
         self.first_epoch_object_location = {}
         super().__init__(config)
 

--- a/src/tbp/monty/frameworks/experiments/profile.py
+++ b/src/tbp/monty/frameworks/experiments/profile.py
@@ -71,7 +71,7 @@ class ProfileExperimentMixin:
             )
 
     def make_profile_dir(self):
-        self.profile_dir = Path(self.output_dir) / "profile"
+        self.profile_dir = os.path.join(self.output_dir, "profile")
         os.makedirs(self.profile_dir, exist_ok=True)
 
     def setup_experiment(self, config):
@@ -83,7 +83,8 @@ class ProfileExperimentMixin:
 
         self.make_profile_dir()
         df = make_stats_df(pr)
-        df.to_csv(self.profile_dir / filename)
+        filepath = os.path.join(self.profile_dir, filename)
+        df.to_csv(filepath)
 
     def run_episode(self):
         mode, epoch, episode = self.get_epoch_state()
@@ -93,7 +94,8 @@ class ProfileExperimentMixin:
         super().run_episode()
         pr.disable()
         df = make_stats_df(pr)
-        df.to_csv(self.profile_dir / filename)
+        filepath = os.path.join(self.profile_dir, filename)
+        df.to_csv(filepath)
 
     def train(self):
         filename = "profile-train.csv"
@@ -102,7 +104,8 @@ class ProfileExperimentMixin:
         super().train()
         pr.disable()
         df = make_stats_df(pr)
-        df.to_csv(self.profile_dir / filename)
+        filepath = os.path.join(self.profile_dir, filename)
+        df.to_csv(filepath)
 
     def evaluate(self):
         filename = "profile-evaluate.csv"
@@ -111,7 +114,8 @@ class ProfileExperimentMixin:
         super().evaluate()
         pr.disable()
         df = make_stats_df(pr)
-        df.to_csv(self.profile_dir / filename)
+        filepath = os.path.join(self.profile_dir, filename)
+        df.to_csv(filepath)
 
     def close(self):
         # If wandb is in use, send tables to wandb

--- a/src/tbp/monty/frameworks/loggers/exp_logger.py
+++ b/src/tbp/monty/frameworks/loggers/exp_logger.py
@@ -8,8 +8,8 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+import os
 import pickle
-from pathlib import Path
 
 from typing_extensions import override
 
@@ -165,8 +165,7 @@ class TestLogger(BaseMontyLogger):
 
     @override
     def close(self, logger_args, output_dir, model):
-        outfile = Path(output_dir) / "fake_log.pkl"
-        with outfile.open("wb") as f:
+        with open(os.path.join(output_dir, "fake_log.pkl"), "wb") as f:
             pickle.dump(self.log, f)
 
     def __deepcopy__(self, memo):

--- a/src/tbp/monty/frameworks/loggers/monty_handlers.py
+++ b/src/tbp/monty/frameworks/loggers/monty_handlers.py
@@ -309,7 +309,7 @@ class ReproduceEpisodeHandler(MontyHandler):
     def report_episode(self, data, output_dir, episode, mode="train", **kwargs):
         # Set up data directory with reproducibility info for each episode
         if not hasattr(self, "data_dir"):
-            self.data_dir = Path(output_dir) / "reproduce_episode_data"
+            self.data_dir = os.path.join(output_dir, "reproduce_episode_data")
             os.makedirs(self.data_dir, exist_ok=True)
 
         # TODO: store a pointer to the training model
@@ -320,7 +320,7 @@ class ReproduceEpisodeHandler(MontyHandler):
 
         # Write data to action file
         action_file = f"{mode}_episode_{episode}_actions.jsonl"
-        action_file_path = self.data_dir / action_file
+        action_file_path = os.path.join(self.data_dir, action_file)
         actions = data["BASIC"][f"{mode}_actions"][episode]
         with open(action_file_path, "w") as f:
             f.writelines(
@@ -330,7 +330,7 @@ class ReproduceEpisodeHandler(MontyHandler):
 
         # Write data to object params / targets file
         object_file = f"{mode}_episode_{episode}_target.txt"
-        object_file_path = self.data_dir / object_file
+        object_file_path = os.path.join(self.data_dir, object_file)
         target = data["BASIC"][f"{mode}_targets"][episode]
         with open(object_file_path, "w") as f:
             json.dump(target, f, cls=BufferEncoder)

--- a/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
@@ -11,7 +11,6 @@
 import logging
 import os
 import shutil
-from pathlib import Path
 
 import numpy as np
 from tqdm import tqdm
@@ -47,7 +46,7 @@ class LoggerSDR:
             logger.warning("EvidenceSDR log path is set to None.")
             return
 
-        path = Path(path).expanduser()
+        path = os.path.expanduser(path)
 
         # overwrite existing logs
         if os.path.exists(path):
@@ -76,7 +75,7 @@ class LoggerSDR:
         """
         if hasattr(self, "path"):
             np.save(
-                self.path / f"episode_{self.episode:03d}.npy",
+                os.path.join(self.path, f"episode_{str(self.episode).zfill(3)}.npy"),
                 data,
             )
             self.episode += 1

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import ClassVar
 
 import numpy as np
@@ -188,7 +189,7 @@ class MontyForGraphMatching(MontyBase):
     def load_state_dict_from_parallel(self, parallel_dirs, save=False):
         lm_dict = {}
         for pdir in parallel_dirs:
-            state_dict = torch.load(pdir / "model.pt")
+            state_dict = torch.load(os.path.join(pdir, "model.pt"))
             for lm in state_dict["lm_dict"].keys():
                 if lm not in lm_dict:
                     lm_dict[lm] = dict(
@@ -215,10 +216,10 @@ class MontyForGraphMatching(MontyBase):
         # Everything but lm dict for saving new model
         new_state_dict = {k: v for k, v in state_dict.items() if k != "lm_dict"}
         new_state_dict["lm_dict"] = lm_dict
-        load_dir = parallel_dirs[0].parent
+        load_dir = os.path.dirname(parallel_dirs[0])
 
         if save:
-            torch.save(new_state_dict, load_dir / "model.pt")
+            torch.save(new_state_dict, os.path.join(load_dir, "model.pt"))
 
         self.load_state_dict(new_state_dict)
 

--- a/src/tbp/monty/frameworks/run.py
+++ b/src/tbp/monty/frameworks/run.py
@@ -13,7 +13,6 @@ import logging
 import os
 import pprint
 import time
-from pathlib import Path
 
 from tbp.monty.frameworks.config_utils.cmd_parser import create_cmd_parser
 from tbp.monty.frameworks.utils.dataclass_utils import config_to_dict
@@ -97,9 +96,9 @@ def main(all_configs, experiments=None):
         # NOTE: wandb args are further processed in monty_experiment
         if not exp_config["logging_config"]["run_name"]:
             exp_config["logging_config"]["run_name"] = experiment
-        exp_config["logging_config"]["output_dir"] = (
-            Path(exp_config["logging_config"]["output_dir"])
-            / exp_config["logging_config"]["run_name"]
+        exp_config["logging_config"]["output_dir"] = os.path.join(
+            exp_config["logging_config"]["output_dir"],
+            exp_config["logging_config"]["run_name"],
         )
         # If we are not running in parallel, this should always be False
         exp_config["logging_config"]["log_parallel_wandb"] = False

--- a/src/tbp/monty/frameworks/utils/follow_up_configs.py
+++ b/src/tbp/monty/frameworks/utils/follow_up_configs.py
@@ -11,7 +11,6 @@
 import copy
 import json
 import os
-from pathlib import Path
 
 import torch
 
@@ -29,9 +28,9 @@ def recover_output_dir(config, config_name):
     Returns:
         output_dir: Path to output directory.
     """
-    output_dir = Path(config["logging_config"]["output_dir"])
+    output_dir = config["logging_config"]["output_dir"]
     if not config["logging_config"]["run_name"]:
-        output_dir = output_dir / config_name
+        output_dir = os.path.join(config["logging_config"]["output_dir"], config_name)
 
     return output_dir
 
@@ -45,7 +44,7 @@ def recover_run_name(config, config_name):
 
 def recover_wandb_id(output_dir):
     # 0 is just go specify any epoch subdirectory; ids should all be the same
-    config_file_name = Path(output_dir) / "0" / "config.pt"
+    config_file_name = os.path.join(output_dir, "0", "config.pt")
     cfg = torch.load(config_file_name)
     config = config_to_dict(cfg)
     return config["logging_config"]["wandb_id"]
@@ -84,7 +83,7 @@ def create_eval_episode_config(
     new_config = copy.deepcopy(config_to_dict(parent_config))
 
     # Determine parent output_dir, run_name, based on how run.py modifies on the fly
-    output_dir = Path(new_config["logging_config"]["output_dir"])
+    output_dir = new_config["logging_config"]["output_dir"]
     run_name = new_config["logging_config"]["run_name"]
     wandb_id = None
     if update_run_dir:
@@ -93,16 +92,16 @@ def create_eval_episode_config(
         wandb_id = recover_wandb_id(output_dir)
 
     # 1) Use a policy that uses exact actions from previous episode
-    motor_file = (
-        output_dir / "reproduce_episode_data" / f"eval_episode_{episode}_actions.jsonl"
+    motor_file = os.path.join(
+        output_dir, "reproduce_episode_data", f"eval_episode_{episode}_actions.jsonl"
     )
     new_config["monty_config"]["motor_system_config"]["motor_system_args"][
         "policy_args"
     ]["file_name"] = motor_file
 
     # 2) Load object params from this episode into environment interface config
-    object_params_file = (
-        output_dir / "reproduce_episode_data" / f"eval_episode_{episode}_target.txt"
+    object_params_file = os.path.join(
+        output_dir, "reproduce_episode_data", f"eval_episode_{episode}_target.txt"
     )
     with open(object_params_file) as f:
         target_data = json.load(f)
@@ -132,7 +131,7 @@ def create_eval_episode_config(
         )
 
     # Second, update the output directory, run_name, set resume to True
-    new_output_dir = output_dir / f"eval_episode_{episode}_rerun"
+    new_output_dir = os.path.join(output_dir, f"eval_episode_{episode}_rerun")
     os.makedirs(new_output_dir, exist_ok=True)
     new_config["logging_config"]["output_dir"] = new_output_dir
     new_config["logging_config"]["run_name"] = run_name
@@ -159,7 +158,7 @@ def create_eval_config_multiple_episodes(
     ###
 
     # Recover output dir based on how run.py modifies on the fly
-    output_dir = Path(new_config["logging_config"]["output_dir"])
+    output_dir = new_config["logging_config"]["output_dir"]
     run_name = new_config["logging_config"]["run_name"]
     wandb_id = None
     if update_run_dir:
@@ -175,7 +174,7 @@ def create_eval_config_multiple_episodes(
         new_config["notes"].update(notes)
 
     # Update the output directory to be a "rerun" subdir
-    new_output_dir = output_dir / "eval_rerun_episodes"
+    new_output_dir = os.path.join(output_dir, "eval_rerun_episodes")
     os.makedirs(new_output_dir, exist_ok=True)
     new_config["logging_config"]["output_dir"] = new_output_dir
     new_config["logging_config"]["run_name"] = run_name
@@ -201,15 +200,15 @@ def create_eval_config_multiple_episodes(
     target_rotations = []
     for episode_counter, episode in enumerate(episodes):
         # Get actions from this episode
-        motor_file = (
-            output_dir
-            / "reproduce_episode_data"
-            / f"eval_episode_{episode}_actions.jsonl"
+        motor_file = os.path.join(
+            output_dir,
+            "reproduce_episode_data",
+            f"eval_episode_{episode}_actions.jsonl",
         )
 
         # Get object params from this episode
-        object_params_file = (
-            output_dir / "reproduce_episode_data" / f"eval_episode_{episode}_target.txt"
+        object_params_file = os.path.join(
+            output_dir, "reproduce_episode_data", f"eval_episode_{episode}_target.txt"
         )
         with open(object_params_file) as f:
             target_data = json.load(f)

--- a/src/tbp/monty/frameworks/utils/logging_utils.py
+++ b/src/tbp/monty/frameworks/utils/logging_utils.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import copy
 import json
 import logging
+import os
 import shutil
 from collections import deque
 from itertools import chain
@@ -53,15 +54,15 @@ def load_stats(
     train_stats, eval_stats, detailed_stats, lm_models = None, None, None, None
     if load_train:
         print("...loading and checking train statistics...")
-        train_stats = pd.read_csv(exp_path / "train_stats.csv")
+        train_stats = pd.read_csv(os.path.join(exp_path, "train_stats.csv"))
 
     if load_eval:
         print("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp_path / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp_path, "eval_stats.csv"))
 
     if load_detailed:
         print("...loading detailed run statistics...")
-        json_file = exp_path / "detailed_run_stats.json"
+        json_file = os.path.join(exp_path, "detailed_run_stats.json")
         try:
             with open(json_file) as f:
                 detailed_stats = json.load(f)
@@ -81,7 +82,7 @@ def load_models_from_dir(exp_path, pretrained_dict=None):
 
     if pretrained_dict is not None:
         lm_models["pretrained"] = {}
-        state_dict = torch.load(Path(pretrained_dict) / "model.pt")
+        state_dict = torch.load(os.path.join(pretrained_dict, "model.pt"))
         for lm_id in list(state_dict["lm_dict"].keys()):
             pretrained_models = state_dict["lm_dict"][lm_id]["graph_memory"]
             lm_models["pretrained"][lm_id] = pretrained_models
@@ -89,7 +90,7 @@ def load_models_from_dir(exp_path, pretrained_dict=None):
     for child in Path(exp_path).iterdir():
         folder = child.name
         if folder.isnumeric():
-            state_dict = torch.load(child / "model.pt")
+            state_dict = torch.load(os.path.join(exp_path, folder, "model.pt"))
             for lm_id in list(state_dict["lm_dict"].keys()):
                 epoch_models = state_dict["lm_dict"][lm_id]["graph_memory"]
                 if folder not in lm_models.keys():

--- a/src/tbp/monty/simulators/habitat/configs.py
+++ b/src/tbp/monty/simulators/habitat/configs.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
-from pathlib import Path
 from typing import Callable, Mapping
 
 from tbp.monty.frameworks.agents import AgentID
@@ -83,7 +82,7 @@ class EnvInitArgs:
     )
     scene_id: int | None = field(default=None)
     seed: int = field(default=42)
-    data_path: str = Path(os.environ["MONTY_DATA"]) / "habitat" / "objects" / "ycb"
+    data_path: str = os.path.join(os.environ["MONTY_DATA"], "habitat/objects/ycb")
 
 
 @dataclass
@@ -135,7 +134,7 @@ class EnvInitArgsSurfaceViewMount(EnvInitArgs):
 
 @dataclass
 class EnvInitArgsMontyWorldPatchViewMount(EnvInitArgsPatchViewMount):
-    data_path: str = Path(os.environ["MONTY_DATA"]) / "numenta_lab"
+    data_path: str = os.path.join(os.environ["MONTY_DATA"], "numenta_lab")
 
 
 @dataclass
@@ -245,7 +244,7 @@ class NoisyPatchViewFinderMountHabitatEnvInterfaceConfig:
 
 @dataclass
 class EnvInitArgsShapenetPatchViewMount(EnvInitArgsPatchViewMount):
-    data_path: str = Path(os.environ["MONTY_DATA"]) / "shapenet"
+    data_path: str = os.path.join(os.environ["MONTY_DATA"], "shapenet")
 
 
 @dataclass

--- a/tests/unit/base_config_test.py
+++ b/tests/unit/base_config_test.py
@@ -16,6 +16,7 @@ pytest.importorskip(
 
 import copy
 import logging
+import os
 import shutil
 import tempfile
 import unittest
@@ -204,7 +205,7 @@ class BaseConfigTest(unittest.TestCase):
             logger.info(info_message)
             logger.warning(warning_message)
 
-            with open(exp.output_dir / "log.txt") as f:
+            with open(os.path.join(exp.output_dir, "log.txt")) as f:
                 log = f.read()
 
             self.assertTrue(info_message in log)
@@ -223,7 +224,7 @@ class BaseConfigTest(unittest.TestCase):
             logger.debug(debug_message)
             logger.warning(warning_message)
 
-            with open(exp.output_dir / "log.txt") as f:
+            with open(os.path.join(exp.output_dir, "log.txt")) as f:
                 log = f.read()
 
             self.assertTrue(debug_message not in log)

--- a/tests/unit/embodied_data_test.py
+++ b/tests/unit/embodied_data_test.py
@@ -8,6 +8,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+import os
 import unittest
 from pathlib import Path
 
@@ -309,7 +310,10 @@ class EmbodiedDataTest(unittest.TestCase):
         patch_size = 48
         expected_keys = ["depth", "rgba", "pixel_loc"]
 
-        data_path = Path(__file__).parent / "resources" / "dataloader_test_images"
+        data_path = "./resources/dataloader_test_images/"
+        data_path = os.path.join(
+            Path(__file__).parent, "resources/dataloader_test_images/"
+        )
 
         base_policy_config_rel = make_base_policy_config(
             action_space_type="distant_agent",
@@ -360,11 +364,10 @@ class EmbodiedDataTest(unittest.TestCase):
         patch_size = 48
         expected_keys = ["depth", "rgba", "pixel_loc"]
 
-        data_path = (
-            Path(__file__).parent
-            / "resources"
-            / "dataloader_test_images"
-            / "0_numenta_mug"
+        data_path = "./resources/dataloader_test_images/"
+        data_path = os.path.join(
+            Path(__file__).parent,
+            "resources/dataloader_test_images/0_numenta_mug/",
         )
 
         base_policy_config_rel = make_base_policy_config(

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -17,6 +17,7 @@ pytest.importorskip(
 )
 
 import copy
+import os
 import shutil
 import tempfile
 import unittest
@@ -783,14 +784,14 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
         for key in [
@@ -911,7 +912,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
             pprint("...check time out logging...")
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.assertEqual(
                 train_stats["individual_ts_performance"][0],
                 "no_match",
@@ -950,7 +951,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         for i in range(3):
             self.assertEqual(
                 eval_stats["individual_ts_performance"][i],
@@ -983,7 +984,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.post_epoch()
 
         pprint("...checking run stats...")
-        train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
         for i in [0, 1]:
             self.assertEqual(
                 train_stats["primary_performance"][i],
@@ -1026,7 +1027,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             print(train_stats)
             self.check_train_results(train_stats)
 
@@ -1034,7 +1035,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
@@ -1047,7 +1048,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             print(train_stats)
             self.check_train_results(train_stats)
 
@@ -1055,7 +1056,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
@@ -1626,14 +1627,14 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
@@ -1645,7 +1646,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             print(train_stats)
             self.check_train_results(train_stats, num_lms=5)
 
@@ -1656,7 +1657,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
                 exp.run_epoch()
             exp.logger_handler.post_eval(exp.logger_args)
             pprint("...loading and checking eval statistics...")
-            eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
             self.check_eval_results(eval_stats, num_lms=5)
 
             pprint("checking that evaluation also works with larger mmd.")
@@ -1666,7 +1667,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats, num_lms=5)
 
@@ -1678,7 +1679,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
             # Same as in previous test we make it a bit more difficult during eval
             for lm in exp.model.learning_modules:
@@ -1687,7 +1688,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_multilm_eval_results(eval_stats, num_lms=5, min_done=3)
 
@@ -1705,7 +1706,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
 
             exp.train()
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             # Just checking that objects are still recognized correctly when moving off
             # the object.
             self.check_train_results(train_stats, num_lms=5)
@@ -1727,7 +1728,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats, num_lms=5)
 
@@ -1810,14 +1811,14 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats, num_lms=5)
 
@@ -1833,14 +1834,14 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats, num_lms=5)
 
@@ -1853,14 +1854,14 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats, num_lms=5)
 
             pprint("...evaluating...")
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats, num_lms=5)
 
@@ -1880,7 +1881,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             # NOTE: This might fail if the model becomes more noise robust or
             # better able to deal with few incomplete objects in memory.
             for i in range(6):
@@ -1895,7 +1896,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         for i in range(3):
             self.assertEqual(
                 eval_stats["primary_performance"][i],
@@ -1920,7 +1921,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             # NOTE: This might fail if the model becomes more noise robust or
             # better able to deal with few incomplete objects in memory.
             for i in range(6):
@@ -1935,7 +1936,7 @@ class EvidenceLMTest(BaseGraphTestCases.BaseGraphTest):
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         for i in range(3):
             self.assertEqual(
                 eval_stats["primary_performance"][i],

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -17,6 +17,7 @@ pytest.importorskip(
 )
 
 import copy
+import os
 import shutil
 import tempfile
 import unittest
@@ -161,7 +162,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         """Code that gets executed before every test."""
         super().setUp()
 
-        self.output_dir = Path(tempfile.mkdtemp())
+        self.output_dir = tempfile.mkdtemp()
         self.compositional_save_path = tempfile.mkdtemp()
 
         base = dict(
@@ -744,14 +745,14 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
             pprint("...loading and checking train statistics...")
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
@@ -763,7 +764,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
             pprint("...loading and checking train statistics...")
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
 
             self.check_train_results(train_stats)
 
@@ -771,7 +772,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
@@ -784,7 +785,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
 
             self.check_train_results(train_stats)
 
@@ -792,7 +793,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
 
         self.check_eval_results(eval_stats)
 
@@ -806,8 +807,10 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         # Create a separate experiment for evaluation to mimic the us case of re-running
         # eval episodes from a pretrained model
         eval_cfg_1 = copy.deepcopy(config)
-        # path to latest checkpoint
-        eval_cfg_1["experiment_args"].model_name_or_path = exp.output_dir / "2"
+        eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
+            exp.output_dir,
+            "2",  # latest checkpoint
+        )
         with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
             # TODO: update so it only runs one episode
             pprint("...evaluating (first time) ...")
@@ -847,9 +850,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
         # Check that basic csv stats are the same
         ###
-        original_eval_stats_file = eval_exp_1.output_dir / "eval_stats.csv"
-        new_eval_stats_file = (
-            eval_exp_1.output_dir / "eval_episode_0_rerun" / "eval_stats.csv"
+        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
+        new_eval_stats_file = os.path.join(
+            eval_exp_1.output_dir, "eval_episode_0_rerun", "eval_stats.csv"
         )
 
         original_stats = pd.read_csv(original_eval_stats_file)
@@ -865,9 +868,13 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
 
         # TODO: Once json file i/o code has been updated, only load single episode
-        original_json_file = eval_exp_1.output_dir / "detailed_run_stats.json"
-        new_json_file = (
-            eval_exp_1.output_dir / "eval_episode_0_rerun" / "detailed_run_stats.json"
+        original_json_file = os.path.join(
+            eval_exp_1.output_dir, "detailed_run_stats.json"
+        )
+        new_json_file = os.path.join(
+            eval_exp_1.output_dir,
+            "eval_episode_0_rerun",
+            "detailed_run_stats.json",
         )
 
         original_detailed_stats = deserialize_json_chunks(original_json_file)
@@ -897,8 +904,10 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         # Create a separate experiment for evaluation to mimic the us case of re-running
         # eval episodes from a pretrained model
         eval_cfg_1 = copy.deepcopy(config)
-        # path to latest checkpoint
-        eval_cfg_1["experiment_args"].model_name_or_path = exp.output_dir / "2"
+        eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
+            exp.output_dir,
+            "2",  # latest checkpoint
+        )
         with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
             pprint("...evaluating (first time) ...")
             eval_exp_1.evaluate()
@@ -946,9 +955,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
         # Check that basic csv stats are the same
         ###
-        original_eval_stats_file = eval_exp_1.output_dir / "eval_stats.csv"
-        new_eval_stats_file = (
-            eval_exp_1.output_dir / "eval_rerun_episodes" / "eval_stats.csv"
+        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
+        new_eval_stats_file = os.path.join(
+            eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
         )
 
         original_stats = pd.read_csv(original_eval_stats_file)
@@ -964,9 +973,13 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
 
         # TODO: Once json file i/o code has been updated, only load single episode
-        original_json_file = eval_exp_1.output_dir / "detailed_run_stats.json"
-        new_json_file = (
-            eval_exp_1.output_dir / "eval_rerun_episodes" / "detailed_run_stats.json"
+        original_json_file = os.path.join(
+            eval_exp_1.output_dir, "detailed_run_stats.json"
+        )
+        new_json_file = os.path.join(
+            eval_exp_1.output_dir,
+            "eval_rerun_episodes",
+            "detailed_run_stats.json",
         )
 
         original_detailed_stats = deserialize_json_chunks(original_json_file)
@@ -997,8 +1010,10 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         # Create a separate experiment for evaluation to mimic the us case of re-running
         # eval episodes from a pretrained model
         eval_cfg_1 = copy.deepcopy(config)
-        # path to latest checkpoint
-        eval_cfg_1["experiment_args"].model_name_or_path = exp.output_dir / "2"
+        eval_cfg_1["experiment_args"].model_name_or_path = os.path.join(
+            exp.output_dir,
+            "2",  # latest checkpoint
+        )
         with MontyObjectRecognitionExperiment(eval_cfg_1) as eval_exp_1:
             pprint("...evaluating (first time) ...")
             eval_exp_1.evaluate()
@@ -1029,9 +1044,9 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
         # Check that basic csv stats are the same
         ###
-        original_eval_stats_file = eval_exp_1.output_dir / "eval_stats.csv"
-        new_eval_stats_file = (
-            eval_exp_1.output_dir / "eval_rerun_episodes" / "eval_stats.csv"
+        original_eval_stats_file = os.path.join(eval_exp_1.output_dir, "eval_stats.csv")
+        new_eval_stats_file = os.path.join(
+            eval_exp_1.output_dir, "eval_rerun_episodes", "eval_stats.csv"
         )
 
         original_stats = pd.read_csv(original_eval_stats_file)
@@ -1047,9 +1062,13 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         ###
 
         # TODO: Once json file i/o code has been updated, only load single episode
-        original_json_file = eval_exp_1.output_dir / "detailed_run_stats.json"
-        new_json_file = (
-            eval_exp_1.output_dir / "eval_rerun_episodes" / "detailed_run_stats.json"
+        original_json_file = os.path.join(
+            eval_exp_1.output_dir, "detailed_run_stats.json"
+        )
+        new_json_file = os.path.join(
+            eval_exp_1.output_dir,
+            "eval_rerun_episodes",
+            "detailed_run_stats.json",
         )
 
         original_detailed_stats = deserialize_json_chunks(original_json_file)
@@ -1080,9 +1099,10 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
         # We are training for 3 epochs by default, load most recent indexing from 0
         print("Loading a saved checkpoint")
         cfg2 = copy.deepcopy(self.fixed_actions_feat)
-        output_dir = Path(config["logging_config"].output_dir)
-        # path to latest checkpoint
-        cfg2["experiment_args"].model_name_or_path = output_dir / "2"
+        cfg2["experiment_args"].model_name_or_path = os.path.join(
+            config["logging_config"].output_dir,
+            "2",  # latest checkpoint
+        )
         with MontyObjectRecognitionExperiment(cfg2) as exp2:
             graph_memory_1 = exp.model.learning_modules[
                 0
@@ -1130,7 +1150,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
                     exp.post_epoch()
 
         pprint("...check time out logging...")
-        train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
         self.assertEqual(
             train_stats["primary_performance"][2],
             "pose_time_out",
@@ -1187,7 +1207,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.post_epoch()
 
         pprint("...checking run stats...")
-        train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+        train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
         for i in [0, 1]:
             self.assertEqual(
                 train_stats["primary_performance"][i],
@@ -1343,14 +1363,14 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.train()
             pprint("...loading and checking train statistics...")
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_train_results(train_stats)
 
             pprint("...evaluating...")
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         self.check_eval_results(eval_stats)
 
     def gm_learn_object(
@@ -1706,14 +1726,14 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             pprint("...training...")
             exp.train()
 
-            train_stats = pd.read_csv(exp.output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
 
             pprint("...evaluating...")
             exp.evaluate()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         self.check_multilm_eval_results(
             eval_stats, num_lms=5, min_done=3, num_episodes=1
         )
@@ -1760,7 +1780,7 @@ class GraphLearningTest(BaseGraphTestCases.BaseGraphTest):
             exp.post_epoch()
 
         pprint("...loading and checking eval statistics...")
-        eval_stats = pd.read_csv(exp.output_dir / "eval_stats.csv")
+        eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
         # Just testing 1 episode here. Somehow the second rotation doesn't get
         # recognized. Probably just some parameter setting due to flaws in old
         # LM but didn't want to dig too deep into that for now.

--- a/tests/unit/habitat_sim_test.py
+++ b/tests/unit/habitat_sim_test.py
@@ -22,6 +22,7 @@ pytest.importorskip(
 )
 
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -395,8 +396,9 @@ class HabitatSimTest(unittest.TestCase):
         # Check valid data path
         with tempfile.TemporaryDirectory() as data_path:
             # Create valid habitat object
-            object_config_path = Path(data_path) / "test_obj.object_config.json"
-            with object_config_path.open("w") as json_file:
+            with open(
+                os.path.join(data_path, "test_obj.object_config.json"), "w"
+            ) as json_file:
                 json.dump(
                     {"render_asset": "icosphereSolid_subdivs_1", "mass": 1}, json_file
                 )

--- a/tests/unit/hierarchy_test.py
+++ b/tests/unit/hierarchy_test.py
@@ -8,10 +8,10 @@
 # https://opensource.org/licenses/MIT.
 
 import copy
+import os
 import shutil
 import tempfile
 import unittest
-from pathlib import Path
 from pprint import pprint
 
 import numpy as np
@@ -63,7 +63,7 @@ class HierarchyTest(BaseGraphTestCases.BaseGraphTest):
         """Code that gets executed before every test."""
         super().setUp()
 
-        self.output_dir = Path(tempfile.mkdtemp())
+        self.output_dir = tempfile.mkdtemp()
 
         base = dict(
             experiment_class=MontyObjectRecognitionExperiment,
@@ -215,7 +215,7 @@ class HierarchyTest(BaseGraphTestCases.BaseGraphTest):
             experiment_args=SupervisedPretrainingExperimentArgs(
                 supervised_lm_ids=["learning_module_1"],
                 min_lms_match=2,
-                model_name_or_path=self.output_dir / "pretrained",
+                model_name_or_path=os.path.join(self.output_dir, "pretrained"),
             ),
             monty_config=TwoLMStackedMontyConfig(
                 # set min_train_steps to 200 to send more observations to LM_1 after
@@ -231,7 +231,7 @@ class HierarchyTest(BaseGraphTestCases.BaseGraphTest):
                 do_train=False,
                 min_lms_match=1,
                 n_eval_epochs=2,
-                model_name_or_path=self.output_dir / "pretrained",
+                model_name_or_path=os.path.join(self.output_dir, "pretrained"),
             ),
             logging_config=LoggingConfig(
                 output_dir=self.output_dir,
@@ -300,16 +300,15 @@ class HierarchyTest(BaseGraphTestCases.BaseGraphTest):
         with MontyObjectRecognitionExperiment(config) as exp:
             pprint("...training...")
             exp.train()
-            output_dir = Path(exp.output_dir)
-            train_stats = pd.read_csv(output_dir / "train_stats.csv")
+            train_stats = pd.read_csv(os.path.join(exp.output_dir, "train_stats.csv"))
             self.check_hierarchical_lm_train_results(train_stats)
 
-            models = load_models_from_dir(output_dir)
+            models = load_models_from_dir(exp.output_dir)
             self.check_hierarchical_models(models)
 
             pprint("...evaluating...")
             exp.evaluate()
-            eval_stats = pd.read_csv(output_dir / "eval_stats.csv")
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
             self.check_hierarchical_lm_eval_results(eval_stats)
 
     def test_semisupervised_stacked_lms_experiment(self):
@@ -396,7 +395,7 @@ class HierarchyTest(BaseGraphTestCases.BaseGraphTest):
         with MontyObjectRecognitionExperiment(config) as exp:
             exp.evaluate()
             pprint("... loading and checking eval statistics...")
-            eval_stats = pd.read_csv(Path(exp.output_dir) / "eval_stats.csv")
+            eval_stats = pd.read_csv(os.path.join(exp.output_dir, "eval_stats.csv"))
             episode = 0
             num_lms = len(exp.model.learning_modules)
             for lm_id in range(num_lms):

--- a/tests/unit/run_parallel_test.py
+++ b/tests/unit/run_parallel_test.py
@@ -56,7 +56,7 @@ from tests.unit.graph_learning_test import MotorSystemConfigFixed
 
 class RunParallelTest(unittest.TestCase):
     def setUp(self):
-        self.output_dir = Path(tempfile.mkdtemp())
+        self.output_dir = tempfile.mkdtemp()
         self.train_rotations = [[0.0, 0.0, 0.0], [0.0, 45.0, 0.0], [0.0, 135.0, 0.0]]
         self.eval_rotations = [[0.0, 30.0, 0.0], [0.0, 60.0, 0.0], [0.0, 90.0, 0.0]]
         self.supervised_pre_training = dict(
@@ -98,13 +98,15 @@ class RunParallelTest(unittest.TestCase):
         self.eval_config = copy.deepcopy(self.supervised_pre_training)
         self.eval_config.update(
             experiment_class=MontyObjectRecognitionExperiment,
-            logging_config=LoggingConfig(output_dir=self.output_dir / "eval"),
+            logging_config=LoggingConfig(
+                output_dir=os.path.join(self.output_dir, "eval")
+            ),
             experiment_args=ExperimentArgs(
                 do_eval=True,
                 do_train=False,
                 # Tests the usual case: n_eval_epochs = len(eval_rotations)
                 n_eval_epochs=len(self.eval_rotations),
-                model_name_or_path=self.output_dir / "pretrained",
+                model_name_or_path=os.path.join(self.output_dir, "pretrained"),
             ),
             eval_env_interface_args=EnvironmentInterfacePerObjectEvalArgs(
                 object_names=["capsule3DSolid", "cubeSolid"],
@@ -130,26 +132,29 @@ class RunParallelTest(unittest.TestCase):
         # This tests that parallel code can handle n_eval_epochs < len(rotations)
         self.eval_config_lt = copy.deepcopy(self.eval_config)
         self.eval_config_lt["experiment_args"].n_eval_epochs = 2
-        self.output_dir_lt = self.output_dir / "lt"
+        self.output_dir_lt = os.path.join(self.output_dir, "lt")
         self.eval_config_lt["logging_config"].output_dir = self.output_dir_lt
         os.makedirs(self.eval_config_lt["logging_config"].output_dir)
 
         # This tests that parallel code can handle n_eval_epochs > len(rotations)
         self.eval_config_gt = copy.deepcopy(self.eval_config)
         self.eval_config_gt["experiment_args"].n_eval_epochs = 4
-        self.output_dir_gt = self.output_dir / "gt"
+        self.output_dir_gt = os.path.join(self.output_dir, "gt")
         self.eval_config_gt["logging_config"].output_dir = self.output_dir_gt
         os.makedirs(self.eval_config_gt["logging_config"].output_dir)
 
     def check_reproducibility_logs(self, serial_repro_dir, parallel_repro_dir):
-        s_param_files = sorted(serial_repro_dir.glob("*target*"))
-        p_param_files = sorted(parallel_repro_dir.glob("*target*"))
+        s_param_files = sorted(p.name for p in Path(serial_repro_dir).glob("*target*"))
+        p_param_files = sorted(
+            p.name for p in Path(parallel_repro_dir).glob("*target*")
+        )
 
         # Same param files for each episode. No more, no less.
-        self.assertEqual(
-            {p.name for p in s_param_files}, {p.name for p in p_param_files}
-        )
-        for sfile, pfile in zip(s_param_files, p_param_files):
+        self.assertEqual(set(s_param_files), set(p_param_files))
+        for file in s_param_files:
+            pfile = os.path.join(parallel_repro_dir, file)
+            sfile = os.path.join(serial_repro_dir, file)
+
             with open(pfile) as f:
                 ptarget = f.read()
 
@@ -199,12 +204,16 @@ class RunParallelTest(unittest.TestCase):
         # Compare results
         ###
         parallel_model = torch.load(
-            self.output_dir
-            / "unittest_supervised_pre_training"
-            / "pretrained"
-            / "model.pt"
+            os.path.join(
+                self.output_dir,
+                "unittest_supervised_pre_training",
+                "pretrained",
+                "model.pt",
+            )
         )
-        serial_model = torch.load(self.output_dir / "pretrained" / "model.pt")
+        serial_model = torch.load(
+            os.path.join(self.output_dir, "pretrained", "model.pt")
+        )
 
         # Same objects
         self.assertEqual(
@@ -256,10 +265,10 @@ class RunParallelTest(unittest.TestCase):
             is_unittest=True,
         )
 
-        eval_dir = self.output_dir / "eval"
-        parallel_eval_dir = eval_dir / "unittest_eval_eq"
-        serial_repro_dir = eval_dir / "reproduce_episode_data"
-        parallel_repro_dir = parallel_eval_dir / "reproduce_episode_data"
+        eval_dir = os.path.join(self.output_dir, "eval")
+        parallel_eval_dir = os.path.join(eval_dir, "unittest_eval_eq")
+        serial_repro_dir = os.path.join(eval_dir, "reproduce_episode_data")
+        parallel_repro_dir = os.path.join(parallel_eval_dir, "reproduce_episode_data")
 
         # Check that reproducibility logger has same files for both
         self.check_reproducibility_logs(serial_repro_dir, parallel_repro_dir)
@@ -269,8 +278,8 @@ class RunParallelTest(unittest.TestCase):
         # you don't know the execution order so it will have the same data, just
         # different order
 
-        scsv = pd.read_csv(eval_dir / "eval_stats.csv")
-        pcsv = pd.read_csv(parallel_eval_dir / "eval_stats.csv")
+        scsv = pd.read_csv(os.path.join(eval_dir, "eval_stats.csv"))
+        pcsv = pd.read_csv(os.path.join(parallel_eval_dir, "eval_stats.csv"))
 
         # We have to drop these columns because they are not the same in the parallel
         # and serial runs. In particular, 'stepwise_performance' and
@@ -305,15 +314,17 @@ class RunParallelTest(unittest.TestCase):
         )
 
         eval_dir_lt = self.output_dir_lt
-        parallel_eval_dir_lt = eval_dir_lt / "unittest_eval_lt"
-        serial_repro_dir_lt = eval_dir_lt / "reproduce_episode_data"
-        parallel_repro_dir_lt = parallel_eval_dir_lt / "reproduce_episode_data"
+        parallel_eval_dir_lt = os.path.join(eval_dir_lt, "unittest_eval_lt")
+        serial_repro_dir_lt = os.path.join(eval_dir_lt, "reproduce_episode_data")
+        parallel_repro_dir_lt = os.path.join(
+            parallel_eval_dir_lt, "reproduce_episode_data"
+        )
 
         # Check that reproducibility logger has same files for both
         self.check_reproducibility_logs(serial_repro_dir_lt, parallel_repro_dir_lt)
 
-        scsv_lt = pd.read_csv(eval_dir_lt / "eval_stats.csv")
-        pcsv_lt = pd.read_csv(parallel_eval_dir_lt / "eval_stats.csv")
+        scsv_lt = pd.read_csv(os.path.join(eval_dir_lt, "eval_stats.csv"))
+        pcsv_lt = pd.read_csv(os.path.join(parallel_eval_dir_lt, "eval_stats.csv"))
 
         # Remove columns that are not the same in the parallel and serial runs.
         for col in ["time", "stepwise_performance", "stepwise_target_object"]:
@@ -340,15 +351,17 @@ class RunParallelTest(unittest.TestCase):
         )
 
         eval_dir_gt = self.output_dir_gt
-        parallel_eval_dir_gt = eval_dir_gt / "unittest_eval_gt"
-        serial_repro_dir_gt = eval_dir_gt / "reproduce_episode_data"
-        parallel_repro_dir_gt = parallel_eval_dir_gt / "reproduce_episode_data"
+        parallel_eval_dir_gt = os.path.join(eval_dir_gt, "unittest_eval_gt")
+        serial_repro_dir_gt = os.path.join(eval_dir_gt, "reproduce_episode_data")
+        parallel_repro_dir_gt = os.path.join(
+            parallel_eval_dir_gt, "reproduce_episode_data"
+        )
 
         # Check that reproducibility logger has same files for both
         self.check_reproducibility_logs(serial_repro_dir_gt, parallel_repro_dir_gt)
 
-        scsv_gt = pd.read_csv(eval_dir_gt / "eval_stats.csv")
-        pcsv_gt = pd.read_csv(parallel_eval_dir_gt / "eval_stats.csv")
+        scsv_gt = pd.read_csv(os.path.join(eval_dir_gt, "eval_stats.csv"))
+        pcsv_gt = pd.read_csv(os.path.join(parallel_eval_dir_gt, "eval_stats.csv"))
 
         for col in ["time", "stepwise_performance", "stepwise_target_object"]:
             scsv_gt.drop(columns=col, inplace=True)

--- a/tests/unit/run_test.py
+++ b/tests/unit/run_test.py
@@ -17,13 +17,13 @@ pytest.importorskip(
     reason="Habitat Sim optional dependency not installed.",
 )
 
+import os
 import pathlib
 import pickle
 import shutil
 import sys
 import tempfile
 import unittest
-from pathlib import Path
 from unittest import mock
 
 import magnum as mn
@@ -158,9 +158,10 @@ class MontyRunTest(unittest.TestCase):
         sys.argv = ["monty", "-e", "test_1"]
         main(all_configs=self.CONFIGS)
 
-        output_dir = Path(self.CONFIGS["test_1"]["logging_config"].output_dir)
-
-        with open(output_dir / "test_1" / "fake_log.pkl", "rb") as f:
+        output_dir = os.path.join(
+            self.CONFIGS["test_1"]["logging_config"].output_dir, "test_1"
+        )
+        with open(os.path.join(output_dir, "fake_log.pkl"), "rb") as f:
             exp_log = pickle.load(f)
 
         self.assertListEqual(exp_log, EXPECTED_LOG)
@@ -168,9 +169,10 @@ class MontyRunTest(unittest.TestCase):
     def test_main_with_single_experiment(self):
         main(all_configs=self.CONFIGS, experiments=["test_1"])
 
-        output_dir = Path(self.CONFIGS["test_1"]["logging_config"].output_dir)
-
-        with open(output_dir / "test_1" / "fake_log.pkl", "rb") as f:
+        output_dir = os.path.join(
+            self.CONFIGS["test_1"]["logging_config"].output_dir, "test_1"
+        )
+        with open(os.path.join(output_dir, "fake_log.pkl"), "rb") as f:
             exp_log = pickle.load(f)
 
         self.assertListEqual(exp_log, EXPECTED_LOG)
@@ -178,14 +180,18 @@ class MontyRunTest(unittest.TestCase):
     def test_main_with_multiple_experiment(self):
         main(all_configs=self.CONFIGS, experiments=["test_1", "test_2"])
 
-        output_dir = Path(self.CONFIGS["test_1"]["logging_config"].output_dir)
-
-        with open(output_dir / "test_1" / "fake_log.pkl", "rb") as f:
+        output_dir_1 = os.path.join(
+            self.CONFIGS["test_1"]["logging_config"].output_dir, "test_1"
+        )
+        with open(os.path.join(output_dir_1, "fake_log.pkl"), "rb") as f:
             exp_log_1 = pickle.load(f)
 
         self.assertListEqual(exp_log_1, EXPECTED_LOG)
 
-        with open(output_dir / "test_2" / "fake_log.pkl", "rb") as f:
+        output_dir_2 = os.path.join(
+            self.CONFIGS["test_2"]["logging_config"].output_dir, "test_2"
+        )
+        with open(os.path.join(output_dir_2, "fake_log.pkl"), "rb") as f:
             exp_log_2 = pickle.load(f)
 
         self.assertListEqual(exp_log_2, EXPECTED_LOG)
@@ -193,8 +199,8 @@ class MontyRunTest(unittest.TestCase):
     def test_run(self):
         run(config=self.CONFIGS["test_1"])
 
-        output_dir = Path(self.CONFIGS["test_1"]["logging_config"].output_dir)
-        with open(output_dir / "fake_log.pkl", "rb") as f:
+        output_dir = os.path.join(self.CONFIGS["test_1"]["logging_config"].output_dir)
+        with open(os.path.join(output_dir, "fake_log.pkl"), "rb") as f:
             exp_log = pickle.load(f)
 
         self.assertListEqual(exp_log, EXPECTED_LOG)
@@ -207,9 +213,8 @@ class MontyRunTest(unittest.TestCase):
             # We want the _last_ "tests" index
             base_repo_idx += 1
         base_dir = pathlib.Path(*current_file_path.parts[:base_repo_idx])
-        exp_dir = base_dir / "benchmarks"
-        assert (exp_dir / "configs").exists()
-        sys.path.append(str(exp_dir))
+        exp_dir = os.path.join(str(base_dir), "benchmarks")
+        sys.path.append(exp_dir)
         import configs  # noqa: F401, PLC0415
 
 

--- a/tools/github_readme_sync/export.py
+++ b/tools/github_readme_sync/export.py
@@ -11,7 +11,6 @@
 import logging
 import os
 import shutil
-from pathlib import Path
 
 from slugify import slugify
 
@@ -21,7 +20,6 @@ from tools.github_readme_sync.readme import ReadMe
 
 
 def export(output_dir: str, rdme: ReadMe):
-    output_dir = Path(output_dir)
     hierarchy = []
     categories = rdme.get_categories()
 
@@ -42,7 +40,7 @@ def export(output_dir: str, rdme: ReadMe):
             "\n" if i > 0 else "" + f"{BLUE}{slugify(category['title']).upper()}{RESET}"
         )
 
-        category_folder_path = output_dir / slugify(category["title"])
+        category_folder_path = os.path.join(output_dir, slugify(category["title"]))
         os.makedirs(category_folder_path, exist_ok=True)
 
         docs_from_server = rdme.get_category_docs(category)
@@ -70,13 +68,13 @@ def process_doc(*, server_doc, hierarchy_doc, folder_path, indent_level, rdme):
     indent = INDENTATION_UNIT * indent_level
     logging.info(f"{indent}{CYAN}{hierarchy_doc['slug']}{RESET}")
 
-    doc_path = folder_path / f"{hierarchy_doc['slug']}.md"
+    doc_path = os.path.join(folder_path, f"{hierarchy_doc['slug']}.md")
     with open(doc_path, "w") as f:
         f.write(rdme.get_doc_by_slug(server_doc["slug"]))
 
     children = server_doc.get("children", [])
     if children:
-        child_folder_path = folder_path / hierarchy_doc["slug"]
+        child_folder_path = os.path.join(folder_path, hierarchy_doc["slug"])
         os.makedirs(child_folder_path, exist_ok=True)
 
     for child in children:

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -17,7 +17,6 @@ import os
 import re
 from collections import OrderedDict
 from copy import deepcopy
-from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs
 
@@ -207,7 +206,7 @@ class ReadMe:
                 return match.group(0)
 
             # Get absolute path of CSV relative to current document
-            csv_path = Path(file_path) / csv_path
+            csv_path = os.path.join(file_path, csv_path)
             csv_path = os.path.normpath(csv_path)
 
             try:
@@ -497,7 +496,7 @@ class ReadMe:
         """
 
         def replace_match(match):
-            snippet_path = Path(file_path) / match.group(1)
+            snippet_path = os.path.join(file_path, match.group(1))
             snippet_path = os.path.normpath(snippet_path)
 
             try:

--- a/tools/github_readme_sync/tests/export_test.py
+++ b/tools/github_readme_sync/tests/export_test.py
@@ -8,6 +8,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -21,7 +22,7 @@ class TestExport(unittest.TestCase):
     def setUp(self):
         # Create a temporary directory for the test
         self.test_dir = tempfile.TemporaryDirectory()
-        self.test_output_dir = Path(self.test_dir.name)
+        self.test_output_dir = self.test_dir.name
 
     def tearDown(self):
         # Clean up the temporary directory after the test
@@ -68,18 +69,22 @@ class TestExport(unittest.TestCase):
         self.assertEqual(hierarchy, expected_hierarchy)
 
         # Assert that the directory structure is created as expected
-        self.assertTrue((self.test_output_dir / "category-1").is_dir())
-        self.assertTrue((self.test_output_dir / "category-2").is_dir())
+        self.assertTrue(Path(os.path.join(self.test_output_dir, "category-1")).is_dir())
+        self.assertTrue(Path(os.path.join(self.test_output_dir, "category-2")).is_dir())
 
         # Assert that the document files are created as expected
-        self.assertTrue((self.test_output_dir / "category-1" / "doc-1.md").is_file())
-        self.assertTrue((self.test_output_dir / "category-2" / "doc-2.md").is_file())
+        self.assertTrue(
+            Path(os.path.join(self.test_output_dir, "category-1", "doc-1.md")).is_file()
+        )
+        self.assertTrue(
+            Path(os.path.join(self.test_output_dir, "category-2", "doc-2.md")).is_file()
+        )
 
         # Assert the content of the files is correct
-        with open(self.test_output_dir / "category-1" / "doc-1.md") as f:
+        with open(os.path.join(self.test_output_dir, "category-1", "doc-1.md")) as f:
             self.assertEqual(f.read(), "Content of Doc 1")
 
-        with open(self.test_output_dir / "category-2" / "doc-2.md") as f:
+        with open(os.path.join(self.test_output_dir, "category-2", "doc-2.md")) as f:
             self.assertEqual(f.read(), "Content of Doc 2")
 
 

--- a/tools/github_readme_sync/tests/hierarchy_test.py
+++ b/tools/github_readme_sync/tests/hierarchy_test.py
@@ -34,7 +34,7 @@ from tools.github_readme_sync.readme import ReadMe
 class TestHierarchyFile(unittest.TestCase):
     def setUp(self):
         self.test_dir_context = tempfile.TemporaryDirectory()
-        self.test_dir = Path(self.test_dir_context.name)
+        self.test_dir = self.test_dir_context.name
         self.server = None
         self.server_thread = None
 
@@ -62,7 +62,7 @@ class TestHierarchyFile(unittest.TestCase):
         ]
         create_hierarchy_file(self.test_dir, hierarchy_structure)
 
-        hierarchy_file_path = self.test_dir / HIERARCHY_FILE
+        hierarchy_file_path = os.path.join(self.test_dir, HIERARCHY_FILE)
         self.assertTrue(os.path.exists(hierarchy_file_path))
 
         with open(hierarchy_file_path) as f:
@@ -81,22 +81,22 @@ class TestHierarchyFile(unittest.TestCase):
             )
 
     def test_check_hierarchy_file_success(self):
-        hierarchy_file = self.test_dir / HIERARCHY_FILE
+        hierarchy_file = os.path.join(self.test_dir, HIERARCHY_FILE)
         with open(hierarchy_file, "w") as f:
             f.write(
                 f"{CATEGORY_PREFIX}category-1: Category 1\n"
                 f"{DOCUMENT_PREFIX}[doc-1](category-1/doc-1.md)\n"
             )
 
-        os.makedirs(self.test_dir / "category-1")
-        doc_file = self.test_dir / "category-1" / "doc-1.md"
+        os.makedirs(os.path.join(self.test_dir, "category-1"))
+        doc_file = os.path.join(self.test_dir, "category-1", "doc-1.md")
         with open(doc_file, "w") as f:
             f.write("---\ntitle: Doc 1\n---\nContent")
 
         check_hierarchy_file(self.test_dir)
 
     def test_check_hierarchy_file_duplicate_slugs(self):
-        hierarchy_file = self.test_dir / HIERARCHY_FILE
+        hierarchy_file = os.path.join(self.test_dir, HIERARCHY_FILE)
         with open(hierarchy_file, "w") as f:
             f.write(
                 f"{CATEGORY_PREFIX}category-1: Category 1\n"
@@ -104,12 +104,12 @@ class TestHierarchyFile(unittest.TestCase):
                 f"{DOCUMENT_PREFIX}[doc-1](doc-1.md)\n"
             )
 
-        os.makedirs(self.test_dir / "category-1")
-        doc_file1 = self.test_dir / "category-1" / "doc-1.md"
+        os.makedirs(os.path.join(self.test_dir, "category-1"))
+        doc_file1 = os.path.join(self.test_dir, "category-1", "doc-1.md")
         with open(doc_file1, "w") as f:
             f.write("---\ntitle: Doc 1\n---\nContent")
 
-        doc_file2 = self.test_dir / "doc-1.md"
+        doc_file2 = os.path.join(self.test_dir, "doc-1.md")
         with open(doc_file2, "w") as f:
             f.write("---\ntitle: Doc 1\n---\nContent")
 
@@ -120,15 +120,15 @@ class TestHierarchyFile(unittest.TestCase):
         self.assertTrue(any("Duplicate" in message for message in log.output))
 
     def test_check_hierarchy_broken_link_in_file(self):
-        hierarchy_file = self.test_dir / HIERARCHY_FILE
+        hierarchy_file = os.path.join(self.test_dir, HIERARCHY_FILE)
         with open(hierarchy_file, "w") as f:
             f.write(
                 f"{CATEGORY_PREFIX}category-1: Category 1\n"
                 f"{DOCUMENT_PREFIX}[doc-1](category-1/doc-1.md)\n"
             )
 
-        os.makedirs(self.test_dir / "category-1")
-        doc_file = self.test_dir / "category-1" / "doc-1.md"
+        os.makedirs(os.path.join(self.test_dir, "category-1"))
+        doc_file = os.path.join(self.test_dir, "category-1", "doc-1.md")
         with open(doc_file, "w") as f:
             f.write(
                 "---\ntitle: Doc 1\n---\nContent\n"
@@ -136,7 +136,7 @@ class TestHierarchyFile(unittest.TestCase):
                 "[fragment](category-1/missing.md#fragment)"
             )
 
-        existing_file = self.test_dir / "category-1" / "existing.md"
+        existing_file = os.path.join(self.test_dir, "category-1", "existing.md")
         with open(existing_file, "w") as f:
             f.write("---\ntitle: Existing Doc\n---\nContent")
 
@@ -172,7 +172,7 @@ class TestHierarchyFile(unittest.TestCase):
         while not hasattr(self, "server_url"):
             pass
 
-        test_file = self.test_dir / "test_external_links.md"
+        test_file = os.path.join(self.test_dir, "test_external_links.md")
         with open(test_file, "w") as f:
             f.write(f"[Valid Link]({self.server_url}/valid)\n")
             f.write(f"[Missing Link]({self.server_url}/missing)\n")

--- a/tools/github_readme_sync/tests/readme_test.py
+++ b/tools/github_readme_sync/tests/readme_test.py
@@ -648,24 +648,22 @@ This is a test document.""",
 
     def test_convert_csv_to_html_table_relative_path(self):
         # Create a temporary directory structure
-        with tempfile.TemporaryDirectory() as tmp_dir_str:
-            tmp_dir = Path(tmp_dir_str)
-
+        with tempfile.TemporaryDirectory() as tmp_dir:
             # Create subdirectories
-            data_dir = tmp_dir / "data"
-            docs_dir = tmp_dir / "docs"
+            data_dir = os.path.join(tmp_dir, "data")
+            docs_dir = os.path.join(tmp_dir, "docs")
             os.makedirs(data_dir)
             os.makedirs(docs_dir)
 
             # Create a CSV file in the data directory
-            csv_path = data_dir / "test.csv"
+            csv_path = os.path.join(data_dir, "test.csv")
             with open(csv_path, "w") as f:
                 writer = csv.writer(f)
                 writer.writerow(["Header 1", "Header 2"])
                 writer.writerow(["Value 1", "Value 2"])
 
             # Create a mock markdown file path in the docs directory
-            doc_path = docs_dir / "doc.md"
+            doc_path = os.path.join(docs_dir, "doc.md")
 
             # Test relative path from doc to csv
             result = self.readme.convert_csv_to_html_table(
@@ -683,19 +681,18 @@ This is a test document.""",
             self.assertIn("</table></div>", result)
 
     def test_insert_markdown_snippet(self):
-        with tempfile.TemporaryDirectory() as tmp_dir_str:
-            tmp_dir = Path(tmp_dir_str)
-            docs_dir = tmp_dir / "docs"
-            other_dir = tmp_dir / "other"
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            docs_dir = os.path.join(tmp_dir, "docs")
+            other_dir = os.path.join(tmp_dir, "other")
             os.makedirs(docs_dir)
             os.makedirs(other_dir)
 
-            source_md = other_dir / "source.md"
+            source_md = os.path.join(other_dir, "source.md")
             with open(source_md, "w") as f:
                 f.write(
                     "# Test Header\nThis is test content\n* List item 1\n* List item 2"
                 )
-            doc_path = docs_dir / "doc.md"
+            doc_path = os.path.join(docs_dir, "doc.md")
 
             result = self.readme.insert_markdown_snippet(
                 "!snippet[../../other/source.md]", doc_path

--- a/tools/github_readme_sync/upload.py
+++ b/tools/github_readme_sync/upload.py
@@ -10,7 +10,6 @@
 
 import logging
 import os
-from pathlib import Path
 
 from tools.github_readme_sync.colors import BLUE, CYAN, GRAY, RESET, WHITE
 from tools.github_readme_sync.hierarchy import INDENTATION_UNIT
@@ -124,7 +123,7 @@ def print_child(level: int, doc: dict, created: bool):
 
 
 def load_doc(file_path: str, category_slug: str, child: dict):
-    file_path = Path(file_path) / category_slug / f"{child['slug']}.md"
+    file_path = os.path.join(file_path, category_slug, f"{child['slug']}.md")
     if not os.path.exists(file_path):
         raise ValueError(f"File {file_path} does not exist")
 

--- a/tools/print_version/cli.py
+++ b/tools/print_version/cli.py
@@ -10,14 +10,15 @@
 
 import argparse
 import importlib.util
-from pathlib import Path
+import os
 
 import semver
 
 
 def get_version():
-    project_root = Path(__file__).resolve().parent.parent.parent
-    version_module_path = project_root / "src" / "tbp" / "monty" / "__init__.py"
+    version_module_path = os.path.join(
+        os.path.dirname(__file__), "../../src/tbp/monty/__init__.py"
+    )
 
     spec = importlib.util.spec_from_file_location("tbp.monty", version_module_path)
     module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
This reverts commit d904fce126aa48d82dcb517b3e0c691926d5dfbe due to test failures.

#545 was inadvertently merged due to a GitHub infrastructure outage, which appears to have had the effect of making skipped checks be treated as not required.

FYI @carver 