### PR TITLE
docs!: update benchmark results for compositional models

### DIFF
--- a/benchmarks/results/logos_on_objects.csv
+++ b/benchmarks/results/logos_on_objects.csv
@@ -1,6 +1,6 @@
 Experiment,Correct Child or Parent (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Avg Prediction Error|align right,Run Time (mins)|align right
-infer_comp_lvl1_with_monolithic_models,64.29,61.9,354.17,77.31,0.37,29
-infer_comp_lvl1_with_comp_models,83.33,32.14,50.46,54.89,0.36,4
-infer_comp_lvl2_with_comp_models,86.19,28.57,35.23,42.13,0.36,10
-infer_comp_lvl3_with_comp_models,64.57,48.57,34.97,50.01,0.37,18
-infer_comp_lvl4_with_comp_models,66.21,46.15,35.87,40.45,0.37,19
+infer_comp_lvl1_with_monolithic_models,64.29,61.9,354,77.31,0.37,28
+infer_comp_lvl1_with_comp_models,77.38,44.05,51,37.75,0.33,4
+infer_comp_lvl2_with_comp_models,81.90,40.48,35,36.59,0.33,10
+infer_comp_lvl3_with_comp_models,60.00,58.00,35,47.75,0.34,18
+infer_comp_lvl4_with_comp_models,59.89,55.22,36,44.10,0.34,18


### PR DESCRIPTION
Commit [c8190776a2a2](https://github.com/ramyamounir/tbp.monty/commit/c8190776a2a26c6b83ef681d3a8385873dec6fb5) includes object id in matching which affects the compositional models experiment. The higher LM now uses the lower LM object ids for matching which affects the performance. Here are the effects:

Runs are on WandB tagged under `PR#569`:

### infer_comp_lvl1_with_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 64.29 | 64.29 | 0 | ⬜ |
| used_mlh (%) | 61.9 | 61.9 | 0 | ⬜ |
| match_steps | 354 | 354 | 0 | ⬜ |
| rotation_error (deg) | 77.31 | 77.31 | 0 | ⬜ |
| avg_prediction_error | 0.37 | 0.37 | 0 | ⬜ |
| runtime (min) | 29 | 28 | -1 | ✅ |

### infer_comp_lvl1_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 83.33 | 77.38 | -5.95 | ❌ |
| used_mlh (%) | 32.14 | 44.05 | 11.91 | ❌ |
| match_steps | 50 | 51 | 1 | ❌ |
| rotation_error (deg) | 54.89 | 37.75 | -17.14 | ✅ |
| avg_prediction_error | 0.36 | 0.33 | -0.03 | ✅ |
| runtime (min) | 4 | 4 | 0 | ⬜ |

### infer_comp_lvl2_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 86.19 | 81.9 | -4.29 | ❌ |
| used_mlh (%) | 28.57 | 40.48 | 11.91 | ❌ |
| match_steps | 35 | 35 | 0 | ⬜ |
| rotation_error (deg) | 42.13 | 36.59 | -5.54 | ✅ |
| avg_prediction_error | 0.36 | 0.33 | -0.03 | ✅ |
| runtime (min) | 10 | 10 | 0 | ⬜ |

### infer_comp_lvl3_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 64.57 | 60 | -4.57 | ❌ |
| used_mlh (%) | 48.57 | 58 | 9.43 | ❌ |
| match_steps | 35 | 35 | 0 | ⬜ |
| rotation_error (deg) | 50.01 | 47.75 | -2.26 | ✅ |
| avg_prediction_error | 0.37 | 0.34 | -0.03 | ✅ |
| runtime (min) | 18 | 18 | 0 | ⬜ |

### infer_comp_lvl4_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 66.21 | 59.89 | -6.32 | ❌ |
| used_mlh (%) | 46.15 | 55.22 | 9.07 | ❌ |
| match_steps | 36 | 36 | 0 | ⬜ |
| rotation_error (deg) | 40.45 | 44.1 | 3.65 | ❌ |
| avg_prediction_error | 0.37 | 0.34 | -0.03 | ✅ |
| runtime (min) | 19 | 18 | -1 | ✅ |

FYI @tristanls-tbp , @hlee9212 