### PR TITLE
docs: add back accidentally deleted TODO comment

### DIFF
--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -341,6 +341,7 @@ class GraphLearningTest(BaseGraphTest):
         eval_cfg_1.test.config.n_eval_epochs = 1
         eval_exp_1 = hydra.utils.instantiate(eval_cfg_1.test)
         with eval_exp_1:
+            # TODO: update so it only runs one episode
             eval_exp_1.evaluate()
 
         # Create detailed follow-up experiment


### PR DESCRIPTION
This TODO was accidentally deleted during the config refactor in #540 and it was supposed to be included but my push was rejected due to changes on the remote, and I didn't see the error message until after that PR was merged.