### PR TITLE
chore: rename secret names to match those on tbp.monty

### DIFF
--- a/.github/workflows/future_work_widget_deploy.yml
+++ b/.github/workflows/future_work_widget_deploy.yml
@@ -76,13 +76,13 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.FUTURE_WORK_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.FUTURE_WORK_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.FUTUREWORK_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.FUTUREWORK_SECRET_ACCESS_KEY }}
           aws-region: ${{ 'us-east-1' }}
       - name: Upload future work widget to S3
         run: |
           # Called twice to prevent downtime during deployment.
           # First sync to ensure new files are uploaded.
           # Second sync to delete any files that are no longer in the source directory.
-          aws s3 sync "${{ runner.temp }}/future-work-widget/" s3://${{ secrets.FUTURE_WORK_S3_BUCKET_NAME }}/
-          aws s3 sync "${{ runner.temp }}/future-work-widget/" s3://${{ secrets.FUTURE_WORK_S3_BUCKET_NAME }}/ --delete
+          aws s3 sync "${{ runner.temp }}/future-work-widget/" s3://${{ secrets.FUTUREWORK_S3_BUCKET_NAME }}/
+          aws s3 sync "${{ runner.temp }}/future-work-widget/" s3://${{ secrets.FUTUREWORK_S3_BUCKET_NAME }}/ --delete


### PR DESCRIPTION
Too many underscores in the versions I was using on my fork.