### PR TITLE
chore: podcast no longer exists

### DIFF
--- a/docs/future-work/oss-communication-improvements/organize-start-podcast-series.md
+++ b/docs/future-work/oss-communication-improvements/organize-start-podcast-series.md
@@ -4,7 +4,7 @@ rfc: required
 estimated-scope: large
 improved-metric: community-engagement
 skills: interviewing, writing, audio-editing, video-production
-output-type: audio, podcast
+output-type: audio, video
 ---
 
 We  would like to organize and start a podcast series that covers the Thousand Brains Project / Theory or adjacent topics.

--- a/docs/snippets/future-work-output-type.md
+++ b/docs/snippets/future-work-output-type.md
@@ -1,1 +1,1 @@
-`documentation` `website` `tutorial` `automation` `video` `community-event` `audio` 
+`documentation` `website` `tutorial` `automation` `video` `community-event` `audio`


### PR DESCRIPTION
This fixes the broken build, but does not address why the validate future work items was not failing in the original PR.  That will be addressed in a separete PR.