### PR TITLE
chore: use runners with 16GB of memory to install Monty

### DIFF
--- a/.github/workflows/future_work_widget_deploy.yml
+++ b/.github/workflows/future_work_widget_deploy.yml
@@ -17,7 +17,9 @@ on:
 jobs:
   install_monty:
     name: install-monty
-    runs-on: ubuntu-latest
+    runs-on:
+      group: tbp.monty
+      labels: tbp-linux-x64-ubuntu2204-4core
     if: ${{ github.repository_owner == 'thousandbrainsproject' }}
     outputs:
       conda_env_cache_key_sha: ${{ steps.install_monty.outputs.conda_env_cache_key_sha }}

--- a/.github/workflows/future_work_widget_validate.yml
+++ b/.github/workflows/future_work_widget_validate.yml
@@ -18,7 +18,9 @@ on:
 jobs:
   install_monty:
     name: install-monty
-    runs-on: ubuntu-latest
+    runs-on:
+      group: tbp.monty
+      labels: tbp-linux-x64-ubuntu2204-4core
     if: ${{ github.repository_owner == 'thousandbrainsproject' }}
     outputs:
       conda_env_cache_key_sha: ${{ steps.install_monty.outputs.conda_env_cache_key_sha }}

--- a/.github/workflows/monty.yml
+++ b/.github/workflows/monty.yml
@@ -251,7 +251,7 @@ jobs:
     name: install-monty
     runs-on:
       group: tbp.monty
-      labels: tbp-linux-x64-ubuntu2204-2core
+      labels: tbp-linux-x64-ubuntu2204-4core
     needs:
       - check_license_monty # Don't run if license check fails
       - should_run_monty


### PR DESCRIPTION
In #575, @carver identified that OOM-killer kills the `conda` process when installing Monty. This pull request doubles the available memory from 8GB to 16GB for the `install_monty` jobs.

Note that some install Monty job steps on `ubuntu-latest` (a smaller runner) attempt to install Monty if it cannot be retrieved from the cache. I did not double memory for those machines, as not finding the cache has not been a problem. However, if it becomes a problem, then those runners might need to be larger as well.