### PR TITLE
refactor: enable ruff PTH107 for Path.unlink()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,6 @@ ignore = [
     "PT018", # PT018: Assertion should be broken down into multiple parts
     "PT027", # PT027: Use `pytest.raises` instead of unittest-style `assertRaises`
     "PTH103", # PTH103: `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
-    "PTH107", # PTH107: `os.remove()` should be replaced by `Path.unlink()`
     "PTH110", # PTH110: `os.path.exists()` should be replaced by `Path.exists()`
     "PTH111", # PTH111: `os.path.expanduser()` should be replaced by `Path.expanduser()`
     "PTH119", # PTH119: `os.path.basename()` should be replaced by `Path.name`

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -70,11 +70,12 @@ def mv_files(filenames: Iterable[Path], outdir: Path):
 
 
 def cat_files(filenames, outfile):
+    outfile = Path(outfile)
     if os.path.exists(outfile):
         print(f"Removing existing file before writing new one: {outfile}")
-        os.remove(outfile)
+        outfile.unlink()
 
-    Path(outfile).touch()  # create file that captures output
+    outfile.touch()  # create file that captures output
     for file in filenames:
         os.system(f"cat {file} >> {outfile}")
 
@@ -104,8 +105,7 @@ def post_parallel_log_cleanup(filenames, outfile, cat_fn):
 
     # Remove json files
     for f in existing_files:
-        if os.path.exists(f):
-            os.remove(f)
+        Path(f).unlink(missing_ok=True)
 
 
 def post_parallel_profile_cleanup(parallel_dirs, base_dir, mode):


### PR DESCRIPTION
Use `Path.unlink()` instead of `os.remove(path_str)`. When it doesn't affect functionality, use `.unlink(missing_ok=True)` to avoid an `os.path.exists(path_str)` check first.