### PR TITLE
refactor: enable ruff rule PTH103, use Path.mkdir()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,6 @@ ignore = [
     "PT009", # PT009: Use a regular `assert` instead of unittest-style `assertEqual`
     "PT018", # PT018: Assertion should be broken down into multiple parts
     "PT027", # PT027: Use `pytest.raises` instead of unittest-style `assertRaises`
-    "PTH103", # PTH103: `os.makedirs()` should be replaced by `Path.mkdir(parents=True)`
     "PTH110", # PTH110: `os.path.exists()` should be replaced by `Path.exists()`
     "PTH111", # PTH111: `os.path.expanduser()` should be replaced by `Path.expanduser()`
     "PTH119", # PTH119: `os.path.basename()` should be replaced by `Path.name`

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import copy
 import datetime
 import logging
-import os
 import pprint
 from pathlib import Path
 from typing import Any, Literal
@@ -326,8 +325,7 @@ class MontyExperiment:
         self.output_dir = Path(logging_config["output_dir"])
         self.run_name = logging_config["run_name"]
 
-        if not os.path.exists(self.output_dir):
-            os.makedirs(self.output_dir)
+        self.output_dir.mkdir(exist_ok=True, parents=True)
 
         # Treat as root logger
         logger.propagate = False
@@ -596,7 +594,7 @@ class MontyExperiment:
         model_state_dict = self.model.state_dict()
         exp_state_dict = self.state_dict()
         output_dir = output_dir if output_dir is not None else self.output_dir
-        os.makedirs(output_dir, exist_ok=True)
+        output_dir.mkdir(exist_ok=True, parents=True)
         # When performing evaluation with parallel runs on a remote server
         # (assumed if we are using parallel wandb logging), then don't save models;
         # these can fill a huge amount of hard-disk memory before they are cleaned up

--- a/src/tbp/monty/frameworks/experiments/profile.py
+++ b/src/tbp/monty/frameworks/experiments/profile.py
@@ -9,7 +9,6 @@
 # https://opensource.org/licenses/MIT.
 
 import cProfile
-import os
 from pathlib import Path
 
 import pandas as pd
@@ -72,7 +71,7 @@ class ProfileExperimentMixin:
 
     def make_profile_dir(self):
         self.profile_dir = Path(self.output_dir) / "profile"
-        os.makedirs(self.profile_dir, exist_ok=True)
+        self.profile_dir.mkdir(exist_ok=True, parents=True)
 
     def setup_experiment(self, config):
         filename = "profile-setup_experiment.csv"

--- a/src/tbp/monty/frameworks/loggers/monty_handlers.py
+++ b/src/tbp/monty/frameworks/loggers/monty_handlers.py
@@ -167,7 +167,7 @@ class DetailedJSONHandler(MontyHandler):
             stats: Dictionary containing episode stats keyed by global episode id.
         """
         episodes_dir = Path(output_dir) / "detailed_run_stats"
-        os.makedirs(episodes_dir, exist_ok=True)
+        episodes_dir.mkdir(exist_ok=True, parents=True)
 
         episode_file = episodes_dir / f"episode_{global_episode_id:06d}.json"
         maybe_rename_existing_file(episode_file)
@@ -310,7 +310,7 @@ class ReproduceEpisodeHandler(MontyHandler):
         # Set up data directory with reproducibility info for each episode
         if not hasattr(self, "data_dir"):
             self.data_dir = Path(output_dir) / "reproduce_episode_data"
-            os.makedirs(self.data_dir, exist_ok=True)
+            self.data_dir.mkdir(exist_ok=True, parents=True)
 
         # TODO: store a pointer to the training model
         # something like if train_epochs == 0:

--- a/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
@@ -52,7 +52,7 @@ class LoggerSDR:
         # overwrite existing logs
         if os.path.exists(path):
             shutil.rmtree(path)
-        os.makedirs(path)
+        path.mkdir(parents=True)
 
         self.path = path
         self.episode = 0

--- a/src/tbp/monty/frameworks/run.py
+++ b/src/tbp/monty/frameworks/run.py
@@ -46,7 +46,7 @@ def main(cfg: DictConfig):
     )
     cfg.experiment.config.logging.output_dir = str(output_dir)
 
-    os.makedirs(cfg.experiment.config.logging.output_dir, exist_ok=True)
+    output_dir.mkdir(exist_ok=True, parents=True)
     experiment = hydra.utils.instantiate(cfg.experiment)
     start_time = time.time()
     with experiment as exp:

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -138,7 +138,7 @@ def move_reproducibility_data(base_dir, parallel_dirs):
     if os.path.exists(outdir):
         shutil.rmtree(outdir)
 
-    os.makedirs(outdir)
+    outdir.mkdir(parents=True)
     repro_dirs = [Path(pdir) / "reproduce_episode_data" for pdir in parallel_dirs]
 
     # Headache to accont for the fact that everyone is episode 0
@@ -381,7 +381,8 @@ def generate_parallel_train_configs(experiment: DictConfig, name: str) -> list[M
 
 
 def single_train(experiment):
-    os.makedirs(experiment["config"]["logging"]["output_dir"], exist_ok=True)
+    output_dir = Path(experiment["config"]["logging"]["output_dir"])
+    output_dir.mkdir(exist_ok=True, parents=True)
     exp = hydra.utils.instantiate(experiment)
     with exp:
         print("---------training---------")
@@ -389,7 +390,8 @@ def single_train(experiment):
 
 
 def single_evaluate(experiment):
-    os.makedirs(experiment["config"]["logging"]["output_dir"], exist_ok=True)
+    output_dir = Path(experiment["config"]["logging"]["output_dir"])
+    output_dir.mkdir(exist_ok=True, parents=True)
     exp = hydra.utils.instantiate(experiment)
     with exp:
         print("---------evaluating---------")
@@ -561,10 +563,11 @@ def post_parallel_train(experiments: list[Mapping], base_dir: str) -> None:
     with exp:
         exp.model.load_state_dict_from_parallel(parallel_dirs, True)
         output_dir = os.path.dirname(experiments[0]["config"]["logging"]["output_dir"])
+        output_dir = Path(output_dir)
         if isinstance(exp, MontySupervisedObjectPretrainingExperiment):
-            output_dir = Path(output_dir) / "pretrained"
-        os.makedirs(output_dir, exist_ok=True)
-        saved_model_file = Path(output_dir) / "model.pt"
+            output_dir = output_dir / "pretrained"
+        output_dir.mkdir(exist_ok=True, parents=True)
+        saved_model_file = output_dir / "model.pt"
         torch.save(exp.model.state_dict(), saved_model_file)
 
     if pretraining:

--- a/src/tbp/monty/frameworks/utils/follow_up_configs.py
+++ b/src/tbp/monty/frameworks/utils/follow_up_configs.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import copy
 import json
-import os
 from pathlib import Path
 
 import torch
@@ -209,7 +208,7 @@ def create_eval_episode_config(
 
     # Second, update the output directory, run_name, set resume to True
     new_output_dir = output_dir / f"eval_episode_{episode}_rerun"
-    os.makedirs(new_output_dir, exist_ok=True)
+    new_output_dir.mkdir(exist_ok=True, parents=True)
     new_config["logging"]["output_dir"] = new_output_dir
     new_config["logging"]["run_name"] = run_name
     new_config["logging"]["resume_wandb_run"] = True
@@ -344,7 +343,7 @@ def create_eval_config_multiple_episodes(
 
     # Update the output directory to be a "rerun" subdir
     new_output_dir = output_dir / "eval_rerun_episodes"
-    os.makedirs(new_output_dir, exist_ok=True)
+    new_output_dir.mkdir(exist_ok=True, parents=True)
     new_config["logging"]["output_dir"] = new_output_dir
     new_config["logging"]["run_name"] = run_name
     new_config["logging"]["resume_wandb_run"] = True

--- a/src/tbp/monty/frameworks/utils/plot_utils_dev.py
+++ b/src/tbp/monty/frameworks/utils/plot_utils_dev.py
@@ -14,7 +14,7 @@ files to segment what is imported.
 
 from __future__ import annotations
 
-import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Sequence, cast
 
 import matplotlib.pyplot as plt
@@ -542,8 +542,7 @@ def show_initial_hypotheses(
     possible_ax = ["x", "y", "z"]
     plt.title(f"Possible Rotations along {possible_ax[axis]} axis")
     if save_fig:
-        if not os.path.exists(save_path):
-            os.makedirs(save_path)
+        Path(save_path).mkdir(exist_ok=True, parents=True)
         print("figure saved at " + save_path)
         plt.savefig(
             save_path + f"initialH_{episode}_{obj}_{possible_ax[axis]}.png",
@@ -722,8 +721,7 @@ def plot_evidence_at_step(
         ax2.set_xticks([]), ax2.set_yticks([]), ax2.set_zticks([])
 
     if save_fig:
-        if not os.path.exists(save_path):
-            os.makedirs(save_path)
+        Path(save_path).mkdir(exist_ok=True, parents=True)
         print("figure saved at " + save_path)
         plt.savefig(
             save_path + f"{episode}_{step}.png",
@@ -1217,8 +1215,7 @@ class PolicyPlot:
         self.ax.set_aspect("equal")
 
         if save_path is not None:
-            if not os.path.exists(save_path):
-                os.makedirs(save_path)
+            Path(save_path).mkdir(exist_ok=True, parents=True)
             print("figure saved at " + save_path)
             plt.savefig(
                 save_path + f"{self.episode}.png",
@@ -1301,8 +1298,7 @@ def plot_learned_graph(
         ax.view_init(view[0], view[1])
 
     if save_fig:
-        if not os.path.exists(save_path):
-            os.makedirs(save_path)
+        Path(save_path).mkdir(exist_ok=True, parents=True)
         print("figure saved at " + save_path)
         plt.savefig(
             save_path + f"{episode}.png",
@@ -1472,8 +1468,7 @@ def plot_graph_mismatch(
         ax.view_init(view[0], view[1])
 
     if save_fig:
-        if not os.path.exists(save_path):
-            os.makedirs(save_path)
+        Path(save_path).mkdir(exist_ok=True, parents=True)
         plt.savefig(
             fname=save_path + plot_name,
             dpi=300,
@@ -1561,8 +1556,7 @@ def plot_hotspots(
         ax.view_init(view[0], view[1])
 
     if save_fig:
-        if not os.path.exists(save_path):
-            os.makedirs(save_path)
+        Path(save_path).mkdir(exist_ok=True, parents=True)
         print("figure saved at " + save_path)
         plt.savefig(
             save_path,

--- a/tools/github_readme_sync/export.py
+++ b/tools/github_readme_sync/export.py
@@ -28,7 +28,7 @@ def export(output_dir: str, rdme: ReadMe):
     if os.path.exists(output_dir):
         shutil.rmtree(output_dir)
 
-    os.makedirs(output_dir, exist_ok=True)
+    output_dir.mkdir(exist_ok=True, parents=True)
 
     for i, category in enumerate(categories):
         category_entry = {
@@ -43,7 +43,7 @@ def export(output_dir: str, rdme: ReadMe):
         )
 
         category_folder_path = output_dir / slugify(category["title"])
-        os.makedirs(category_folder_path, exist_ok=True)
+        category_folder_path.mkdir(exist_ok=True, parents=True)
 
         docs_from_server = rdme.get_category_docs(category)
         for server_doc in docs_from_server:
@@ -77,7 +77,7 @@ def process_doc(*, server_doc, hierarchy_doc, folder_path, indent_level, rdme):
     children = server_doc.get("children", [])
     if children:
         child_folder_path = folder_path / hierarchy_doc["slug"]
-        os.makedirs(child_folder_path, exist_ok=True)
+        child_folder_path.mkdir(exist_ok=True, parents=True)
 
     for child in children:
         child_entry = {

--- a/tools/github_readme_sync/index.py
+++ b/tools/github_readme_sync/index.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from pathlib import Path
 
 import nh3
@@ -102,7 +101,7 @@ def generate_index(docs_dir: str, output_file_path: str) -> str:
 
     entries = process_markdown_files(docs_dir)
 
-    os.makedirs(Path(output_file_path).parent, exist_ok=True)
+    Path(output_file_path).parent.mkdir(exist_ok=True, parents=True)
     with open(output_file_path, "w", encoding="utf-8") as f:
         json.dump(entries, f, indent=2, ensure_ascii=False)
 

--- a/tools/github_readme_sync/tests/file_test.py
+++ b/tools/github_readme_sync/tests/file_test.py
@@ -20,11 +20,12 @@ from tools.github_readme_sync.file import find_markdown_files, get_folders
 class TestGetFolders(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
+        temp_dir_path = Path(self.temp_dir)
 
-        os.makedirs(Path(self.temp_dir).joinpath("folder1"))
-        os.makedirs(Path(self.temp_dir).joinpath("folder2"))
-        open(Path(self.temp_dir).joinpath("file1.txt"), "w").close()
-        open(Path(self.temp_dir).joinpath("file2.txt"), "w").close()
+        (temp_dir_path / "folder1").mkdir(parents=True)
+        (temp_dir_path / "folder2").mkdir(parents=True)
+        open(temp_dir_path / "file1.txt", "w").close()
+        open(temp_dir_path / "file2.txt", "w").close()
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)

--- a/tools/github_readme_sync/tests/hierarchy_test.py
+++ b/tools/github_readme_sync/tests/hierarchy_test.py
@@ -88,7 +88,7 @@ class TestHierarchyFile(unittest.TestCase):
                 f"{DOCUMENT_PREFIX}[doc-1](category-1/doc-1.md)\n"
             )
 
-        os.makedirs(self.test_dir / "category-1")
+        (self.test_dir / "category-1").mkdir(parents=True)
         doc_file = self.test_dir / "category-1" / "doc-1.md"
         with open(doc_file, "w") as f:
             f.write("---\ntitle: Doc 1\n---\nContent")
@@ -104,7 +104,7 @@ class TestHierarchyFile(unittest.TestCase):
                 f"{DOCUMENT_PREFIX}[doc-1](doc-1.md)\n"
             )
 
-        os.makedirs(self.test_dir / "category-1")
+        (self.test_dir / "category-1").mkdir(parents=True)
         doc_file1 = self.test_dir / "category-1" / "doc-1.md"
         with open(doc_file1, "w") as f:
             f.write("---\ntitle: Doc 1\n---\nContent")
@@ -127,7 +127,7 @@ class TestHierarchyFile(unittest.TestCase):
                 f"{DOCUMENT_PREFIX}[doc-1](category-1/doc-1.md)\n"
             )
 
-        os.makedirs(self.test_dir / "category-1")
+        (self.test_dir / "category-1").mkdir(parents=True)
         doc_file = self.test_dir / "category-1" / "doc-1.md"
         with open(doc_file, "w") as f:
             f.write(

--- a/tools/github_readme_sync/tests/readme_test.py
+++ b/tools/github_readme_sync/tests/readme_test.py
@@ -654,8 +654,8 @@ This is a test document.""",
             # Create subdirectories
             data_dir = tmp_dir / "data"
             docs_dir = tmp_dir / "docs"
-            os.makedirs(data_dir)
-            os.makedirs(docs_dir)
+            data_dir.mkdir(parents=True)
+            docs_dir.mkdir(parents=True)
 
             # Create a CSV file in the data directory
             csv_path = data_dir / "test.csv"
@@ -687,8 +687,8 @@ This is a test document.""",
             tmp_dir = Path(tmp_dir_str)
             docs_dir = tmp_dir / "docs"
             other_dir = tmp_dir / "other"
-            os.makedirs(docs_dir)
-            os.makedirs(other_dir)
+            docs_dir.mkdir(parents=True)
+            other_dir.mkdir(parents=True)
 
             source_md = other_dir / "source.md"
             with open(source_md, "w") as f:


### PR DESCRIPTION
`os.makedirs()` creates all folders in the path, which is the equivalent of `Path.mkdir(parents=True)`. So `parents=True` is used in all replacements. `exist_ok=True` is used sometimes, instead of doing a file `exists()` check first.