### PR TITLE
refactor: enable ruff rule PTH120 for Path.parent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -257,7 +257,6 @@ ignore = [
     "PT018", # PT018: Assertion should be broken down into multiple parts
     "PT027", # PT027: Use `pytest.raises` instead of unittest-style `assertRaises`
     "PTH119", # PTH119: `os.path.basename()` should be replaced by `Path.name`
-    "PTH120", # PTH120: `os.path.dirname()` should be replaced by `Path.parent`
     "PTH123", # PTH123: `open()` should be replaced by `Path.open()`
     "RET503", # RET503: Missing explicit `return` at the end of function able to return non-`None` value
     "RUF005", # RUF005: Consider {expression} instead of concatenation

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -562,8 +562,7 @@ def post_parallel_train(experiments: list[Mapping], base_dir: str) -> None:
 
     with exp:
         exp.model.load_state_dict_from_parallel(parallel_dirs, True)
-        output_dir = os.path.dirname(experiments[0]["config"]["logging"]["output_dir"])
-        output_dir = Path(output_dir)
+        output_dir = Path(experiments[0]["config"]["logging"]["output_dir"]).parent
         if isinstance(exp, MontySupervisedObjectPretrainingExperiment):
             output_dir = output_dir / "pretrained"
         output_dir.mkdir(exist_ok=True, parents=True)
@@ -571,7 +570,7 @@ def post_parallel_train(experiments: list[Mapping], base_dir: str) -> None:
         torch.save(exp.model.state_dict(), saved_model_file)
 
     if pretraining:
-        pdirs = [os.path.dirname(i) for i in parallel_dirs]
+        pdirs = [i.parent for i in parallel_dirs]
     else:
         pdirs = parallel_dirs
 
@@ -642,8 +641,7 @@ def run_episodes_parallel(
     end_time = time.time()
     total_time = end_time - start_time
 
-    output_dir = experiments[0]["config"]["logging"]["output_dir"]
-    base_dir = Path(os.path.dirname(output_dir))
+    base_dir = Path(experiments[0]["config"]["logging"]["output_dir"]).parent
 
     if train:
         post_parallel_train(experiments, base_dir)


### PR DESCRIPTION
Prefer `Path.parent` over `os.path.dirname()`.