### PR TITLE
refactor: enable ruff rule PTH119, using Path.name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,7 +255,6 @@ ignore = [
     "PT009", # PT009: Use a regular `assert` instead of unittest-style `assertEqual`
     "PT018", # PT018: Assertion should be broken down into multiple parts
     "PT027", # PT027: Use `pytest.raises` instead of unittest-style `assertRaises`
-    "PTH119", # PTH119: `os.path.basename()` should be replaced by `Path.name`
     "PTH123", # PTH123: `open()` should be replaced by `Path.open()`
     "RET503", # RET503: Missing explicit `return` at the end of function able to return non-`None` value
     "RUF005", # RUF005: Consider {expression} instead of concatenation

--- a/src/tbp/monty/frameworks/environment_utils/server.py
+++ b/src/tbp/monty/frameworks/environment_utils/server.py
@@ -30,7 +30,7 @@ class MontyRequestHandler(http.server.SimpleHTTPRequestHandler):
     def do_PUT(self):
         # Check type of incoming data: depth or rgb
         parsed_url = urlparse(self.path)
-        inc_filename = os.path.basename(parsed_url.path)
+        inc_filename = Path(parsed_url.path).name
         data_type = "depth" if inc_filename == "depth.data" else "rgb"
 
         # check existing filenames in the directory

--- a/tools/github_readme_sync/hierarchy.py
+++ b/tools/github_readme_sync/hierarchy.py
@@ -10,7 +10,6 @@
 
 import concurrent.futures
 import logging
-import os
 import re
 import sys
 import timeit
@@ -167,7 +166,7 @@ def check_links(path):
     errors = []
 
     for match in table_matches:
-        table_name = os.path.basename(match)
+        table_name = Path(match).name
         if table_name in IGNORE_TABLES:
             continue
 

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -207,8 +207,8 @@ class ReadMe:
         """
 
         def replace_match(match):
-            csv_path = match.group(1)
-            table_name = os.path.basename(csv_path)
+            csv_path = Path(match.group(1))
+            table_name = csv_path.name
             if table_name in IGNORE_TABLES:
                 return match.group(0)
 


### PR DESCRIPTION
Prefer `Path(path_str).name` over `os.path.basename(path_str)`