### PR TITLE
refactor: enable ruff rule PTH123, for Path.open()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -255,7 +255,6 @@ ignore = [
     "PT009", # PT009: Use a regular `assert` instead of unittest-style `assertEqual`
     "PT018", # PT018: Assertion should be broken down into multiple parts
     "PT027", # PT027: Use `pytest.raises` instead of unittest-style `assertRaises`
-    "PTH123", # PTH123: `open()` should be replaced by `Path.open()`
     "RET503", # RET503: Missing explicit `return` at the end of function able to return non-`None` value
     "RUF005", # RUF005: Consider {expression} instead of concatenation
     "RUF015", # RUF015: Prefer next({iterable}) over single element slice

--- a/src/tbp/monty/frameworks/environment_utils/server.py
+++ b/src/tbp/monty/frameworks/environment_utils/server.py
@@ -51,7 +51,7 @@ class MontyRequestHandler(http.server.SimpleHTTPRequestHandler):
 
         # Write data to file
         file_length = int(self.headers["Content-Length"])
-        with open(data_path / new_filename, "wb") as output_file:
+        with (data_path / new_filename).open("wb") as output_file:
             output_file.write(self.rfile.read(file_length))
             output_file.close()
 

--- a/src/tbp/monty/frameworks/environments/two_d_data.py
+++ b/src/tbp/monty/frameworks/environments/two_d_data.py
@@ -811,7 +811,7 @@ def load_img(fn):
 
 def load_motor(fn):
     motor = []
-    with open(fn) as fid:
+    with fn.open() as fid:
         lines = fid.readlines()
     lines = [line.strip() for line in lines]
     for myline in lines:

--- a/src/tbp/monty/frameworks/loggers/monty_handlers.py
+++ b/src/tbp/monty/frameworks/loggers/monty_handlers.py
@@ -172,7 +172,7 @@ class DetailedJSONHandler(MontyHandler):
         episode_file = episodes_dir / f"episode_{global_episode_id:06d}.json"
         maybe_rename_existing_file(episode_file)
 
-        with open(episode_file, "w") as f:
+        with episode_file.open("w") as f:
             json.dump(
                 {global_episode_id: stats[global_episode_id]},
                 f,
@@ -192,7 +192,7 @@ class DetailedJSONHandler(MontyHandler):
             maybe_rename_existing_file(save_stats_path)
             self.already_renamed = True
 
-        with open(save_stats_path, "a") as f:
+        with save_stats_path.open("a") as f:
             json.dump(
                 {global_episode_id: stats[global_episode_id]},
                 f,
@@ -322,7 +322,7 @@ class ReproduceEpisodeHandler(MontyHandler):
         action_file = f"{mode}_episode_{episode}_actions.jsonl"
         action_file_path = self.data_dir / action_file
         actions = data["BASIC"][f"{mode}_actions"][episode]
-        with open(action_file_path, "w") as f:
+        with action_file_path.open("w") as f:
             f.writelines(
                 f"{json.dumps(action[0], cls=ActionJSONEncoder)}\n"
                 for action in actions
@@ -332,7 +332,7 @@ class ReproduceEpisodeHandler(MontyHandler):
         object_file = f"{mode}_episode_{episode}_target.txt"
         object_file_path = self.data_dir / object_file
         target = data["BASIC"][f"{mode}_targets"][episode]
-        with open(object_file_path, "w") as f:
+        with object_file_path.open("w") as f:
             json.dump(target, f, cls=BufferEncoder)
 
     def close(self):

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1589,7 +1589,7 @@ def read_action_file(file: str) -> list[Action]:
         List of actions
     """
     file = Path(file).expanduser()
-    with open(file) as f:
+    with file.open() as f:
         file_read = f.read()
 
     lines = [line.strip() for line in file_read.split("\n") if line.strip()]
@@ -1605,7 +1605,7 @@ def write_action_file(actions: list[Action], file: str) -> None:
         actions: list of actions
         file: path to file to save actions to
     """
-    with open(file, "w") as f:
+    with Path(file).open("w") as f:
         f.writelines(
             f"{json.dumps(action, cls=ActionJSONEncoder)}\n" for action in actions
         )

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -672,7 +672,7 @@ def run_episodes_parallel(
     print(f"Done running parallel experiments in {end_time - start_time} seconds")
 
     # Keep a record of how long everything takes
-    with open(base_dir / "parallel_log.txt", "w") as f:
+    with (base_dir / "parallel_log.txt").open("w") as f:
         f.write(f"experiment: {experiment_name}\n")
         f.write(f"num_parallel: {num_parallel}\n")
         f.write(f"total_time: {total_time}")

--- a/src/tbp/monty/frameworks/utils/follow_up_configs.py
+++ b/src/tbp/monty/frameworks/utils/follow_up_configs.py
@@ -79,7 +79,7 @@ def create_eval_episode_hydra_cfg(
         / "reproduce_episode_data"
         / f"eval_episode_{episode}_target.txt"
     )
-    with open(object_params_file) as f:
+    with object_params_file.open() as f:
         target_data = json.load(f)
 
     exp_cfg.eval_env_interface_args.object_names = [
@@ -184,7 +184,7 @@ def create_eval_episode_config(
     object_params_file = (
         output_dir / "reproduce_episode_data" / f"eval_episode_{episode}_target.txt"
     )
-    with open(object_params_file) as f:
+    with object_params_file.open() as f:
         target_data = json.load(f)
 
     new_config["eval_env_interface_args"]["object_names"] = [
@@ -287,7 +287,7 @@ def create_eval_multiple_episodes_hydra_cfg(
             / "reproduce_episode_data"
             / f"eval_episode_{episode}_target.txt"
         )
-        with open(object_params_file) as f:
+        with object_params_file.open() as f:
             target_data = json.load(f)
 
         # Update accumulators
@@ -378,7 +378,7 @@ def create_eval_config_multiple_episodes(
         object_params_file = (
             output_dir / "reproduce_episode_data" / f"eval_episode_{episode}_target.txt"
         )
-        with open(object_params_file) as f:
+        with object_params_file.open() as f:
             target_data = json.load(f)
 
         # Update accumulators

--- a/src/tbp/monty/frameworks/utils/logging_utils.py
+++ b/src/tbp/monty/frameworks/utils/logging_utils.py
@@ -63,7 +63,7 @@ def load_stats(
         print("...loading detailed run statistics...")
         json_file = exp_path / "detailed_run_stats.json"
         try:
-            with open(json_file) as f:
+            with json_file.open() as f:
                 detailed_stats = json.load(f)
         except ValueError:
             detailed_stats = deserialize_json_chunks(json_file)
@@ -124,7 +124,7 @@ def deserialize_json_chunks(json_file, start=0, stop=None, episodes=None):
 
     detailed_json = {}
     stop = stop or np.inf
-    with open(json_file) as f:
+    with Path(json_file).open() as f:
         for line_counter, line in enumerate(f):
             if should_get_episode(start, stop, episodes, line_counter):
                 # NOTE: json logging is only used at inference time and inference

--- a/src/tbp/monty/simulators/tacto/config.py
+++ b/src/tbp/monty/simulators/tacto/config.py
@@ -17,6 +17,7 @@ See Also:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Mapping
 
 import yaml
@@ -174,7 +175,7 @@ class TactoSensorSpec:
 
     @classmethod
     def from_yaml(cls, yaml_file):
-        with open(yaml_file) as f:
+        with Path(yaml_file).open() as f:
             config = yaml.safe_load(f)["sensor"]
         return cls(**config)
 

--- a/tests/unit/base_config_test.py
+++ b/tests/unit/base_config_test.py
@@ -167,7 +167,7 @@ class BaseConfigTest(unittest.TestCase):
             logger.info(info_message)
             logger.warning(warning_message)
 
-            with open(exp.output_dir / "log.txt") as f:
+            with (exp.output_dir / "log.txt").open() as f:
                 log = f.read()
 
             self.assertTrue(info_message in log)
@@ -188,7 +188,7 @@ class BaseConfigTest(unittest.TestCase):
             logger.debug(debug_message)
             logger.warning(warning_message)
 
-            with open(exp.output_dir / "log.txt") as f:
+            with (exp.output_dir / "log.txt").open() as f:
                 log = f.read()
 
             self.assertTrue(debug_message not in log)

--- a/tests/unit/run_parallel_test.py
+++ b/tests/unit/run_parallel_test.py
@@ -72,10 +72,10 @@ class RunParallelTest(unittest.TestCase):
             {p.name for p in s_param_files}, {p.name for p in p_param_files}
         )
         for sfile, pfile in zip(s_param_files, p_param_files):
-            with open(pfile) as f:
+            with pfile.open() as f:
                 ptarget = f.read()
 
-            with open(sfile) as f:
+            with sfile.open() as f:
                 starget = f.read()
 
             ptarget = json.loads(ptarget)

--- a/tests/unit/run_test.py
+++ b/tests/unit/run_test.py
@@ -111,7 +111,7 @@ class MontyRunTest(unittest.TestCase):
 
         output_dir = Path(self.cfg.experiment.config.logging.output_dir)
 
-        with open(output_dir / "fake_log.pkl", "rb") as f:
+        with (output_dir / "fake_log.pkl").open("rb") as f:
             exp_log = pickle.load(f)
 
         self.assertListEqual(exp_log, EXPECTED_LOG)

--- a/tools/future_work_widget/build.py
+++ b/tools/future_work_widget/build.py
@@ -50,7 +50,7 @@ def build(
         if error_message is not None:
             return BuildResult(success=False, error_message=error_message)
 
-        with open(index_file, encoding="utf-8") as f:
+        with index_file.open(encoding="utf-8") as f:
             raw_data = json.load(f)
 
         total_items = len(raw_data)
@@ -70,7 +70,7 @@ def build(
             return _return_error_result(e, future_work_items, total_items)
         else:
             data_file = output_dir / "data.json"
-            with open(data_file, "w", encoding="utf-8") as f:
+            with data_file.open("w", encoding="utf-8") as f:
                 f.write(index.model_dump_json(indent=2, by_alias=True))
 
             return BuildResult(

--- a/tools/future_work_widget/tests/build_test.py
+++ b/tools/future_work_widget/tests/build_test.py
@@ -40,7 +40,7 @@ class TestBuild(unittest.TestCase):
 
         for filename, content in snippet_configs.items():
             snippet_file = snippets_dir / filename
-            with open(snippet_file, "w", encoding="utf-8") as f:
+            with snippet_file.open("w", encoding="utf-8") as f:
                 f.write(content)
 
         return snippets_dir
@@ -82,7 +82,7 @@ class TestBuild(unittest.TestCase):
             ValueError: If the build fails with validation errors.
         """
         index_file = self.temp_path / "index.json"
-        with open(index_file, "w", encoding="utf-8") as f:
+        with index_file.open("w", encoding="utf-8") as f:
             json.dump(input_data, f)
 
         if snippets_dir is None:
@@ -97,7 +97,7 @@ class TestBuild(unittest.TestCase):
             raise ValueError(f"{result.error_message}\nErrors:\n{error_details}")
 
         data_file = self.temp_path / "data.json"
-        with open(data_file, encoding="utf-8") as f:
+        with data_file.open(encoding="utf-8") as f:
             return json.load(f)
 
     def _expect_build_failure(
@@ -209,7 +209,7 @@ class TestBuild(unittest.TestCase):
         ]
 
         index_file = self.temp_path / "index.json"
-        with open(index_file, "w", encoding="utf-8") as f:
+        with index_file.open("w", encoding="utf-8") as f:
             json.dump(input_data, f)
 
         snippets_dir = self._create_snippets({})
@@ -237,7 +237,7 @@ class TestBuild(unittest.TestCase):
         ]
 
         index_file = self.temp_path / "index.json"
-        with open(index_file, "w", encoding="utf-8") as f:
+        with index_file.open("w", encoding="utf-8") as f:
             json.dump(input_data, f)
 
         result = build(index_file, self.temp_path, snippets_dir)
@@ -272,7 +272,7 @@ class TestBuild(unittest.TestCase):
         ]
 
         index_file = self.temp_path / "index.json"
-        with open(index_file, "w", encoding="utf-8") as f:
+        with index_file.open("w", encoding="utf-8") as f:
             json.dump(input_data, f)
 
         snippets_dir = self._create_snippets({})
@@ -372,7 +372,7 @@ class TestBuild(unittest.TestCase):
                 )
 
                 index_file = self.temp_path / "index.json"
-                with open(index_file, "w", encoding="utf-8") as f:
+                with index_file.open("w", encoding="utf-8") as f:
                     json.dump([valid_item], f)
 
                 result = build(index_file, self.temp_path, snippets_dir)
@@ -382,7 +382,7 @@ class TestBuild(unittest.TestCase):
                     **{case["field_name"]: case["invalid_value"]}
                 )
 
-                with open(index_file, "w", encoding="utf-8") as f:
+                with index_file.open("w", encoding="utf-8") as f:
                     json.dump([invalid_item], f)
 
                 result = build(index_file, self.temp_path, snippets_dir)

--- a/tools/future_work_widget/tests/validator_test.py
+++ b/tools/future_work_widget/tests/validator_test.py
@@ -36,12 +36,12 @@ class TestLoadAllowedValues(unittest.TestCase):
 
         expected_tags = ["accuracy", "pose", "learning", "multiobj"]
         tags_file = snippets_dir / "future-work-tags.md"
-        with open(tags_file, "w", encoding="utf-8") as f:
+        with tags_file.open("w", encoding="utf-8") as f:
             f.write(" ".join(f"`{tag}`" for tag in expected_tags))
 
         expected_skills = ["python", "github-actions", "JS", "HTML"]
         skills_file = snippets_dir / "future-work-skills.md"
-        with open(skills_file, "w", encoding="utf-8") as f:
+        with skills_file.open("w", encoding="utf-8") as f:
             f.write(" ".join(f"`{skill}`" for skill in expected_skills))
 
         allowed_values = load_allowed_values(snippets_dir)

--- a/tools/future_work_widget/validator.py
+++ b/tools/future_work_widget/validator.py
@@ -352,7 +352,7 @@ def load_allowed_values(docs_snippets_dir: Path) -> dict[str, list[str]]:
     for file_path in future_work_files:
         field_name = file_path.stem.replace("future-work-", "").replace("-", "_")
 
-        with open(file_path, encoding="utf-8") as f:
+        with file_path.open(encoding="utf-8") as f:
             content = f.read().strip()
 
         parsed_values = []

--- a/tools/github_readme_sync/export.py
+++ b/tools/github_readme_sync/export.py
@@ -70,7 +70,7 @@ def process_doc(*, server_doc, hierarchy_doc, folder_path, indent_level, rdme):
     logging.info(f"{indent}{CYAN}{hierarchy_doc['slug']}{RESET}")
 
     doc_path = folder_path / f"{hierarchy_doc['slug']}.md"
-    with open(doc_path, "w") as f:
+    with doc_path.open("w") as f:
         f.write(rdme.get_doc_by_slug(server_doc["slug"]))
 
     children = server_doc.get("children", [])

--- a/tools/github_readme_sync/file.py
+++ b/tools/github_readme_sync/file.py
@@ -73,5 +73,5 @@ def read_file_content(file_path: str) -> str:
     Returns:
         File content as string
     """
-    with open(file_path, encoding="utf-8") as f:
+    with Path(file_path).open(encoding="utf-8") as f:
         return f.read()

--- a/tools/github_readme_sync/hierarchy.py
+++ b/tools/github_readme_sync/hierarchy.py
@@ -38,7 +38,7 @@ README_URL = "https://thousandbrainsproject.readme.io"
 
 def create_hierarchy_file(output_dir, hierarchy):
     output_dir = Path(output_dir)
-    with open(output_dir / HIERARCHY_FILE, "w") as f:
+    with (output_dir / HIERARCHY_FILE).open("w") as f:
         for category in hierarchy:
             write_category(f, category, 0)
     logging.info(f"{GREEN}Export complete{RESET}")
@@ -77,7 +77,7 @@ def check_hierarchy_file(folder: str):
         logging.error(f"File {hierarchy_file} does not exist")
         sys.exit(1)
 
-    with open(hierarchy_file) as f:
+    with hierarchy_file.open() as f:
         content = f.read()
         content = re.sub(r"<!--.*?-->", "", content, flags=re.DOTALL)
         lines = content.splitlines()
@@ -142,7 +142,7 @@ def sanity_check(path):
 
 def check_links(path):
     path = Path(path)
-    with open(path) as f:
+    with path.open() as f:
         content = f.read()
     file_name = path.name
 

--- a/tools/github_readme_sync/index.py
+++ b/tools/github_readme_sync/index.py
@@ -101,14 +101,16 @@ def generate_index(docs_dir: str, output_file_path: str) -> str:
 
     entries = process_markdown_files(docs_dir)
 
-    Path(output_file_path).parent.mkdir(exist_ok=True, parents=True)
-    with open(output_file_path, "w", encoding="utf-8") as f:
+    output_file_pathstr, output_file_path = output_file_path, Path(output_file_path)
+
+    output_file_path.parent.mkdir(exist_ok=True, parents=True)
+    with output_file_path.open("w", encoding="utf-8") as f:
         json.dump(entries, f, indent=2, ensure_ascii=False)
 
     logger.info(
         f"{GREEN}Generated index with {len(entries)} entries: {output_file_path}{RESET}"
     )
-    return output_file_path
+    return output_file_pathstr
 
 
 def process_markdown_files(docs_dir: str) -> list[dict]:

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -214,10 +214,10 @@ class ReadMe:
 
             # Get absolute path of CSV relative to current document
             csv_path = Path(file_path) / csv_path
-            csv_path = os.path.normpath(csv_path)
+            csv_path = csv_path.resolve()
 
             try:
-                with open(csv_path) as f:
+                with csv_path.open() as f:
                     reader = csv.reader(f)
                     headers = next(reader)
                     rows = list(reader)
@@ -547,10 +547,10 @@ class ReadMe:
 
         def replace_match(match):
             snippet_path = Path(file_path) / match.group(1)
-            snippet_path = os.path.normpath(snippet_path)
+            snippet_path = snippet_path.resolve()
 
             try:
-                with open(snippet_path) as f:
+                with snippet_path.open() as f:
                     unsafe_content = f.read()
                     return self.sanitize_html(unsafe_content)
 

--- a/tools/github_readme_sync/tests/export_test.py
+++ b/tools/github_readme_sync/tests/export_test.py
@@ -76,10 +76,10 @@ class TestExport(unittest.TestCase):
         self.assertTrue((self.test_output_dir / "category-2" / "doc-2.md").is_file())
 
         # Assert the content of the files is correct
-        with open(self.test_output_dir / "category-1" / "doc-1.md") as f:
+        with (self.test_output_dir / "category-1" / "doc-1.md").open() as f:
             self.assertEqual(f.read(), "Content of Doc 1")
 
-        with open(self.test_output_dir / "category-2" / "doc-2.md") as f:
+        with (self.test_output_dir / "category-2" / "doc-2.md").open() as f:
             self.assertEqual(f.read(), "Content of Doc 2")
 
 

--- a/tools/github_readme_sync/tests/file_test.py
+++ b/tools/github_readme_sync/tests/file_test.py
@@ -24,8 +24,8 @@ class TestGetFolders(unittest.TestCase):
 
         (temp_dir_path / "folder1").mkdir(parents=True)
         (temp_dir_path / "folder2").mkdir(parents=True)
-        open(temp_dir_path / "file1.txt", "w").close()
-        open(temp_dir_path / "file2.txt", "w").close()
+        (temp_dir_path / "file1.txt").touch()
+        (temp_dir_path / "file2.txt").touch()
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)

--- a/tools/github_readme_sync/tests/hierarchy_test.py
+++ b/tools/github_readme_sync/tests/hierarchy_test.py
@@ -64,7 +64,7 @@ class TestHierarchyFile(unittest.TestCase):
         hierarchy_file_path = self.test_dir / HIERARCHY_FILE
         self.assertTrue(hierarchy_file_path.exists())
 
-        with open(hierarchy_file_path) as f:
+        with hierarchy_file_path.open() as f:
             content = f.read()
             self.assertIn(f"{CATEGORY_PREFIX}category-1: Category 1\n", content)
             self.assertIn(f"{DOCUMENT_PREFIX}[doc-1](category-1/doc-1.md)\n", content)
@@ -81,7 +81,7 @@ class TestHierarchyFile(unittest.TestCase):
 
     def test_check_hierarchy_file_success(self):
         hierarchy_file = self.test_dir / HIERARCHY_FILE
-        with open(hierarchy_file, "w") as f:
+        with hierarchy_file.open("w") as f:
             f.write(
                 f"{CATEGORY_PREFIX}category-1: Category 1\n"
                 f"{DOCUMENT_PREFIX}[doc-1](category-1/doc-1.md)\n"
@@ -89,14 +89,14 @@ class TestHierarchyFile(unittest.TestCase):
 
         (self.test_dir / "category-1").mkdir(parents=True)
         doc_file = self.test_dir / "category-1" / "doc-1.md"
-        with open(doc_file, "w") as f:
+        with doc_file.open("w") as f:
             f.write("---\ntitle: Doc 1\n---\nContent")
 
         check_hierarchy_file(self.test_dir)
 
     def test_check_hierarchy_file_duplicate_slugs(self):
         hierarchy_file = self.test_dir / HIERARCHY_FILE
-        with open(hierarchy_file, "w") as f:
+        with hierarchy_file.open("w") as f:
             f.write(
                 f"{CATEGORY_PREFIX}category-1: Category 1\n"
                 f"{DOCUMENT_PREFIX}[doc-1](category-1/doc-1.md)\n"
@@ -105,11 +105,11 @@ class TestHierarchyFile(unittest.TestCase):
 
         (self.test_dir / "category-1").mkdir(parents=True)
         doc_file1 = self.test_dir / "category-1" / "doc-1.md"
-        with open(doc_file1, "w") as f:
+        with doc_file1.open("w") as f:
             f.write("---\ntitle: Doc 1\n---\nContent")
 
         doc_file2 = self.test_dir / "doc-1.md"
-        with open(doc_file2, "w") as f:
+        with doc_file2.open("w") as f:
             f.write("---\ntitle: Doc 1\n---\nContent")
 
         with self.assertLogs(level="ERROR") as log:
@@ -120,7 +120,7 @@ class TestHierarchyFile(unittest.TestCase):
 
     def test_check_hierarchy_broken_link_in_file(self):
         hierarchy_file = self.test_dir / HIERARCHY_FILE
-        with open(hierarchy_file, "w") as f:
+        with hierarchy_file.open("w") as f:
             f.write(
                 f"{CATEGORY_PREFIX}category-1: Category 1\n"
                 f"{DOCUMENT_PREFIX}[doc-1](category-1/doc-1.md)\n"
@@ -128,7 +128,7 @@ class TestHierarchyFile(unittest.TestCase):
 
         (self.test_dir / "category-1").mkdir(parents=True)
         doc_file = self.test_dir / "category-1" / "doc-1.md"
-        with open(doc_file, "w") as f:
+        with doc_file.open("w") as f:
             f.write(
                 "---\ntitle: Doc 1\n---\nContent\n"
                 "[missing](category-1/missing.md)\n"
@@ -136,7 +136,7 @@ class TestHierarchyFile(unittest.TestCase):
             )
 
         existing_file = self.test_dir / "category-1" / "existing.md"
-        with open(existing_file, "w") as f:
+        with existing_file.open("w") as f:
             f.write("---\ntitle: Existing Doc\n---\nContent")
 
         with self.assertLogs(level="ERROR") as log:
@@ -172,7 +172,7 @@ class TestHierarchyFile(unittest.TestCase):
             pass
 
         test_file = self.test_dir / "test_external_links.md"
-        with open(test_file, "w") as f:
+        with test_file.open("w") as f:
             f.write(f"[Valid Link]({self.server_url}/valid)\n")
             f.write(f"[Missing Link]({self.server_url}/missing)\n")
             f.write(f"[Fragment]({self.server_url}/valid#fragment)\n")

--- a/tools/github_readme_sync/tests/index_test.py
+++ b/tools/github_readme_sync/tests/index_test.py
@@ -31,16 +31,17 @@ class TestGenerateIndex(unittest.TestCase):
 
         content = f"---\ntitle: test doc\n{frontmatter_fields}\n---\n"
         md_file_path = subdir_path / "test-doc.md"
-        with open(md_file_path, "w", encoding="utf-8") as f:
+        with md_file_path.open("w", encoding="utf-8") as f:
             f.write(content)
 
         index_file_path = generate_index(
             self.temp_dir, str(Path(self.temp_dir) / "index.json")
         )
+        index_file_path = Path(index_file_path)
 
-        self.assertTrue(Path(index_file_path).exists())
+        self.assertTrue(index_file_path.exists())
 
-        with open(index_file_path, encoding="utf-8") as f:
+        with index_file_path.open(encoding="utf-8") as f:
             return json.load(f)
 
     def test_generate_index_with_frontmatter(self):

--- a/tools/github_readme_sync/tests/readme_test.py
+++ b/tools/github_readme_sync/tests/readme_test.py
@@ -800,7 +800,7 @@ This is a test document.""",
 
             # Create a CSV file in the data directory
             csv_path = data_dir / "test.csv"
-            with open(csv_path, "w") as f:
+            with csv_path.open("w") as f:
                 writer = csv.writer(f)
                 writer.writerow(["Header 1", "Header 2"])
                 writer.writerow(["Value 1", "Value 2"])
@@ -832,7 +832,7 @@ This is a test document.""",
             other_dir.mkdir(parents=True)
 
             source_md = other_dir / "source.md"
-            with open(source_md, "w") as f:
+            with source_md.open("w") as f:
                 f.write(
                     "# Test Header\nThis is test content\n* List item 1\n* List item 2"
                 )

--- a/tools/github_readme_sync/upload.py
+++ b/tools/github_readme_sync/upload.py
@@ -127,6 +127,6 @@ def load_doc(file_path: str, category_slug: str, child: dict):
     if not file_path.exists():
         raise ValueError(f"File {file_path} does not exist")
 
-    with open(file_path, encoding="utf-8") as file:
+    with file_path.open(encoding="utf-8") as file:
         body = file.read()
         return process_markdown(body, child["slug"])


### PR DESCRIPTION
Prefer `Path(pathstr).open()` over `open(pathstr)`

This wraps up the last `Path`-focused ruff rule!