### PR TITLE
chore: version 0.14.1

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"


### PR DESCRIPTION
Patch version release due to no `src/tbp/monty` breaking changes since 0.14.0.

> References: 
> - [RFC 7 Monty Versioning - Explanation](https://github.com/thousandbrainsproject/tbp.monty/blob/main/rfcs/0007_monty_versioning.md#explanation)
> - [RFC 10 Conventional Commits - Breaking Changes](https://github.com/thousandbrainsproject/tbp.monty/blob/main/rfcs/0010_conventional_commits.md#breaking-changes)

<img width="1301" height="709" alt="Screenshot 2025-12-11 at 10 44 21" src="https://github.com/user-attachments/assets/293b1351-8066-4704-b836-b0b9b6c3c2d2" />
