### PR TITLE
refactor!: enable ruff NPY002, prefer numpy.random.Generator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,7 +238,6 @@ ignore = [
     "G003", # G003: Logging statement uses `+`
     "G004", # G004: Logging statement uses f-string
     "N804", # N804: First argument of a class method should be named `cls`
-    "NPY002", # NPY002: Replace legacy `np.random.normal` call with `np.random.Generator`
     "PERF203", # PERF203: `try`-`except` within a loop incurs performance overhead
     "PERF401", # PERF401: Use a list comprehension to create a transformed list
     "PERF402", # PERF402: Use `list` or `list.copy` to create a copy of a list

--- a/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
+++ b/src/tbp/monty/frameworks/models/evidence_sdr_matching.py
@@ -105,6 +105,7 @@ class EncoderSDR:
             stability constraint applied and 1.0 is fixed SDRs. Values in between are
             for partial stability.
         log_flag: Flag to activate the logger.
+        random_seed: seed used to initialize the random number generator
     """
 
     def __init__(
@@ -115,6 +116,7 @@ class EncoderSDR:
         n_epochs=1000,
         stability=0.0,
         log_flag=False,
+        random_seed: int = 4,
     ):
         if sdr_on_bits >= sdr_length or sdr_on_bits <= 0:
             logger.warning(
@@ -135,6 +137,8 @@ class EncoderSDR:
 
         # Initialize obj SDR array with arbitrary values
         self.obj_sdrs = np.zeros((0, self.sdr_length))
+
+        self.np_rng = np.random.default_rng(random_seed)
 
     @property
     def n_objects(self):
@@ -255,8 +259,8 @@ class EncoderSDR:
         stable_data = self.obj_sdrs.copy()
         self.stable_ids = np.arange(stable_data.shape[0])
 
-        new_obj_sdrs = np.random.randn(
-            stable_data.shape[0] + n_objects, self.sdr_length
+        new_obj_sdrs = self.np_rng.standard_normal(
+            size=(stable_data.shape[0] + n_objects, self.sdr_length)
         )
 
         new_obj_sdrs[: stable_data.shape[0]] = stable_data
@@ -576,6 +580,7 @@ class EvidenceSDRLMMixin:
             lr=self.sdr_args["sdr_lr"],
             n_epochs=self.sdr_args["n_sdr_epochs"],
             log_flag=self.sdr_args["sdr_log_flag"],
+            random_seed=self.sdr_args["random_seed"],
         )
 
         # TODO: remove this logger and merge with the Monty Loggers after

--- a/src/tbp/monty/frameworks/utils/plot_utils_dev.py
+++ b/src/tbp/monty/frameworks/utils/plot_utils_dev.py
@@ -1277,7 +1277,8 @@ def plot_learned_graph(
 
     # Add optional noise; can be used to visualize e.g. how significant noise
     # in the sensory information might be
-    noise_to_add = np.random.normal(0, noise_amount, size=np.shape(learned_model_cloud))
+    rng = np.random.default_rng()
+    noise_to_add = rng.normal(0, noise_amount, size=np.shape(learned_model_cloud))
     learned_model_cloud = learned_model_cloud + noise_to_add
 
     plt.figure(figsize=(5, 5))

--- a/tests/unit/embodied_data_test.py
+++ b/tests/unit/embodied_data_test.py
@@ -42,6 +42,9 @@ from tbp.monty.frameworks.models.abstract_monty_classes import (
 from tbp.monty.frameworks.models.motor_policies import BasePolicy
 from tbp.monty.frameworks.models.motor_system import MotorSystem
 
+# TODO: use instead of RandomState elsewhere in tests
+RNG = np.random.default_rng(42)
+
 AGENT_ID = AgentID("agent_id_0")
 SENSOR_ID = SensorID("sensor_id_0")
 NUM_STEPS = 10
@@ -53,7 +56,7 @@ POSSIBLE_ACTIONS_DIST = [
     f"{AGENT_ID}.turn_right",
 ]
 POSSIBLE_ACTIONS_ABS = [f"{AGENT_ID}.set_yaw", f"{AGENT_ID}.set_sensor_pitch"]
-EXPECTED_STATES: npt.NDArray[np.uint8] = np.random.randint(
+EXPECTED_STATES: npt.NDArray[np.uint8] = RNG.integers(
     0, 256, size=NUM_STEPS, dtype=np.uint8
 )
 

--- a/tests/unit/evidence_sdr_lm_test.py
+++ b/tests/unit/evidence_sdr_lm_test.py
@@ -25,18 +25,10 @@ from tbp.monty.frameworks.models.goal_state_generation import EvidenceGoalStateG
 from tbp.monty.frameworks.models.states import State
 from tests.unit.resources.unit_test_utils import BaseGraphTest
 
-
-def set_seed(seed):
-    """Set seed for reproducibility."""
-    np.random.seed(seed)
+RANDOM_SEED = 42
 
 
 class EvidenceSDRUnitTest(unittest.TestCase):
-    def setUp(self):
-        """Setup function at the beginning of each experiment."""
-        # set seed for reproducibility
-        set_seed(42)
-
     def test_unit_sdr_conf(self):
         """This tests edge condition of SDR configuration with invalid sparsity.
 
@@ -48,14 +40,24 @@ class EvidenceSDRUnitTest(unittest.TestCase):
 
         """
         encoder_sdr = EncoderSDR(
-            sdr_length=100, sdr_on_bits=100, lr=1e-2, n_epochs=100, log_flag=False
+            sdr_length=100,
+            sdr_on_bits=100,
+            lr=1e-2,
+            n_epochs=100,
+            log_flag=False,
+            random_seed=RANDOM_SEED,
         )
 
         # test that the sparsity is adjusted to 2%
         self.assertEqual(encoder_sdr.sdr_on_bits, int(100 * 0.02))
 
         encoder_sdr = EncoderSDR(
-            sdr_length=100, sdr_on_bits=0, lr=1e-2, n_epochs=100, log_flag=False
+            sdr_length=100,
+            sdr_on_bits=0,
+            lr=1e-2,
+            n_epochs=100,
+            log_flag=False,
+            random_seed=RANDOM_SEED,
         )
 
         # test that the sparsity is adjusted to 2%
@@ -112,7 +114,12 @@ class EvidenceSDRUnitTest(unittest.TestCase):
 
         """
         encoder = EncoderSDR(
-            sdr_length=100, sdr_on_bits=5, lr=1e-2, n_epochs=100, log_flag=True
+            sdr_length=100,
+            sdr_on_bits=5,
+            lr=1e-2,
+            n_epochs=100,
+            log_flag=True,
+            random_seed=RANDOM_SEED,
         )
         encoder.add_objects(5)
 
@@ -136,7 +143,12 @@ class EvidenceSDRUnitTest(unittest.TestCase):
             - Representations of the last 2 objects shouldn't change
         """
         encoder = EncoderSDR(
-            sdr_length=100, sdr_on_bits=5, lr=1e-2, n_epochs=100, log_flag=True
+            sdr_length=100,
+            sdr_on_bits=5,
+            lr=1e-2,
+            n_epochs=100,
+            log_flag=True,
+            random_seed=RANDOM_SEED,
         )
         encoder.add_objects(5)
         training_data = np.full((5, 5), np.nan)
@@ -178,7 +190,12 @@ class EvidenceSDRUnitTest(unittest.TestCase):
         """
         # test for some points out of bound
         encoder = EncoderSDR(
-            sdr_length=100, sdr_on_bits=5, lr=1e-2, n_epochs=100, log_flag=True
+            sdr_length=100,
+            sdr_on_bits=5,
+            lr=1e-2,
+            n_epochs=100,
+            log_flag=True,
+            random_seed=RANDOM_SEED,
         )
         encoder.add_objects(3)
         training_data = np.full((5, 5), np.nan)
@@ -197,7 +214,12 @@ class EvidenceSDRUnitTest(unittest.TestCase):
 
         # test for all points out of bounds
         encoder = EncoderSDR(
-            sdr_length=100, sdr_on_bits=5, lr=1e-2, n_epochs=100, log_flag=True
+            sdr_length=100,
+            sdr_on_bits=5,
+            lr=1e-2,
+            n_epochs=100,
+            log_flag=True,
+            random_seed=RANDOM_SEED,
         )
         encoder.add_objects(3)
         training_data = np.full((5, 5), np.nan)
@@ -221,7 +243,12 @@ class EvidenceSDRUnitTest(unittest.TestCase):
             - SDR overlaps should be close to target overlaps
         """
         encoder = EncoderSDR(
-            sdr_length=2048, sdr_on_bits=41, lr=1e-2, n_epochs=1000, log_flag=True
+            sdr_length=2048,
+            sdr_on_bits=41,
+            lr=1e-2,
+            n_epochs=1000,
+            log_flag=True,
+            random_seed=RANDOM_SEED,
         )
         encoder.add_objects(3)
         training_data = np.full((3, 3), np.nan)
@@ -268,8 +295,6 @@ class EvidenceSDRUnitTest(unittest.TestCase):
         """
         sdr_persistence = []
         for stability in [0.0, 0.33, 0.66, 1.0]:
-            set_seed(42)
-
             encoder = EncoderSDR(
                 sdr_length=2048,
                 sdr_on_bits=41,
@@ -277,6 +302,7 @@ class EvidenceSDRUnitTest(unittest.TestCase):
                 n_epochs=1000,
                 stability=stability,
                 log_flag=True,
+                random_seed=RANDOM_SEED,
             )
 
             encoder.add_objects(3)
@@ -316,7 +342,12 @@ class EvidenceSDRUnitTest(unittest.TestCase):
             - SDRs should be identical with overlap of exactly `sdr_on_bits`
         """
         encoder = EncoderSDR(
-            sdr_length=2048, sdr_on_bits=41, lr=1e-2, n_epochs=1000, log_flag=True
+            sdr_length=2048,
+            sdr_on_bits=41,
+            lr=1e-2,
+            n_epochs=1000,
+            log_flag=True,
+            random_seed=RANDOM_SEED,
         )
         encoder.add_objects(2)
         training_data = np.full((2, 2), np.nan)
@@ -337,9 +368,6 @@ class EvidenceSDRIntegrationTest(BaseGraphTest):
     def setUp(self):
         """Setup function at the beginning of each experiment."""
         self.output_dir = tempfile.mkdtemp()
-
-        # set seed for reproducibility
-        set_seed(42)
 
         self.default_obs_args = dict(
             location=np.array([0.0, 0.0, 0.0]),
@@ -486,6 +514,7 @@ class EvidenceSDRIntegrationTest(BaseGraphTest):
                 sdr_lr=1e-2,  # Learning rate of the encoding algorithm
                 n_sdr_epochs=1000,  # Number of training epochs per episode
                 sdr_log_flag=True,  # log the output of the module
+                random_seed=RANDOM_SEED,
             ),
         )
 

--- a/tests/unit/habitat_data_test.py
+++ b/tests/unit/habitat_data_test.py
@@ -37,7 +37,8 @@ DEFAULT_ACTUATION_AMOUNT = 0.25
 AGENT_ID = AgentID("camera")
 SENSOR_ID = SensorID("sensor_id_0")
 MODALITY = Modality("depth")
-EXPECTED_STATES = np.random.rand(NUM_STEPS, 64, 64, 1)
+RNG = np.random.default_rng(42)
+EXPECTED_STATES = RNG.random(size=(NUM_STEPS, 64, 64, 1))
 
 
 class HabitatDataTest(unittest.TestCase):

--- a/tests/unit/run_test.py
+++ b/tests/unit/run_test.py
@@ -33,12 +33,14 @@ from omegaconf import OmegaConf
 from tbp.monty.frameworks.run import main
 from tbp.monty.simulators.habitat import SingleSensorAgent
 
+RNG = np.random.default_rng(42)
+
 DATASET_LEN = 1000
 TRAIN_EPOCHS = 2
 MAX_TRAIN_STEPS = 10
 MAX_EVAL_STEPS = 5
 EVAL_EPOCHS = 1
-FAKE_OBS = np.random.rand(DATASET_LEN, 64, 64, 1)
+FAKE_OBS = RNG.random(size=(DATASET_LEN, 64, 64, 1))
 EXPECTED_LOG = []
 
 # Train steps
@@ -87,7 +89,7 @@ class MontyRunTest(unittest.TestCase):
             self.mock_agent if agent_idx == 0 else None
         )
         self.mock_sim.reset.return_value = {
-            0: {"agent_id_0.depth": np.random.rand(64, 64, 1)}
+            0: {"agent_id_0.depth": RNG.random(size=(64, 64, 1))}
         }
         self.mock_sim.get_sensor_observations.side_effect = [
             {0: {"agent_id_0.depth": obs}} for obs in FAKE_OBS


### PR DESCRIPTION
This is a first stab. I want to take some time to think through some questions I have like:
- does this correctly thread through the seed everywhere that it needs to?
- should we have a default seed number in `EvidenceSDR`? (I see a default seed used in place elsewhere)
- should it be 42 again? (not just in the tests, but the default class instantiation)
- Same questions for `plot_learned_graph()`
