### PR TITLE
refactor: episode_spec is always a str; never None

### DIFF
--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -156,7 +156,7 @@ def print_config(config: DictConfig) -> None:
     print("-" * 100)
 
 
-def parse_episode_spec(episode_spec: str | None, total: int) -> list[int]:
+def parse_episode_spec(episode_spec: str, total: int) -> list[int]:
     """Parses a zero-based episode selection string into episode indices.
 
     Converts a human-friendly selection string into a sorted list of unique,
@@ -188,8 +188,6 @@ def parse_episode_spec(episode_spec: str | None, total: int) -> list[int]:
     Raises:
         ValueError: If the selection contains any invalid index or range.
     """
-    if episode_spec is None:
-        return list(range(total))
     s = episode_spec.strip().lower()
     if s in ("", "all", ":"):
         return list(range(total))
@@ -242,7 +240,7 @@ def parse_episode_spec(episode_spec: str | None, total: int) -> list[int]:
     return sorted(selected)
 
 
-def filter_episode_configs(configs: list[dict], episode_spec: str | None) -> list[dict]:
+def filter_episode_configs(configs: list[dict], episode_spec: str) -> list[dict]:
     idxs = parse_episode_spec(episode_spec, len(configs))
     return [cfg for i, cfg in enumerate(configs) if i in idxs]
 
@@ -697,7 +695,7 @@ def main(cfg: DictConfig):
         train_configs = generate_parallel_train_configs(
             cfg.experiment, cfg.experiment.config.logging.run_name
         )
-        train_configs = filter_episode_configs(train_configs, cfg.episodes)
+        train_configs = filter_episode_configs(train_configs, str(cfg.episodes))
         if cfg.print_cfg:
             print("Printing configs for spot checking")
             for config in train_configs:
@@ -719,7 +717,7 @@ def main(cfg: DictConfig):
         eval_configs = generate_parallel_eval_configs(
             cfg.experiment, cfg.experiment.config.logging.run_name
         )
-        eval_configs = filter_episode_configs(eval_configs, cfg.episodes)
+        eval_configs = filter_episode_configs(eval_configs, str(cfg.episodes))
         if cfg.print_cfg:
             print("Printing configs for spot checking")
             for config in eval_configs:

--- a/tests/unit/frameworks/run_parallel_test.py
+++ b/tests/unit/frameworks/run_parallel_test.py
@@ -15,7 +15,6 @@ from tbp.monty.frameworks.run_parallel import parse_episode_spec
 
 class ParseEpisodeSpecTest(unittest.TestCase):
     def test_selects_all(self):
-        self.assertEqual(parse_episode_spec(None, total=5), [0, 1, 2, 3, 4])
         self.assertEqual(parse_episode_spec("", total=3), [0, 1, 2])
         self.assertEqual(parse_episode_spec(":", total=3), [0, 1, 2])
         self.assertEqual(parse_episode_spec("all", total=4), [0, 1, 2, 3])
@@ -94,9 +93,6 @@ class ParseEpisodeSpecTest(unittest.TestCase):
 
     def test_total_zero_all_is_empty(self):
         self.assertEqual(parse_episode_spec("all", total=0), [])
-
-    def test_total_zero_none_is_empty(self):
-        self.assertEqual(parse_episode_spec(None, total=0), [])
 
     def test_total_zero_any_specific_raises(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
With the Hydra change, it seems like it parses the argument `episodes="0"` and casts the numeric values to `int`. This causes the error below because the function expects a `str | None`:
```zsh
Error executing job with overrides: ['experiment=randrot_noise_10distinctobj_dist_agent', 'episodes=0']
Traceback (most recent call last):
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/run_parallel.py", line 722, in main
    eval_configs = filter_episode_configs(eval_configs, cfg.episodes)
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/run_parallel.py", line 246, in filter_episode_configs
    idxs = parse_episode_spec(episode_spec, len(configs))
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/run_parallel.py", line 193, in parse_episode_spec
    s = episode_spec.strip().lower()
AttributeError: 'int' object has no attribute 'strip'
```
This PR casts the `episode_spec` value to always become a `str`, and removes the handling of the value `None`. It should never happen, since the default is `"all"` and overriding it will now becomes just a different `str`. Unit tests are also updated.