### PR TITLE
chore: version 0.16.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.15.0"
+__version__ = "0.16.0"


### PR DESCRIPTION
Minor version release due to Major version 0 and breaking changes since 0.15.0.

<img width="1248" height="881" alt="Screenshot 2025-12-24 at 07 49 45" src="https://github.com/user-attachments/assets/0336312a-af3d-41f0-9a79-3c87264fc9fa" />

## refactor!: formalize Transform protocol and expect TransformContext (#645)

All transforms now must conform to the `Transform` protocol:
```python
def __call__(
    self, observations: Observations, ctx: TransformContext
) -> Observations:
```

## refactor!: remove redundant Path coercion in run_parallel.py (#637)

`post_parallel_eval` and `post_parallel_train` function signature changed where `base_dir` is now a `Path`:
```python
def post_parallel_eval(experiments: list[Mapping], base_dir: Path) -> None:
```
```python
def post_parallel_train(experiments: list[Mapping], base_dir: Path) -> None:
```

## refactor!: pass RNG to DefaultMessageNoise during call, not init (#652)

`MessageNoise` protocol now requires `np.random.RandomState`:
```python
class MessageNoise(Protocol):
    def __call__(self, state: State, rng: np.random.RandomState) -> State: ...
```

`no_message_noise` function became `NoMessageNoise` class.

## refactor!: pass RNG to ActionSampler during call, not init. (#653)

`Action`s and `ActionSampler`s are refactored to accept or pass `np.random.RandomState` as part of method calls instead of receiving RNG on initialization.

## feat!: MontyExperiment.run() (#654)

Calls to `experiment.train()` and `experiment.evaluate()` have been replaced with calls to the new `experiment.run()` instead. 
