### PR TITLE
ci: allow merge group to trigger verify_cla

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     branches:
       - main
+  merge_group:
+    types:
+      - checks_requested
 
 permissions:
   issues: write


### PR DESCRIPTION
This PR ensures that required `verify-cla` check runs on `merge_group`.