### PR TITLE
ci: passthrough cla check when in merge group

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - name: "Verify CLA"
         uses: thousandbrainsproject/cla-assistant@v2.0.0
+        if: ${{ github.event_name == 'pull_request_target' }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.CLA_ASSISTANT_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CLA_ASSISTANT_SECRET_ACCESS_KEY }}
@@ -30,3 +31,7 @@ jobs:
           pull-request-number: ${{ github.event.pull_request.number }}
           repo-owner: thousandbrainsproject
           repo-name: tbp.monty
+      - name: "CLA Passthrough"
+        if: ${{ github.event_name == 'merge_group' }}
+        run: |
+          exit 0


### PR DESCRIPTION
`verify_cla` check is required, but by the time we are in merge group, we already verified CLA in the pull request.