### PR TITLE
fix!: remove exploratory steps multiplier

### DIFF
--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -145,8 +145,6 @@ class MontyForGraphMatching(MontyBase):
                 all_lms_no_match = False
 
         if all_lms_no_match:
-            # Take more exploratory steps if we are building a new graph
-            self.num_exploratory_steps = self.num_exploratory_steps * 10
             # No need to check any other conditions if all LMs have no_match
             return True
 


### PR DESCRIPTION
As described under 3 here https://github.com/thousandbrainsproject/tbp.monty/pull/701 we can some unintended behavior with the num_exploratory_steps multiplier. This PR removes those lines. 
I am still running pretraining and benchmarks to see whether this change affects them. 