### PR TITLE
ci: deploy docs when new version released

### DIFF
--- a/.github/workflows/docs_deploy.yml
+++ b/.github/workflows/docs_deploy.yml
@@ -10,6 +10,7 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'src/tbp/monty/__init__.py'
       - 'tools/github_readme_sync/**'
       - '.github/workflows/docs_deploy.yml'
       - '.github/actions/get_preview_info/**'


### PR DESCRIPTION
Currently, new version of the docs is not deployed when Monty version changes. This pull request updates to trigger docs deploy when `src/tbp/monty/__init__.py` is updated, which right now only happens during version change.