### PR TITLE
revert: "fix: set individual ts to "no_match" in no_reset experiments (#712)"

### DIFF
--- a/benchmarks/ycb_unsupervised_inference.csv
+++ b/benchmarks/ycb_unsupervised_inference.csv
@@ -1,3 +1,3 @@
 Experiment,Correct (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right
-unsupervised_inference_distinctobj_dist_agent,99.00,99,12,7
-unsupervised_inference_distinctobj_surf_agent,100.00,99,17,10
+unsupervised_inference_distinctobj_dist_agent,97.00,100,16,10
+unsupervised_inference_distinctobj_surf_agent,95.00,100,22,13

--- a/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
@@ -80,7 +80,6 @@ class MontyForNoResetEvidenceGraphMatching(MontyForEvidenceGraphMatching):
         self._is_done = False
         self.reset_episode_steps()
         self.switch_to_matching_step()
-        self._reset_terminal_states()
 
         # keep target up-to-date for logging
         self.primary_target = primary_target
@@ -91,10 +90,6 @@ class MontyForNoResetEvidenceGraphMatching(MontyForEvidenceGraphMatching):
 
         # reset LMs and SMs buffers to save memory
         self._reset_modules_buffers()
-
-    def _reset_terminal_states(self):
-        for lm in self.learning_modules:
-            lm.set_individual_ts("no_match")
 
     def _reset_modules_buffers(self):
         """Resets buffers for LMs and SMs."""


### PR DESCRIPTION
This reverts commit 53bdf106c477c40439a35d21fbd5729ab8ed8865.

The fix impacted the unsupervised benchmarks negatively: 99% -> 1% accuracy. 