### PR TITLE
docs: cleanup trailing whitespace

### DIFF
--- a/src/tbp/monty/frameworks/utils/sensor_processing.py
+++ b/src/tbp/monty/frameworks/utils/sensor_processing.py
@@ -322,7 +322,7 @@ def curvature_at_point(point_cloud, center_id, normal):
 
         # Rarely, "a" can be singular, causing numpy to throw an error.
         # This appears to be caused by the surface-agent gathering observations that
-        # are largely off the object, but not entirely (e.g. <25% visible), resulting 
+        # are largely off the object, but not entirely (e.g. <25% visible), resulting
         # in a system with insufficient data to be solvable.
         if non_singular_mat(a):
             params = np.linalg.solve(a, beta)
@@ -467,7 +467,7 @@ def principal_curvatures(
 
         # Rarely, "a" can be singular, causing numpy to throw an error.
         # This appears to be caused by the touch-sensor gathering observations that
-        # are largely off the object, but not entirely (e.g. <25% visible), resulting 
+        # are largely off the object, but not entirely (e.g. <25% visible), resulting
         # in a system with insufficient data to be solvable.
         if non_singular_mat(a_mat):
             # Step 2) do least-squares fit to get the parameters of the quadratic form


### PR DESCRIPTION
This got merged into `main` by mistake because the "check-style-monty" failing didn't block an auto-merge.

I introduced these in a GitHub suggestion in a previous PR, so I'm fixing it.