### PR TITLE
[DO NOT MERGE] Reference for Improving Hydra Configs

### DIFF
--- a/conf/agent/patch_view_habitat.yaml
+++ b/conf/agent/patch_view_habitat.yaml
@@ -1,0 +1,30 @@
+# @package config.env_interface_config
+
+defaults:
+  - transform/patch_view_distant@_here_
+
+env_init_func: ${monty.class:tbp.monty.simulators.habitat.environment.HabitatEnvironment}
+env_init_args:
+  objects:
+    - name: coneSolid
+      position: [0.0, 1.5, -0.1]
+  scene_id: null
+  seed: 42
+  data_path: ${path.expanduser:${oc.env:MONTY_DATA}/habitat/objects/ycb}
+  agents:
+    agent_type: ${monty.class:tbp.monty.simulators.habitat.MultiSensorAgent}
+    agent_args:
+      agent_id: ${monty.agent_id:agent_id_0}
+      sensor_ids:
+        - patch
+        - view_finder
+      height: 0.0
+      position: [0.0, 1.5, 0.2]
+      resolutions: [[64, 64], [64, 64]]
+      positions: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+      rotations: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]]
+      semantics: [false, false]
+      zooms: [10.0, 1.0]
+
+rng: null
+

--- a/conf/experiment.yaml
+++ b/conf/experiment.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+
+defaults:
+  - _self_
+  - vars: defaults 
+  - logging: defaults
+  - monty: patch_and_view_inference
+  - agent: patch_view_habitat
+  - environment: ycb_distinct
+  - mode: inference
+  # Experiment config (required) - use override to change defaults above
+  - experiment: MISSING
+
+# Global settings
+config:
+  episodes: all
+  num_parallel: 16
+  print_cfg: false
+  quiet_habitat_logs: true

--- a/conf/experiment/2d_sensor_module/disk_learning_control.yaml
+++ b/conf/experiment/2d_sensor_module/disk_learning_control.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+
+defaults:
+  - override /mode: pretrain
+  - override /logging: pretrain
+  - override /environment: disk_objects
+  - override /monty: patch_and_view_learning
+  
+_target_: tbp.monty.frameworks.experiments.pretraining_experiments.MontySupervisedObjectPretrainingExperiment
+
+# Config overrides
+config:
+  n_train_epochs: 3
+  logging:
+    output_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/2d_sensor}
+    python_log_level: INFO
+    run_name: disk_learning_control
+  env_interface_config:
+    env_init_args:
+      data_path: ${path.expanduser:${oc.env:MONTY_DATA}/compositional_objects}
+  train_env_interface_class: ${monty.class:tbp.monty.frameworks.environments.embodied_data.InformedEnvironmentInterface}
+  train_env_interface_args:
+    object_init_sampler:
+      _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
+      positions:
+        - [0.0, 1.5, 0.0]
+        # - [-0.03, 1.5, 0.0]
+        # - [0.03, 1.5, 0.0]
+      rotations: [[0, 0, 0]]
+

--- a/conf/experiment/benchmarks/ycb/inference/base_config_10distinctobj_dist_agent.yaml
+++ b/conf/experiment/benchmarks/ycb/inference/base_config_10distinctobj_dist_agent.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+
+defaults:
+  - override /logging: defaults
+  - override /monty: benchmark_evidence_sota
+  - override /agent: patch_view_habitat
+  - override /environment: ycb_distinct
+
+_target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+
+config:
+  model_name_or_path: ${vars.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
+  n_eval_epochs: ${vars.rotations_all_count}
+  logging:
+    python_log_level: WARNING
+    monty_log_level: BASIC
+    monty_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.BasicCSVStatsHandler}
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.ReproduceEpisodeHandler}
+    wandb_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbTableStatsHandler}
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbChartStatsHandler}
+    wandb_group: benchmark_experiments
+    output_dir: ${path.expanduser:${oc.env:MONTY_LOGS}/projects/monty_runs}
+    run_name: base_config_10distinctobj_dist_agent
+  monty_config:
+    monty_args:
+      min_eval_steps: ${vars.min_eval_steps}
+  eval_env_interface_class: ${monty.class:tbp.monty.frameworks.environments.embodied_data.InformedEnvironmentInterface}

--- a/conf/experiment/benchmarks/ycb/inference/base_config_10distinctobj_surf_agent.yaml
+++ b/conf/experiment/benchmarks/ycb/inference/base_config_10distinctobj_surf_agent.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+
+defaults:
+  - override /logging: defaults
+  - override /monty: benchmark_evidence_sota_surface
+  - override /agent: surface_habitat
+  - override /environment: ycb_distinct
+
+_target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+
+config:
+  model_name_or_path: ${vars.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
+  n_eval_epochs: ${vars.rotations_all_count}
+  max_total_steps: 5000
+  logging:
+    python_log_level: WARNING
+    monty_log_level: BASIC
+    monty_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.BasicCSVStatsHandler}
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.ReproduceEpisodeHandler}
+    wandb_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbTableStatsHandler}
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbChartStatsHandler}
+    wandb_group: benchmark_experiments
+    output_dir: ${path.expanduser:${oc.env:MONTY_LOGS}/projects/monty_runs}
+    run_name: base_config_10distinctobj_surf_agent
+  monty_config:
+    monty_args:
+      min_eval_steps: ${vars.min_eval_steps}
+  eval_env_interface_class: ${monty.class:tbp.monty.frameworks.environments.embodied_data.InformedEnvironmentInterface}

--- a/conf/hydra/defaults.yaml
+++ b/conf/hydra/defaults.yaml
@@ -1,0 +1,5 @@
+# Hydra configuration overrides
+run:
+  dir: ${config.logging.output_dir}
+sweep:
+  dir: ${config.logging.output_dir}

--- a/conf/mode/_defaults.yaml
+++ b/conf/mode/_defaults.yaml
@@ -1,0 +1,16 @@
+# @package _global_
+# Base experiment configuration - all modes extend this
+
+config:
+  do_train: true
+  do_eval: true
+  show_sensor_output: false
+  max_train_steps: 1000
+  max_eval_steps: 500
+  max_total_steps: 6000
+  n_train_epochs: 3
+  n_eval_epochs: 3
+  model_name_or_path: ""
+  min_lms_match: 1
+  seed: 42
+  supervised_lm_ids: []

--- a/conf/mode/inference.yaml
+++ b/conf/mode/inference.yaml
@@ -1,0 +1,10 @@
+# @package _global_
+# Inference mode - evaluate pretrained models
+
+defaults:
+  - _defaults
+
+config:
+  do_train: false
+  do_eval: true
+  python_log_level: DEBUG

--- a/conf/mode/pretrain.yaml
+++ b/conf/mode/pretrain.yaml
@@ -1,0 +1,10 @@
+# @package _global_
+# Pretraining mode - train models from scratch
+
+defaults:
+  - _defaults
+
+config:
+  do_train: true
+  do_eval: false
+  supervised_lm_ids: all

--- a/conf/mode/unsupervised_train.yaml
+++ b/conf/mode/unsupervised_train.yaml
@@ -1,0 +1,9 @@
+# @package _global_
+# Unsupervised training mode - train without supervision
+
+defaults:
+  - _defaults
+
+config:
+  do_train: true
+  do_eval: false

--- a/conf/monty/benchmark_evidence_sota.yaml
+++ b/conf/monty/benchmark_evidence_sota.yaml
@@ -1,0 +1,12 @@
+# @package config.monty_config
+
+defaults:
+  - monty_class: evidence_matching
+  - monty_args: defaults
+  - motor_system: informed_goal_state_driven
+  - connectivity: patch_view_single_lm
+  # Sensor Modules (not as clean because of the syntax of "sensor_module_N")
+  - /monty/sensor_module/components/patch_distant@sensor_module_configs.sensor_module_0
+  - /monty/sensor_module/components/probe_view_finder@sensor_module_configs.sensor_module_1
+  # Learning Module
+  - learning_module/evidence_distant_fast@learning_module_configs.learning_module_0


### PR DESCRIPTION
Hi @tristanls-tbp  and @jeremyshoemaker, here's my draft PR in case it will be helpful during your Feb 2026 focus week. Instead of making a draft PR with 100+ files, I decided to just include a few to illustrate the points. Feel free to incorporate as much or as little suggestions from below, leave questions, and close it when it is no longer needed. 

# Changes I made to Hydra Configs

1. Use of `@package` syntax and `override`. 
- Using these will eliminate the ugly and long injection syntax under `defaults`, and all files with `clear_*.yaml` pattern. 
- Adding `@package` to first line of files should be fairly straightforward. 
- Using `override` requires you to think about how the code is (or should be) organized by modules, which is much harder. See [conf/experiment.yaml](https://github.com/thousandbrainsproject/feat.2d_sensor/blob/1e8f6c519dbae42be3532154383eccb43839c583/conf/experiment.yaml) and [conf/monty/benchmark_evidence_sota.yaml](https://github.com/thousandbrainsproject/feat.2d_sensor/blob/1e8f6c519dbae42be3532154383eccb43839c583/conf/monty/benchmark_evidence_sota.yaml), which shows how I tried to organize it. 

**Update on the last point:** Actually, I think the current organization under `conf/experiment/config` is fine (i.e. `environment`, `environment_interface`, `logging`, `monty`) and these could be the initial config groups. 

2. Reorganization
- Small QoL: I organized experiments into separate folders, as shown below:
```
conf/experiment
├── 2d_sensor_module
│   ├── inference
│   └── learning
├── benchmarks
│   ├── compositional
│   │   ├── inference
│   │   └── training
│   ├── monty_meets_world
│   ├── unsupervised
│   │   ├── inference
│   │   └── learning
│   └── ycb
│       ├── 10obj
│       ├── 77obj
│       └── pretraining
└── tutorials
```
- I moved most of the folders from `conf/experiment/configs` to `conf/`, something like shown below. These folders are called [config groups in Hydra](https://hydra.cc/docs/tutorials/basic/your_first_app/config_groups/) and also reflected in the organization of [conf/experiment.yaml](https://github.com/thousandbrainsproject/feat.2d_sensor/blob/1e8f6c519dbae42be3532154383eccb43839c583/conf/experiment.yaml).
```
conf
├── _experiment # just renamed this so it's not mixed in with below
├── agent
│   └── transform
├── environment
├── hydra
├── logging
├── monty
│   ├── _preset
│   ├── connectivity
│   ├── learning_module
│   │   ├── feature_weights
│   │   ├── gsg
│   │   ├── hypotheses_updater
│   │   └── tolerances
│   ├── monty
│   ├── motor_system
│   │   ├── action_space
│   │   └── policy
│   └── sensor_module
│       ├── patch
│       └── view_finder
├── mode
└── vars # I renamed "benchmarks" to vars but basically contains bunch of variables like rotations 
```
**Update:** Again, I think the current organization is fine and can be moved outside from `conf/experiment/config` to `conf/` directly. 

## Guiding Principles
1. Identify "axes of variation" - these should be folders under `conf/`.
- These are like "decision points", e.g. an experiment consists of environment, logging, Monty (which consists of SM, LM, Motor System), etc. I mostly followed this:
<img width="1730" height="808" alt="image" src="https://github.com/user-attachments/assets/cc924ba7-44da-4e59-a8a4-d2f9ea68b72d" />

- In a perfectly ideal world there should be about 1:1 correspondence between the Python class and config file. 
- **Update:** Again, I'm fine with current organization already.

2. Identify presets or "bundles" that are actually commonly used and those that are too specific (e.g. I think there used to be something like `benchmark_evidence_sota_noisy.yaml` that was a Monty preset used in one benchmark experiment). 
- **Update:** Seems like a lot of these have been identified and removed already. :) 
3. The top-level experiment should mostly a be thin selector.

## Other Tips
1. Keep packaging syntax at the leaf configs, and let the preset/bundle just select leaves.  
2. Rule of thumb for using `_self_`:
	1. Put `_self_` last in a "thin selector" file so local values in that file override imported defaults
	2. Put `_self_` early in "base defaults" if you want imported configs to override base values 
	5. Use `python run.py experiment=NAME --info defaults-tree` to verify the order.

I realize this is a monumental task (thanks!). Maybe it'll be possible to try to refactor out one config group (or "axis of variation") at a time? The simplest one to refactor out is dataset, as shown below. This means under "experiment.yaml" we can add in a config group, like "dataset: ycb" and any custom experiments can override with their own dataset. This one may sound trivial but it may actually be very helpful to users with their own datasets, and for me where I'm making a bunch of synthetic datasets to test my RP. I'm also happy to help "refactor" out sensor module related configs when I get to my IP project. 

```
conf/object_set
├── compositional
│   ├── curved_objects.yaml
│   ├── flat_objects.yaml
│   ├── logos.yaml
│   ├── lvl1.yaml
│   ├── lvl2.yaml
│   ├── lvl3.yaml
│   ├── lvl4.yaml
│   └── parent_to_child_mapping.yaml
├── numenta_lab.yaml
├── omniglot.yaml
├── tutorial.yaml
└── ycb
    ├── all_77.yaml
    ├── distinct_10.yaml
    └── similar_10.yaml
```

Random point: The purpose of [conf/hydra/defaults.yaml](https://github.com/thousandbrainsproject/feat.2d_sensor/blob/1e8f6c519dbae42be3532154383eccb43839c583/conf/hydra/defaults.yaml) was a QoL for me to save the hydra config with the experiment output folder instead of under `outputs/` in our root folder. Yes, you can configure Hydra via Hydra. 😆