### PR TITLE
test: use correct experiment mode

### DIFF
--- a/tests/integration/positioning_procedures/get_good_view_test.py
+++ b/tests/integration/positioning_procedures/get_good_view_test.py
@@ -104,8 +104,8 @@ class GetGoodViewTest(unittest.TestCase):
             with exp:
                 exp.train()
 
-                exp.experiment_mode = ExperimentMode.TRAIN
-                exp.model.set_experiment_mode("train")
+                exp.experiment_mode = ExperimentMode.EVAL
+                exp.model.set_experiment_mode("eval")
                 exp.pre_epoch()
                 exp.pre_episode()
 


### PR DESCRIPTION
When moving the test, I managed to swap experiment mode, which made the test invalid and flaky. This pull request corrects that error.

Original test experiment mode was `EVAL`: https://github.com/thousandbrainsproject/tbp.monty/pull/749/changes#diff-138c94b1ebb4079773642766f95f6f117249f60a17b80dd8a857f4ad93657697L361-L362

I was readily able to reproduce the failure on my machine. Since this fix, I ran it 20 times without failure.