### PR TITLE
chore: version 0.22.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.21.0"
+__version__ = "0.22.0"


### PR DESCRIPTION
Minor version release due to Major version 0 and breaking changes since 0.21.0.

<img width="1240" height="679" alt="Screenshot 2026-02-05 at 15 24 15" src="https://github.com/user-attachments/assets/0454852a-1d61-42ab-8273-d505b762a5e0" />


<img width="1251" height="1035" alt="Screenshot 2026-02-05 at 15 24 00" src="https://github.com/user-attachments/assets/2fb5f00e-0d1d-4962-908e-b9f9bde3e2f9" />

## feat!: package configuration with monty; make it discoverable by users (#710)

All configurations are now in `src/tbp/monty/conf` and packaged with Monty distribution.

## refactor!: don't call get_good_view_with_patch_refinement after successful jump (#747)

This introduces small acceptable changes to benchmark results for distant agents and updated `base_10multi_distinctobj_dist_agent` expectations.

## refactor!: PositioningProcedure separate from Policy (#749)

`PositioningProcedure`s are no longer part of the Policy inheritance chain.

## refactor!: HabitatSalienceSM accepts instances of collaborators (#755)

Update the `HabitatSalienceSM` constructor parameters to expect instances rather than types. This is aligned with our move toward dependency injection.

## refactor!: make MotorPolicy take ActionSampler (#758)

Update motor policy constructor parameters to expect instances of `ActionSampler`. This is aligned with our move toward dependency injection.

## refactor!: ExperimentMode instead of "eval" & "train" strings (#760)

Strings are replaced with `ExperimentMode` enum.

## refactor!: make EvidenceGraphLM take GSG instance (#761)

Update `EvidenceGraphLM` constructor parameters to expect instances of Goal State Generators. This is aligned with our move toward dependency injection.

## refactor!: BasePolicy.action is unused. Move to InformedPolicy. (#764)

Remove unused parameter from `BasePolicy`. Also removed invoking RNG in the constructor, facilitating shift toward `RuntimeContext` RNG use. This is aligned with our move toward dependency injection.

## refactor!: MotorSystem and MotorPolicy access RNG through RuntimeContext (#762)

Instead of accessing `self.rng`, the `MotorSystem` and motor policies receive and invoke RNG through `RuntimeContext`.