### PR TITLE
refactor!: instantiate MotorPolicy from Hydra

### DIFF
--- a/src/tbp/monty/conf/experiment/config/monty/motor_system/cur_informed_surface_goal_state_driven.yaml
+++ b/src/tbp/monty/conf/experiment/config/monty/motor_system/cur_informed_surface_goal_state_driven.yaml
@@ -1,11 +1,11 @@
 defaults:
-  - policy/surface_curve_informed@motor_system_args.policy_args
-  - action_space/surface_agent@motor_system_args.policy_args.action_sampler
+  - policy/surface_curve_informed@motor_system_args.policy
+  - action_space/surface_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
     desired_object_distance: 0.025

--- a/src/tbp/monty/conf/experiment/config/monty/motor_system/curvature_informed_surface.yaml
+++ b/src/tbp/monty/conf/experiment/config/monty/motor_system/curvature_informed_surface.yaml
@@ -1,11 +1,11 @@
 defaults:
-  - policy/surface_curve_informed@motor_system_args.policy_args
-  - action_space/surface_agent@motor_system_args.policy_args.action_sampler
+  - policy/surface_curve_informed@motor_system_args.policy
+  - action_space/surface_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
     desired_object_distance: 0.025

--- a/src/tbp/monty/conf/experiment/config/monty/motor_system/defaults.yaml
+++ b/src/tbp/monty/conf/experiment/config/monty/motor_system/defaults.yaml
@@ -1,11 +1,11 @@
 defaults:
-  - policy/base@motor_system_args.policy_args
-  - action_space/distant_agent@motor_system_args.policy_args.action_sampler
+  - policy/base@motor_system_args.policy
+  - action_space/distant_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.BasePolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.BasePolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.UniformlyDistributedSampler
     agent_id: ${monty.agent_id:agent_id_0}

--- a/src/tbp/monty/conf/experiment/config/monty/motor_system/informed_goal_state_driven.yaml
+++ b/src/tbp/monty/conf/experiment/config/monty/motor_system/informed_goal_state_driven.yaml
@@ -1,11 +1,11 @@
 defaults:
-  - policy/informed@motor_system_args.policy_args
-  - action_space/distant_agent@motor_system_args.policy_args.action_sampler
+  - policy/informed@motor_system_args.policy
+  - action_space/distant_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
       rotation_degrees: 5.0

--- a/src/tbp/monty/conf/experiment/config/monty/motor_system/informed_goal_state_driven_farther_away.yaml
+++ b/src/tbp/monty/conf/experiment/config/monty/motor_system/informed_goal_state_driven_farther_away.yaml
@@ -1,11 +1,11 @@
 defaults:
-  - policy/informed@motor_system_args.policy_args
-  - action_space/distant_agent@motor_system_args.policy_args.action_sampler
+  - policy/informed@motor_system_args.policy
+  - action_space/distant_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
       rotation_degrees: 10.0 # Relatively large step-size

--- a/src/tbp/monty/conf/experiment/config/monty/motor_system/informed_no_trans.yaml
+++ b/src/tbp/monty/conf/experiment/config/monty/motor_system/informed_no_trans.yaml
@@ -1,11 +1,11 @@
 defaults:
-  - policy/informed@motor_system_args.policy_args
-  - action_space/distant_agent@motor_system_args.policy_args.action_sampler
+  - policy/informed@motor_system_args.policy
+  - action_space/distant_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
       rotation_degrees: 5.0

--- a/src/tbp/monty/conf/experiment/config/monty/motor_system/informed_no_trans_step_s1.yaml
+++ b/src/tbp/monty/conf/experiment/config/monty/motor_system/informed_no_trans_step_s1.yaml
@@ -1,11 +1,11 @@
 defaults:
-  - policy/informed@motor_system_args.policy_args
-  - action_space/distant_agent@motor_system_args.policy_args.action_sampler
+  - policy/informed@motor_system_args.policy
+  - action_space/distant_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
       rotation_degrees: 1.0

--- a/src/tbp/monty/conf/experiment/config/monty/motor_system/informed_no_trans_step_s20.yaml
+++ b/src/tbp/monty/conf/experiment/config/monty/motor_system/informed_no_trans_step_s20.yaml
@@ -1,11 +1,11 @@
 defaults:
-  - policy/informed@motor_system_args.policy_args
-  - action_space/distant_agent@motor_system_args.policy_args.action_sampler
+  - policy/informed@motor_system_args.policy
+  - action_space/distant_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
       rotation_degrees: 20.0

--- a/src/tbp/monty/conf/experiment/config/monty/motor_system/naive_scan_spiral.yaml
+++ b/src/tbp/monty/conf/experiment/config/monty/motor_system/naive_scan_spiral.yaml
@@ -1,11 +1,11 @@
 defaults:
-  - policy/naive_scan@motor_system_args.policy_args
-  - action_space/distant_agent@motor_system_args.policy_args.action_sampler
+  - policy/naive_scan@motor_system_args.policy
+  - action_space/distant_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
     fixed_amount: 5

--- a/src/tbp/monty/conf/experiment/config/monty/motor_system/surface.yaml
+++ b/src/tbp/monty/conf/experiment/config/monty/motor_system/surface.yaml
@@ -1,11 +1,11 @@
 defaults:
-  - policy/surface@motor_system_args.policy_args
-  - action_space/surface_agent@motor_system_args.policy_args.action_sampler
+  - policy/surface@motor_system_args.policy
+  - action_space/surface_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
     desired_object_distance: 0.025 # 2.5 cm desired distance

--- a/src/tbp/monty/conf/experiment/supervised_pre_training_base.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_base.yaml
@@ -8,7 +8,7 @@ defaults:
   - config/monty/motor_system/clear_motor_system_config@config.monty_config
   # use spiral policy for more even object coverage during learning
   - config/monty/motor_system/naive_scan_spiral@config.monty_config.motor_system_config
-  - config/monty/motor_system/policy/naive_scan@config.monty_config.motor_system_config.motor_system_args.policy_args
+  - config/monty/motor_system/policy/naive_scan@config.monty_config.motor_system_config.motor_system_args.policy
   - config/environment/patch_view_finder_mount_habitat@config.env_interface_config
   - config/environment_interface/per_object@config.train_env_interface_args
   - config/environment_interface/ycb/distinct_objects@config.train_env_interface_args.object_names
@@ -25,7 +25,7 @@ config:
       num_exploratory_steps: 500
     motor_system_config:
       motor_system_args:
-        policy_args:
+        policy:
           fixed_amount: 5
     learning_module_configs:
       learning_module_0:

--- a/src/tbp/monty/conf/experiment/supervised_pre_training_logos_after_flat_objects.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_logos_after_flat_objects.yaml
@@ -27,9 +27,8 @@ config:
       num_exploratory_steps: 1000
     motor_system_config:
       motor_system_args:
-        policy_args:
+        policy:
           fixed_amount: 1
   train_env_interface_args:
     object_init_sampler:
       _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
-

--- a/src/tbp/monty/conf/experiment/supervised_pre_training_objects_with_logos_lvl1_comp_models_resampling.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_objects_with_logos_lvl1_comp_models_resampling.yaml
@@ -18,7 +18,7 @@ config:
       min_train_steps: 500
     motor_system_config:
       motor_system_args:
-        policy_args:
+        policy:
           action_sampler:
             # As learning with random saccades + hypothesis jumps,
             # make saccades smaller

--- a/src/tbp/monty/conf/experiment/test/config/monty/motor_system/fixed.yaml
+++ b/src/tbp/monty/conf/experiment/test/config/monty/motor_system/fixed.yaml
@@ -1,11 +1,11 @@
 defaults:
-  - /experiment/config/monty/motor_system/policy/informed@motor_system_args.policy_args
-  - /experiment/config/monty/motor_system/action_space/distant_agent@motor_system_args.policy_args.action_sampler
+  - /experiment/config/monty/motor_system/policy/informed@motor_system_args.policy
+  - /experiment/config/monty/motor_system/action_space/distant_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
       rotation_degrees: 5.0

--- a/src/tbp/monty/conf/experiment/test/config/monty/motor_system/uniformly_distributed.yaml
+++ b/src/tbp/monty/conf/experiment/test/config/monty/motor_system/uniformly_distributed.yaml
@@ -1,10 +1,10 @@
 defaults:
-  - /experiment/config/monty/motor_system/policy/informed@motor_system_args.policy_args
-  - /experiment/config/monty/motor_system/action_space/distant_agent@motor_system_args.policy_args.action_sampler
+  - /experiment/config/monty/motor_system/policy/informed@motor_system_args.policy
+  - /experiment/config/monty/motor_system/action_space/distant_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.UniformlyDistributedSampler

--- a/src/tbp/monty/conf/test/config/monty/motor_system/absolute.yaml
+++ b/src/tbp/monty/conf/test/config/monty/motor_system/absolute.yaml
@@ -1,11 +1,11 @@
 defaults:
   - /experiment/config/monty/motor_system/defaults@
-  - /experiment/config/monty/motor_system/action_space/absolute_only@motor_system_args.policy_args.action_sampler
+  - /experiment/config/monty/motor_system/action_space/absolute_only@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.BasePolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.BasePolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.UniformlyDistributedSampler
     agent_id: ${monty.agent_id:agent_id_0}

--- a/src/tbp/monty/conf/test/config/monty/motor_system/surface.yaml
+++ b/src/tbp/monty/conf/test/config/monty/motor_system/surface.yaml
@@ -1,11 +1,11 @@
 defaults:
   - /experiment/config/monty/motor_system/defaults@
-  - /experiment/config/monty/motor_system/action_space/surface_agent@motor_system_args.policy_args.action_sampler
+  - /experiment/config/monty/motor_system/action_space/surface_agent@motor_system_args.policy.action_sampler
 
 motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
 motor_system_args:
-  policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.BasePolicy}
-  policy_args:
+  policy:
+    _target_: tbp.monty.frameworks.models.motor_policies.BasePolicy
     action_sampler:
       _target_: tbp.monty.frameworks.actions.action_samplers.UniformlyDistributedSampler
     agent_id: ${monty.agent_id:agent_id_0}

--- a/src/tbp/monty/conf/test/hierarchy/two_lms_constrained.yaml
+++ b/src/tbp/monty/conf/test/hierarchy/two_lms_constrained.yaml
@@ -7,7 +7,7 @@ defaults:
   - /experiment/config/monty/two_lm_stacked@config.monty_config
   - /experiment/config/monty/motor_system/clear_motor_system_config@config.monty_config
   - /experiment/config/monty/motor_system/naive_scan_spiral@config.monty_config.motor_system_config
-  - /experiment/config/monty/motor_system/policy/naive_scan@config.monty_config.motor_system_config.motor_system_args.policy_args
+  - /experiment/config/monty/motor_system/policy/naive_scan@config.monty_config.motor_system_config.motor_system_args.policy
   - /experiment/config/monty/learning_modules/clear_learning_module_configs@config.monty_config
   - /experiment/config/environment/two_lm_stacked_distant_mount_habitat@config.env_interface_config
 
@@ -58,7 +58,7 @@ config:
           max_nodes_per_graph: 2000
     motor_system_config:
       motor_system_args:
-        policy_args:
+        policy:
           fixed_amount: 10
   env_interface_config:
     env_init_args:

--- a/src/tbp/monty/conf/test/hierarchy/two_lms_heterarchy.yaml
+++ b/src/tbp/monty/conf/test/hierarchy/two_lms_heterarchy.yaml
@@ -5,7 +5,7 @@ defaults:
   - /experiment/config/monty/learning_modules/clear_learning_module_configs@config.monty_config
   - /experiment/config/monty/motor_system/clear_motor_system_config@config.monty_config
   - /experiment/config/monty/motor_system/naive_scan_spiral@config.monty_config.motor_system_config
-  - /experiment/config/monty/motor_system/policy/naive_scan@config.monty_config.motor_system_config.motor_system_args.policy_args
+  - /experiment/config/monty/motor_system/policy/naive_scan@config.monty_config.motor_system_config.motor_system_args.policy
   - /experiment/config/environment/two_lm_stacked_distant_mount_habitat@config.env_interface_config
 
 config:
@@ -56,7 +56,7 @@ config:
             distance: 0.02
     motor_system_config:
       motor_system_args:
-        policy_args:
+        policy:
           fixed_amount: 10
   env_interface_config:
     env_init_args:

--- a/src/tbp/monty/conf/test/integration/positioning_procedures/get_good_view/dist_agent_too_far_away.yaml
+++ b/src/tbp/monty/conf/test/integration/positioning_procedures/get_good_view/dist_agent_too_far_away.yaml
@@ -7,7 +7,7 @@ config:
   monty_config:
     motor_system_config:
       motor_system_args:
-        policy_args:
+        policy:
           action_sampler:
             rotation_degrees: 5.0
           good_view_percentage: 0.5

--- a/src/tbp/monty/conf/test/integration/positioning_procedures/get_good_view/multi_object_target_not_visible.yaml
+++ b/src/tbp/monty/conf/test/integration/positioning_procedures/get_good_view/multi_object_target_not_visible.yaml
@@ -10,7 +10,7 @@ config:
   monty_config:
     motor_system_config:
       motor_system_args:
-        policy_args:
+        policy:
           action_sampler:
             rotation_degrees: 5.0
           good_view_percentage: 0.5

--- a/src/tbp/monty/conf/test/policy/dist_fixed_action.yaml
+++ b/src/tbp/monty/conf/test/policy/dist_fixed_action.yaml
@@ -7,7 +7,7 @@ config:
   monty_config:
     motor_system_config:
       motor_system_args:
-        policy_args:
+        policy:
           action_sampler:
             actions:
               - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}

--- a/src/tbp/monty/conf/test/policy/surf_fixed_action.yaml
+++ b/src/tbp/monty/conf/test/policy/surf_fixed_action.yaml
@@ -9,7 +9,7 @@ config:
   monty_config:
     motor_system_config:
       motor_system_args:
-        policy_args:
+        policy:
           action_sampler:
             translation_distance: 0.05
           desired_object_distance: 0.025

--- a/src/tbp/monty/conf/test/policy/surf_poor_initial_view.yaml
+++ b/src/tbp/monty/conf/test/policy/surf_poor_initial_view.yaml
@@ -9,7 +9,7 @@ config:
   monty_config:
     motor_system_config:
       motor_system_args:
-        policy_args:
+        policy:
           action_sampler:
             translation_distance: 0.05
           desired_object_distance: 0.025

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -38,7 +38,6 @@ from tbp.monty.frameworks.models.abstract_monty_classes import (
     LearningModule,
     SensorModule,
 )
-from tbp.monty.frameworks.models.motor_policies import MotorPolicy
 from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.frameworks.utils.dataclass_utils import (
     get_subset_of_args,
@@ -174,14 +173,7 @@ class MontyExperiment:
                 "motor_system_class must be a subclass of MotorSystem, got "
                 f"{motor_system_class}"
             )
-        policy_class = motor_system_args["policy_class"]
-        policy_args = motor_system_args["policy_args"]
-        if not issubclass(policy_class, MotorPolicy):
-            raise TypeError(
-                f"policy_class must be a subclass of MotorPolicy, got {policy_class}"
-            )
-        policy = policy_class(**policy_args)
-        motor_system = motor_system_class(policy=policy)
+        motor_system = motor_system_class(**motor_system_args)
 
         # Get mapping between sensor modules, learning modules and agents
         lm_len = len(learning_modules)

--- a/tests/conf/snapshots/base_10multi_distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/base_10multi_distinctobj_dist_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 10.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/base_10simobj_surf_agent.yaml
+++ b/tests/conf/snapshots/base_10simobj_surf_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -122,7 +122,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/base_77obj_dist_agent.yaml
+++ b/tests/conf/snapshots/base_77obj_dist_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/base_77obj_surf_agent.yaml
+++ b/tests/conf/snapshots/base_77obj_surf_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -122,7 +122,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/base_config_10distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/base_config_10distinctobj_dist_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/base_config_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/base_config_10distinctobj_surf_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -122,7 +122,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/bright_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/bright_world_image_on_scanned_model.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 20.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/dark_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/dark_world_image_on_scanned_model.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 20.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/hand_intrusion_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/hand_intrusion_world_image_on_scanned_model.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 20.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/infer_comp_lvl1_with_comp_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl1_with_comp_models.yaml
@@ -159,7 +159,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -174,7 +174,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/infer_comp_lvl1_with_comp_models_and_resampling.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl1_with_comp_models_and_resampling.yaml
@@ -159,7 +159,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -174,7 +174,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/infer_comp_lvl1_with_monolithic_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl1_with_monolithic_models.yaml
@@ -159,7 +159,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -174,7 +174,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/infer_comp_lvl2_with_comp_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl2_with_comp_models.yaml
@@ -159,7 +159,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -174,7 +174,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/infer_comp_lvl3_with_comp_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl3_with_comp_models.yaml
@@ -159,7 +159,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -174,7 +174,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/infer_comp_lvl4_with_comp_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl4_with_comp_models.yaml
@@ -159,7 +159,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -174,7 +174,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/multi_object_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/multi_object_world_image_on_scanned_model.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 20.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/only_surf_agent_training_10obj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_10obj.yaml
@@ -99,7 +99,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/only_surf_agent_training_10simobj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_10simobj.yaml
@@ -99,7 +99,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/only_surf_agent_training_allobj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_allobj.yaml
@@ -99,7 +99,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/only_surf_agent_training_numenta_lab_obj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_numenta_lab_obj.yaml
@@ -99,7 +99,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randomrot_rawnoise_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randomrot_rawnoise_10distinctobj_surf_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -122,7 +122,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randrot_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_10distinctobj_surf_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -122,7 +122,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_5lms_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_5lms_dist_agent.yaml
@@ -159,7 +159,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -174,7 +174,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_dist_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_dist_on_distm.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_dist_on_distm.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_surf_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -122,7 +122,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randrot_noise_10simobj_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10simobj_dist_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randrot_noise_10simobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10simobj_surf_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -122,7 +122,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randrot_noise_77obj_5lms_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_5lms_dist_agent.yaml
@@ -159,7 +159,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -174,7 +174,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randrot_noise_77obj_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_dist_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randrot_noise_77obj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_surf_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -122,7 +122,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/randrot_noise_sim_on_scan_monty_world.yaml
+++ b/tests/conf/snapshots/randrot_noise_sim_on_scan_monty_world.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 20.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/supervised_pre_training_5lms.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_5lms.yaml
@@ -185,7 +185,7 @@ experiment:
             save_raw_obs: false
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -200,7 +200,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 500

--- a/tests/conf/snapshots/supervised_pre_training_5lms_all_objects.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_5lms_all_objects.yaml
@@ -185,7 +185,7 @@ experiment:
             save_raw_obs: false
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -200,7 +200,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 500

--- a/tests/conf/snapshots/supervised_pre_training_base.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_base.yaml
@@ -99,7 +99,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -114,7 +114,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 500

--- a/tests/conf/snapshots/supervised_pre_training_curved_objects_after_flat_and_logo.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_curved_objects_after_flat_and_logo.yaml
@@ -156,7 +156,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -171,7 +171,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/supervised_pre_training_flat_objects_wo_logos.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_flat_objects_wo_logos.yaml
@@ -156,7 +156,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -171,7 +171,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/supervised_pre_training_logos_after_flat_objects.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_logos_after_flat_objects.yaml
@@ -156,7 +156,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -171,7 +171,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models.yaml
@@ -156,7 +156,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -171,7 +171,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models_resampling.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models_resampling.yaml
@@ -156,7 +156,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -171,7 +171,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 2.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 0

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_monolithic_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_monolithic_models.yaml
@@ -155,7 +155,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -170,7 +170,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl2_comp_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl2_comp_models.yaml
@@ -156,7 +156,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -171,7 +171,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl3_comp_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl3_comp_models.yaml
@@ -156,7 +156,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -171,7 +171,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl4_comp_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl4_comp_models.yaml
@@ -156,7 +156,7 @@ experiment:
             save_raw_obs: true
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -171,7 +171,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj.yaml
+++ b/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj.yaml
@@ -101,7 +101,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -116,7 +116,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj_noise.yaml
+++ b/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj_noise.yaml
@@ -101,7 +101,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -116,7 +116,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/surf_agent_unsupervised_10simobj.yaml
+++ b/tests/conf/snapshots/surf_agent_unsupervised_10simobj.yaml
@@ -101,7 +101,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -116,7 +116,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_eval.yaml
+++ b/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_eval.yaml
@@ -187,7 +187,7 @@ experiment:
             save_raw_obs: false
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -202,7 +202,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_train.yaml
+++ b/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_train.yaml
@@ -185,7 +185,7 @@ experiment:
             save_raw_obs: false
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -200,7 +200,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.NaiveScanPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 500

--- a/tests/conf/snapshots/tutorial/first_experiment.yaml
+++ b/tests/conf/snapshots/tutorial/first_experiment.yaml
@@ -99,7 +99,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -114,7 +114,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/tutorial/monty_meets_world_2dimage_inference.yaml
+++ b/tests/conf/snapshots/tutorial/monty_meets_world_2dimage_inference.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 20.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/tutorial/omniglot_inference.yaml
+++ b/tests/conf/snapshots/tutorial/omniglot_inference.yaml
@@ -101,7 +101,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -116,7 +116,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/tutorial/omniglot_training.yaml
+++ b/tests/conf/snapshots/tutorial/omniglot_training.yaml
@@ -99,7 +99,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -114,7 +114,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 1.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/tutorial/surf_agent_2obj_eval.yaml
+++ b/tests/conf/snapshots/tutorial/surf_agent_2obj_eval.yaml
@@ -101,7 +101,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -120,7 +120,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/tutorial/surf_agent_2obj_train.yaml
+++ b/tests/conf/snapshots/tutorial/surf_agent_2obj_train.yaml
@@ -99,7 +99,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -114,12 +114,12 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
             alpha: 0.1
             pc_alpha: 0.5
             max_pc_bias_steps: 32
             min_general_steps: 8
             min_heading_steps: 12
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 500

--- a/tests/conf/snapshots/tutorial/surf_agent_2obj_unsupervised.yaml
+++ b/tests/conf/snapshots/tutorial/surf_agent_2obj_unsupervised.yaml
@@ -100,7 +100,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -115,7 +115,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/unsupervised_inference_distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/unsupervised_inference_distinctobj_dist_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 5.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/unsupervised_inference_distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/unsupervised_inference_distinctobj_surf_agent.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.025
@@ -122,7 +122,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
               - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/world_image_from_stream_on_scanned_model.yaml
+++ b/tests/conf/snapshots/world_image_from_stream_on_scanned_model.yaml
@@ -102,7 +102,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -117,7 +117,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 20.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/conf/snapshots/world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/world_image_on_scanned_model.yaml
@@ -103,7 +103,7 @@ experiment:
     monty_config:
       motor_system_config:
         motor_system_args:
-          policy_args:
+          policy:
             file_name: null
             good_view_percentage: 0.5
             desired_object_distance: 0.03
@@ -118,7 +118,7 @@ experiment:
               - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               rotation_degrees: 20.0
-          policy_class: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicy}
+            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
         motor_system_class: ${monty.class:tbp.monty.frameworks.models.motor_system.MotorSystem}
       monty_args:
         num_exploratory_steps: 1000

--- a/tests/integration/positioning_procedures/get_good_view_test.py
+++ b/tests/integration/positioning_procedures/get_good_view_test.py
@@ -57,11 +57,11 @@ class GetGoodViewTest(unittest.TestCase):
                 exp.pre_epoch()
                 exp.pre_episode()
 
-                policy_args = config.test.config["monty_config"]["motor_system_config"][
+                policy_cfg = config.test.config["monty_config"]["motor_system_config"][
                     "motor_system_args"
-                ]["policy_args"]
-                target_perc_on_target_obj = policy_args["good_view_percentage"]
-                target_closest_point = policy_args["desired_object_distance"]
+                ]["policy"]
+                target_perc_on_target_obj = policy_cfg["good_view_percentage"]
+                target_closest_point = policy_cfg["desired_object_distance"]
 
                 observation = next(exp.env_interface)
                 view = observation[exp.model.motor_system._policy.agent_id][
@@ -109,11 +109,11 @@ class GetGoodViewTest(unittest.TestCase):
                 exp.pre_epoch()
                 exp.pre_episode()
 
-                policy_args = config.test.config["monty_config"]["motor_system_config"][
+                policy_cfg = config.test.config["monty_config"]["motor_system_config"][
                     "motor_system_args"
-                ]["policy_args"]
-                target_perc_on_target_obj = policy_args["good_view_percentage"]
-                target_closest_point = policy_args["desired_object_distance"]
+                ]["policy"]
+                target_perc_on_target_obj = policy_cfg["good_view_percentage"]
+                target_closest_point = policy_cfg["desired_object_distance"]
 
                 observation = next(exp.env_interface)
                 view = observation[exp.model.motor_system._policy.agent_id][

--- a/tests/integration/reproducibility/config.py
+++ b/tests/integration/reproducibility/config.py
@@ -43,7 +43,7 @@ def hydra_config(
     if fixed_actions_path:
         overrides.append(
             "+experiment.config.monty_config.motor_system_config"
-            f".motor_system_args.policy_args.file_name={fixed_actions_path}",
+            f".motor_system_args.policy.file_name={fixed_actions_path}",
         )
     if model_name_or_path:
         overrides.append(

--- a/tests/unit/embodied_data_test.py
+++ b/tests/unit/embodied_data_test.py
@@ -167,17 +167,17 @@ class EmbodiedDataTest(unittest.TestCase):
         with hydra.initialize_config_dir(config_dir=str(HYDRA_ROOT), version_base=None):
             self.policy_cfg_fragment = hydra.compose(
                 config_name="experiment/config/monty/motor_system/defaults"
-            ).experiment.config.monty.motor_system.motor_system_args.policy_args
+            ).experiment.config.monty.motor_system.motor_system_args.policy
             self.policy_cfg_abs_fragment = hydra.compose(
                 config_name="test/config/monty/motor_system/absolute"
-            ).test.config.monty.motor_system.motor_system_args.policy_args
+            ).test.config.monty.motor_system.motor_system_args.policy
 
     def test_embodied_env_interface_dist(self):
         seed = 42
         rng = np.random.RandomState(seed)
-        base_policy_cfg_dist = hydra.utils.instantiate(self.policy_cfg_fragment)
-        base_policy_cfg_dist["agent_id"] = AGENT_ID
-        motor_system_dist = MotorSystem(policy=BasePolicy(**base_policy_cfg_dist))
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_fragment)
+        base_policy.agent_id = AGENT_ID
+        motor_system_dist = MotorSystem(policy=base_policy)
         env = FakeEnvironmentRel()
         env_interface_dist = EnvironmentInterface(
             env,
@@ -211,10 +211,10 @@ class EmbodiedDataTest(unittest.TestCase):
     def test_embodied_env_interface_abs(self):
         seed = 42
         rng = np.random.RandomState(seed)
-        base_policy_cfg_abs = hydra.utils.instantiate(self.policy_cfg_abs_fragment)
-        base_policy_cfg_abs["agent_id"] = AGENT_ID
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_abs_fragment)
+        base_policy.agent_id = AGENT_ID
 
-        motor_system_abs = MotorSystem(policy=BasePolicy(**base_policy_cfg_abs))
+        motor_system_abs = MotorSystem(policy=base_policy)
         env = FakeEnvironmentAbs()
         env_interface_abs = EnvironmentInterface(
             env,
@@ -247,10 +247,10 @@ class EmbodiedDataTest(unittest.TestCase):
     def test_embodied_env_interface_dist_states(self):
         seed = 42
         rng = np.random.RandomState(seed)
-        base_policy_cfg_dist = hydra.utils.instantiate(self.policy_cfg_fragment)
-        base_policy_cfg_dist["agent_id"] = AGENT_ID
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_fragment)
+        base_policy.agent_id = AGENT_ID
 
-        motor_system_dist = MotorSystem(policy=BasePolicy(**base_policy_cfg_dist))
+        motor_system_dist = MotorSystem(policy=base_policy)
         env = FakeEnvironmentRel()
         env_interface_dist = EnvironmentInterface(
             env=env,
@@ -272,10 +272,10 @@ class EmbodiedDataTest(unittest.TestCase):
         seed = 42
         rng = np.random.RandomState(seed)
 
-        base_policy_cfg_abs = hydra.utils.instantiate(self.policy_cfg_abs_fragment)
-        base_policy_cfg_abs["agent_id"] = AGENT_ID
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_abs_fragment)
+        base_policy.agent_id = AGENT_ID
 
-        motor_system_abs = MotorSystem(policy=BasePolicy(**base_policy_cfg_abs))
+        motor_system_abs = MotorSystem(policy=base_policy)
         env = FakeEnvironmentAbs()
         env_interface_abs = EnvironmentInterface(
             env=env,
@@ -317,10 +317,10 @@ class EmbodiedDataTest(unittest.TestCase):
     def test_omniglot_data_loader(self):
         rng = np.random.RandomState(42)
 
-        base_policy_cfg_abs = hydra.utils.instantiate(self.policy_cfg_abs_fragment)
-        base_policy_cfg_abs["agent_id"] = AGENT_ID
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_abs_fragment)
+        base_policy.agent_id = AGENT_ID
 
-        motor_system_abs = MotorSystem(policy=BasePolicy(**base_policy_cfg_abs))
+        motor_system_abs = MotorSystem(policy=base_policy)
 
         alphabets = [0, 0, 0, 1, 1, 1]
         characters = [1, 2, 3, 1, 2, 3]
@@ -353,12 +353,10 @@ class EmbodiedDataTest(unittest.TestCase):
 
         data_path = Path(__file__).parent / "resources" / "dataloader_test_images"
 
-        base_policy_cfg_rel = hydra.utils.instantiate(self.policy_cfg_fragment)
-        base_policy_cfg_rel["agent_id"] = AGENT_ID
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_fragment)
+        base_policy.agent_id = AGENT_ID
 
-        motor_system_rel = MotorSystem(
-            policy=BasePolicy(**base_policy_cfg_rel), state=MotorSystemState()
-        )
+        motor_system_rel = MotorSystem(policy=base_policy, state=MotorSystemState())
 
         env_init_args = {"patch_size": patch_size, "data_path": data_path}
         env = SaccadeOnImageEnvironment(**env_init_args)
@@ -406,10 +404,10 @@ class EmbodiedDataTest(unittest.TestCase):
             / "0_numenta_mug"
         )
 
-        base_policy_cfg_rel = hydra.utils.instantiate(self.policy_cfg_fragment)
-        base_policy_cfg_rel["agent_id"] = AGENT_ID
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_fragment)
+        base_policy.agent_id = AGENT_ID
 
-        motor_system_rel = MotorSystem(policy=BasePolicy(**base_policy_cfg_rel))
+        motor_system_rel = MotorSystem(policy=base_policy)
 
         env_init_args = {"patch_size": patch_size, "data_path": data_path}
         env = SaccadeOnImageFromStreamEnvironment(**env_init_args)

--- a/tests/unit/evidence_lm_test.py
+++ b/tests/unit/evidence_lm_test.py
@@ -66,7 +66,7 @@ class EvidenceLMTest(BaseGraphTest):
                 "monty_config",
                 "motor_system_config",
                 "motor_system_args",
-                "policy_args",
+                "policy",
                 "file_name",
             ]
         )

--- a/tests/unit/graph_learning_test.py
+++ b/tests/unit/graph_learning_test.py
@@ -112,7 +112,7 @@ class GraphLearningTest(BaseGraphTest):
                 "monty_config",
                 "motor_system_config",
                 "motor_system_args",
-                "policy_args",
+                "policy",
                 "file_name",
             ]
         )

--- a/tests/unit/habitat_data_test.py
+++ b/tests/unit/habitat_data_test.py
@@ -77,13 +77,13 @@ class HabitatDataTest(unittest.TestCase):
         with hydra.initialize_config_dir(config_dir=str(HYDRA_ROOT), version_base=None):
             self.policy_cfg_fragment = hydra.compose(
                 config_name="experiment/config/monty/motor_system/defaults",
-            ).experiment.config.monty.motor_system.motor_system_args.policy_args
+            ).experiment.config.monty.motor_system.motor_system_args.policy
             self.policy_cfg_abs_fragment = hydra.compose(
                 config_name="test/config/monty/motor_system/absolute",
-            ).test.config.monty.motor_system.motor_system_args.policy_args
+            ).test.config.monty.motor_system.motor_system_args.policy
             self.policy_cfg_surf_fragment = hydra.compose(
                 config_name="test/config/monty/motor_system/surface",
-            ).test.config.monty.motor_system.motor_system_args.policy_args
+            ).test.config.monty.motor_system.motor_system_args.policy
 
     @mock.patch("habitat_sim.Agent", autospec=True)
     @mock.patch("habitat_sim.Simulator", autospec=True)
@@ -105,10 +105,10 @@ class HabitatDataTest(unittest.TestCase):
         rng = np.random.RandomState(seed)
 
         # Create distant-agent motor systems / policies
-        base_policy_cfg_dist = hydra.utils.instantiate(self.policy_cfg_fragment)
-        base_policy_cfg_dist["agent_id"] = AGENT_ID
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_fragment)
+        base_policy.agent_id = AGENT_ID
 
-        motor_system_dist = MotorSystem(policy=BasePolicy(**base_policy_cfg_dist))
+        motor_system_dist = MotorSystem(policy=base_policy)
 
         # Create habitat env datasets with distant-agent action space
         env_init_args = {"agents": self.camera_dist_config}
@@ -161,10 +161,10 @@ class HabitatDataTest(unittest.TestCase):
         seed = 42
         rng = np.random.RandomState(seed)
 
-        base_policy_cfg_abs = hydra.utils.instantiate(self.policy_cfg_abs_fragment)
-        base_policy_cfg_abs["agent_id"] = AGENT_ID
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_abs_fragment)
+        base_policy.agent_id = AGENT_ID
 
-        motor_system_abs = MotorSystem(policy=BasePolicy(**base_policy_cfg_abs))
+        motor_system_abs = MotorSystem(policy=base_policy)
 
         # Create habitat env with absolute action space
         env_init_args = {"agents": self.camera_abs_config}
@@ -218,10 +218,10 @@ class HabitatDataTest(unittest.TestCase):
         rng = np.random.RandomState(seed)
         # Note we just test random actions (i.e. base policy) with the surface-agent
         # action space
-        base_policy_cfg_surf = hydra.utils.instantiate(self.policy_cfg_surf_fragment)
-        base_policy_cfg_surf["agent_id"] = AGENT_ID
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_surf_fragment)
+        base_policy.agent_id = AGENT_ID
 
-        motor_system_surf = MotorSystem(policy=BasePolicy(**base_policy_cfg_surf))
+        motor_system_surf = MotorSystem(policy=base_policy)
 
         # Create habitat env interface with distant-agent action space
         env_init_args = {"agents": self.camera_surf_config}
@@ -275,9 +275,9 @@ class HabitatDataTest(unittest.TestCase):
         seed = 42
         rng = np.random.RandomState(seed)
 
-        base_policy_cfg_dist = hydra.utils.instantiate(self.policy_cfg_fragment)
-        base_policy_cfg_dist["agent_id"] = AGENT_ID
-        motor_system_dist = MotorSystem(policy=BasePolicy(**base_policy_cfg_dist))
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_fragment)
+        base_policy.agent_id = AGENT_ID
+        motor_system_dist = MotorSystem(policy=base_policy)
 
         env_init_args = {"agents": self.camera_dist_config}
         env = HabitatEnvironment(**env_init_args)
@@ -315,9 +315,9 @@ class HabitatDataTest(unittest.TestCase):
         seed = 42
         rng = np.random.RandomState(seed)
 
-        base_policy_cfg_abs = hydra.utils.instantiate(self.policy_cfg_abs_fragment)
-        base_policy_cfg_abs["agent_id"] = AGENT_ID
-        motor_system_abs = MotorSystem(policy=BasePolicy(**base_policy_cfg_abs))
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_abs_fragment)
+        base_policy.agent_id = AGENT_ID
+        motor_system_abs = MotorSystem(policy=base_policy)
         env_init_args = {"agents": self.camera_abs_config}
         env = HabitatEnvironment(**env_init_args)
         env_interface_abs = EnvironmentInterface(
@@ -355,9 +355,9 @@ class HabitatDataTest(unittest.TestCase):
 
         # Note we just test random actions (i.e. base policy) with the surface-agent
         # action space
-        base_policy_cfg_surf = hydra.utils.instantiate(self.policy_cfg_surf_fragment)
-        base_policy_cfg_surf["agent_id"] = AGENT_ID
-        motor_system_surf = MotorSystem(policy=BasePolicy(**base_policy_cfg_surf))
+        base_policy: BasePolicy = hydra.utils.instantiate(self.policy_cfg_surf_fragment)
+        base_policy.agent_id = AGENT_ID
+        motor_system_surf = MotorSystem(policy=base_policy)
 
         env_init_args = {"agents": self.camera_surf_config}
         env = HabitatEnvironment(**env_init_args)

--- a/tests/unit/policy_test.py
+++ b/tests/unit/policy_test.py
@@ -11,6 +11,9 @@
 import pytest
 
 from tbp.monty.context import RuntimeContext
+from tbp.monty.frameworks.models.motor_policies import (
+    SurfacePolicyCurvatureInformed,
+)
 from tests import HYDRA_ROOT
 
 pytest.importorskip(
@@ -277,7 +280,7 @@ class PolicyTest(unittest.TestCase):
 
             target_closest_point = config["monty_config"]["motor_system_config"][
                 "motor_system_args"
-            ]["policy_args"]["desired_object_distance"]
+            ]["policy"]["desired_object_distance"]
 
             # Utility policy should not have moved too close to the object
             assert closest_point_on_target_obj > target_closest_point, (
@@ -594,10 +597,10 @@ class PolicyTest(unittest.TestCase):
         hypothetical outputs from the motor-system.
         """
         motor_system_cfg = hydra.utils.instantiate(self.motor_system_cfg_fragment)
-        policy_class = motor_system_cfg["motor_system_args"]["policy_class"]
-        policy_args = motor_system_cfg["motor_system_args"]["policy_args"]
-        policy_args["max_pc_bias_steps"] = 2
-        policy = policy_class(**policy_args)
+        policy: SurfacePolicyCurvatureInformed = motor_system_cfg["motor_system_args"][
+            "policy"
+        ]
+        policy.max_pc_bias_steps = 2
         policy.pre_episode()
 
         rng = np.random.RandomState(123)
@@ -695,7 +698,9 @@ class PolicyTest(unittest.TestCase):
         # the same); note the agent is still orthogonal to the PC directions.
 
         # Update relevant motor-system variables
-        policy.ignoring_pc_counter = policy_args["min_general_steps"]
+        policy.ignoring_pc_counter = self.motor_system_cfg_fragment[
+            "motor_system_args"
+        ]["policy"]["min_general_steps"]
         proprioceptive_state[AgentID("agent_id_0")].rotation = qt.quaternion(0, 0, 1, 0)
 
         policy.processed_observations = self.fake_obs_pc[5]
@@ -713,12 +718,13 @@ class PolicyTest(unittest.TestCase):
         """
         motor_system_cfg = hydra.utils.instantiate(self.motor_system_cfg_fragment)
 
-        policy_class = motor_system_cfg["motor_system_args"]["policy_class"]
-        policy_args = motor_system_cfg["motor_system_args"]["policy_args"]
         # Overwrite min_general_steps default value so that we more quickly transition
         # into taking PC steps when testing this
-        policy_args["min_general_steps"] = 1
-        policy = policy_class(**policy_args)
+        policy: SurfacePolicyCurvatureInformed = motor_system_cfg["motor_system_args"][
+            "policy"
+        ]
+        initial_min_general_steps = 1
+        policy.min_general_steps = initial_min_general_steps
         policy.pre_episode()
 
         rng = np.random.RandomState(123)
@@ -799,7 +805,7 @@ class PolicyTest(unittest.TestCase):
         assert np.isclose(direction[2], 0), (
             "Direction should be in the x-y plane (relative to the agent)"
         )
-        assert policy.ignoring_pc_counter == policy_args["min_general_steps"], (
+        assert policy.ignoring_pc_counter == initial_min_general_steps, (
             "Shouldn't increment ignoring_pc_counter"
         )
         assert policy.following_pc_counter == 2, (
@@ -936,10 +942,7 @@ class PolicyTest(unittest.TestCase):
         motor_system_cfg = hydra.utils.instantiate(self.motor_system_cfg_fragment)
         motor_system_class = motor_system_cfg["motor_system_class"]
         motor_system_args = motor_system_cfg["motor_system_args"]
-        policy_class = motor_system_args["policy_class"]
-        policy_args = motor_system_args["policy_args"]
-        policy = policy_class(**policy_args)
-        motor_system = motor_system_class(policy=policy)
+        motor_system = motor_system_class(**motor_system_args)
         motor_system.pre_episode()
 
         # The target displacement of the agent from the object; used to determine

--- a/tests/unit/run_parallel_test.py
+++ b/tests/unit/run_parallel_test.py
@@ -43,7 +43,7 @@ class RunParallelTest(unittest.TestCase):
                 "num_parallel=1",
                 f"++experiment.config.logging.output_dir={output_dir}",
                 "+experiment.config.monty_config.motor_system_config"
-                ".motor_system_args.policy_args.file_name="
+                ".motor_system_args.policy.file_name="
                 f"{Path(__file__).parent / 'resources/fixed_test_actions.jsonl'}",
             ]
             if model_name_or_path:


### PR DESCRIPTION
Continuing to refactor away from the `*_class`, `*_args` pattern, changes MotorPolicy to be directly instantiated by Hydra from the config.