### PR TITLE
chore: add num_episodes in benchmarks

### DIFF
--- a/benchmarks/logos_on_objects.csv
+++ b/benchmarks/logos_on_objects.csv
@@ -1,4 +1,4 @@
-Experiment,Correct Child or Parent (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Avg Prediction Error|align right,Run Time (mins)|align right,Num Episodes|hidden,
+Experiment,Correct Child or Parent (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Avg Prediction Error|align right,Run Time (mins)|align right,Num Episodes|hidden
 infer_comp_lvl1_with_monolithic_models,61.90,53.57,320,68.97,0.37,26,84
 infer_comp_lvl1_with_comp_models,82.14,40.48,44,24.11,0.33,4,84
 infer_comp_lvl2_with_comp_models,76.67,43.33,36,50.76,0.34,14,210

--- a/benchmarks/logos_on_objects.csv
+++ b/benchmarks/logos_on_objects.csv
@@ -1,6 +1,6 @@
-Experiment,Correct Child or Parent (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Avg Prediction Error|align right,Run Time (mins)|align right,Num Episodes|hidden
-infer_comp_lvl1_with_monolithic_models,61.90,53.57,320,68.97,0.37,26,0
-infer_comp_lvl1_with_comp_models,82.14,40.48,44,24.11,0.33,4,0
-infer_comp_lvl2_with_comp_models,76.67,43.33,36,50.76,0.34,14,0
-infer_comp_lvl3_with_comp_models,59.14,55.14,37,42.04,0.34,15,0
-infer_comp_lvl4_with_comp_models,56.32,57.97,32,38.72,0.34,15,0
+Experiment,Correct Child or Parent (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Avg Prediction Error|align right,Run Time (mins)|align right,Num Episodes|hidden,
+infer_comp_lvl1_with_monolithic_models,61.9,53.57,320,68.97,0.37,26,84
+infer_comp_lvl1_with_comp_models,82.14,40.48,44,24.11,0.33,4,84
+infer_comp_lvl2_with_comp_models,76.67,43.33,36,50.76,0.34,14,210
+infer_comp_lvl3_with_comp_models,59.14,55.14,37,42.04,0.34,15,350
+infer_comp_lvl4_with_comp_models,56.32,57.97,32,38.72,0.34,15,364

--- a/benchmarks/logos_on_objects.csv
+++ b/benchmarks/logos_on_objects.csv
@@ -1,5 +1,5 @@
 Experiment,Correct Child or Parent (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Avg Prediction Error|align right,Run Time (mins)|align right,Num Episodes|hidden,
-infer_comp_lvl1_with_monolithic_models,61.9,53.57,320,68.97,0.37,26,84
+infer_comp_lvl1_with_monolithic_models,61.90,53.57,320,68.97,0.37,26,84
 infer_comp_lvl1_with_comp_models,82.14,40.48,44,24.11,0.33,4,84
 infer_comp_lvl2_with_comp_models,76.67,43.33,36,50.76,0.34,14,210
 infer_comp_lvl3_with_comp_models,59.14,55.14,37,42.04,0.34,15,350

--- a/benchmarks/montymeetsworld.csv
+++ b/benchmarks/montymeetsworld.csv
@@ -1,7 +1,7 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden,
 randrot_noise_sim_on_scan_monty_world,89.17,88.33,445,47,23,120
 world_image_on_scanned_model,68.75,70.83,415,12,14,48
-dark_world_image_on_scanned_model,25,14.58,235,8,9,48
+dark_world_image_on_scanned_model,25.00,14.58,235,8,9,48
 bright_world_image_on_scanned_model,39.58,66.67,414,12,14,48
-hand_intrusion_world_image_on_scanned_model,37.5,25,284,10,12,48
-multi_object_world_image_on_scanned_model,22.92,0,157,6,7,48
+hand_intrusion_world_image_on_scanned_model,37.50,25.00,284,10,12,48
+multi_object_world_image_on_scanned_model,22.92,0.00,157,6,7,48

--- a/benchmarks/montymeetsworld.csv
+++ b/benchmarks/montymeetsworld.csv
@@ -1,4 +1,4 @@
-Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden,
+Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
 randrot_noise_sim_on_scan_monty_world,89.17,88.33,445,47,23,120
 world_image_on_scanned_model,68.75,70.83,415,12,14,48
 dark_world_image_on_scanned_model,25.00,14.58,235,8,9,48

--- a/benchmarks/montymeetsworld.csv
+++ b/benchmarks/montymeetsworld.csv
@@ -1,7 +1,7 @@
-Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-randrot_noise_sim_on_scan_monty_world,89.17,88.33,445,47,23,0
-world_image_on_scanned_model,68.75,70.83,415,12,14,0
-dark_world_image_on_scanned_model,25.00,14.58,235,8,9,0
-bright_world_image_on_scanned_model,39.58,66.67,414,12,14,0
-hand_intrusion_world_image_on_scanned_model,37.50,25.00,284,10,12,0
-multi_object_world_image_on_scanned_model,22.92,0.00,157,6,7,0
+Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden,
+randrot_noise_sim_on_scan_monty_world,89.17,88.33,445,47,23,120
+world_image_on_scanned_model,68.75,70.83,415,12,14,48
+dark_world_image_on_scanned_model,25,14.58,235,8,9,48
+bright_world_image_on_scanned_model,39.58,66.67,414,12,14,48
+hand_intrusion_world_image_on_scanned_model,37.5,25,284,10,12,48
+multi_object_world_image_on_scanned_model,22.92,0,157,6,7,48

--- a/benchmarks/ycb_10objs.csv
+++ b/benchmarks/ycb_10objs.csv
@@ -1,13 +1,13 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-base_config_10distinctobj_dist_agent,100.00,2.86,34,8.64,3,8,0
-base_config_10distinctobj_surf_agent,100.00,0.00,28,3.87,3,12,0
-randrot_noise_10distinctobj_dist_agent,100.00,2.00,35,13.23,3,13,0
-randrot_noise_10distinctobj_dist_on_distm,100.00,3.00,31,15.42,3,13,0
-randrot_noise_10distinctobj_surf_agent,100.00,0.00,29,10.37,3,23,0
-randrot_10distinctobj_surf_agent,100.00,0.00,29,5.16,2,11,0
-randrot_noise_10distinctobj_5lms_dist_agent,100.00,1.00,50,56.65,6,37,0
-base_10simobj_surf_agent,98.57,4.29,53,3.53,5,23,0
-randrot_noise_10simobj_dist_agent,88.00,32.00,202,30.30,12,81,0
-randrot_noise_10simobj_surf_agent,97.00,28.00,157,18.01,18,146,0
-randomrot_rawnoise_10distinctobj_surf_agent,72.00,68.00,14,103.01,5,7,0
+base_config_10distinctobj_dist_agent,100,2.86,34,8.64,3,8,140
+base_config_10distinctobj_surf_agent,100,0,28,3.87,3,12,140
+randrot_noise_10distinctobj_dist_agent,100,2,35,13.23,3,13,100
+randrot_noise_10distinctobj_dist_on_distm,100,3,31,15.42,3,13,100
+randrot_noise_10distinctobj_surf_agent,100,0,29,10.37,3,23,100
+randrot_10distinctobj_surf_agent,100,0,29,5.16,2,11,100
+randrot_noise_10distinctobj_5lms_dist_agent,100,1,50,56.65,6,37,100
+base_10simobj_surf_agent,98.57,4.29,53,3.53,5,23,100
+randrot_noise_10simobj_dist_agent,88,32,202,30.3,12,81,100
+randrot_noise_10simobj_surf_agent,97,28,157,18.01,18,146,100
+randomrot_rawnoise_10distinctobj_surf_agent,72,68,14,103.01,5,7,100
 base_10multi_distinctobj_dist_agent,47.14,4.29,33,18.42,40,2,140

--- a/benchmarks/ycb_10objs.csv
+++ b/benchmarks/ycb_10objs.csv
@@ -1,13 +1,13 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-base_config_10distinctobj_dist_agent,100,2.86,34,8.64,3,8,140
-base_config_10distinctobj_surf_agent,100,0,28,3.87,3,12,140
-randrot_noise_10distinctobj_dist_agent,100,2,35,13.23,3,13,100
-randrot_noise_10distinctobj_dist_on_distm,100,3,31,15.42,3,13,100
-randrot_noise_10distinctobj_surf_agent,100,0,29,10.37,3,23,100
-randrot_10distinctobj_surf_agent,100,0,29,5.16,2,11,100
-randrot_noise_10distinctobj_5lms_dist_agent,100,1,50,56.65,6,37,100
+base_config_10distinctobj_dist_agent,100.00,2.86,34,8.64,3,8,140
+base_config_10distinctobj_surf_agent,100.00,0.00,28,3.87,3,12,140
+randrot_noise_10distinctobj_dist_agent,100.00,2.00,35,13.23,3,13,100
+randrot_noise_10distinctobj_dist_on_distm,100.00,3.00,31,15.42,3,13,100
+randrot_noise_10distinctobj_surf_agent,100.00,0.00,29,10.37,3,23,100
+randrot_10distinctobj_surf_agent,100.00,0.00,29,5.16,2,11,100
+randrot_noise_10distinctobj_5lms_dist_agent,100.00,1.00,50,56.65,6,37,100
 base_10simobj_surf_agent,98.57,4.29,53,3.53,5,23,100
-randrot_noise_10simobj_dist_agent,88,32,202,30.3,12,81,100
-randrot_noise_10simobj_surf_agent,97,28,157,18.01,18,146,100
-randomrot_rawnoise_10distinctobj_surf_agent,72,68,14,103.01,5,7,100
+randrot_noise_10simobj_dist_agent,88.00,32.00,202,30.3,12,81,100
+randrot_noise_10simobj_surf_agent,97.00,28.00,157,18.01,18,146,100
+randomrot_rawnoise_10distinctobj_surf_agent,72.00,68.00,14,103.01,5,7,100
 base_10multi_distinctobj_dist_agent,47.14,4.29,33,18.42,40,2,140

--- a/benchmarks/ycb_77objs.csv
+++ b/benchmarks/ycb_77objs.csv
@@ -1,4 +1,4 @@
-Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden,
+Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
 base_77obj_dist_agent,93.94,10.39,78,11.10,15,40,231
 base_77obj_surf_agent,100.00,4.33,45,4.08,13,30,231
 randrot_noise_77obj_dist_agent,88.74,17.75,120,33.03,30,86,231

--- a/benchmarks/ycb_77objs.csv
+++ b/benchmarks/ycb_77objs.csv
@@ -1,6 +1,6 @@
-Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-base_77obj_dist_agent,93.94,10.39,78,11.10,15,40,0
-base_77obj_surf_agent,100.00,4.33,45,4.08,13,30,0
-randrot_noise_77obj_dist_agent,88.74,17.75,120,33.03,30,86,0
-randrot_noise_77obj_surf_agent,99.57,20.35,109,23.73,40,127,0
-randrot_noise_77obj_5lms_dist_agent,96.10,1.3,68,57.04,16,145,0
+Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden,
+base_77obj_dist_agent,93.94,10.39,78,11.1,15,40,231
+base_77obj_surf_agent,100,4.33,45,4.08,13,30,231
+randrot_noise_77obj_dist_agent,88.74,17.75,120,33.03,30,86,231
+randrot_noise_77obj_surf_agent,99.57,20.35,109,23.73,40,127,231
+randrot_noise_77obj_5lms_dist_agent,96.1,1.3,68,57.04,16,145,77

--- a/benchmarks/ycb_77objs.csv
+++ b/benchmarks/ycb_77objs.csv
@@ -1,6 +1,6 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden,
-base_77obj_dist_agent,93.94,10.39,78,11.1,15,40,231
-base_77obj_surf_agent,100,4.33,45,4.08,13,30,231
+base_77obj_dist_agent,93.94,10.39,78,11.10,15,40,231
+base_77obj_surf_agent,100.00,4.33,45,4.08,13,30,231
 randrot_noise_77obj_dist_agent,88.74,17.75,120,33.03,30,86,231
 randrot_noise_77obj_surf_agent,99.57,20.35,109,23.73,40,127,231
-randrot_noise_77obj_5lms_dist_agent,96.1,1.3,68,57.04,16,145,77
+randrot_noise_77obj_5lms_dist_agent,96.10,1.3,68,57.04,16,145,77

--- a/benchmarks/ycb_unsupervised.csv
+++ b/benchmarks/ycb_unsupervised.csv
@@ -1,4 +1,4 @@
 Experiment, Correct - 1st Epoch(%)|align right, Correct - >1st Epoch (%)|align right, Mean Objects per Graph|align right, Mean Graphs per Object|align right, Run Time (mins)|align right, Episode Run Time (s)|align right, Num Episodes|hidden
-surf_agent_unsupervised_10distinctobj,80.00,98.89,1.22,1.1,24,14,0
-surf_agent_unsupervised_10distinctobj_noise,80.00,85.56,1.08,1.44,40,24,0
-surf_agent_unsupervised_10simobj,40.00,80.00,2.14,1.5,31,19,0
+surf_agent_unsupervised_10distinctobj,80.00,98.89,1.22,1.1,24,14,100
+surf_agent_unsupervised_10distinctobj_noise,80.00,85.56,1.08,1.44,40,24,100
+surf_agent_unsupervised_10simobj,40.00,80.00,2.14,1.5,31,19,100

--- a/benchmarks/ycb_unsupervised_inference.csv
+++ b/benchmarks/ycb_unsupervised_inference.csv
@@ -1,3 +1,3 @@
 Experiment,Correct (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-unsupervised_inference_distinctobj_dist_agent,97.00,97,18,5,0
-unsupervised_inference_distinctobj_surf_agent,100.00,99,21,10,0
+unsupervised_inference_distinctobj_dist_agent,97,97,18,5,100
+unsupervised_inference_distinctobj_surf_agent,100,99,21,10,100

--- a/benchmarks/ycb_unsupervised_inference.csv
+++ b/benchmarks/ycb_unsupervised_inference.csv
@@ -1,3 +1,3 @@
 Experiment,Correct (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-unsupervised_inference_distinctobj_dist_agent,97,97,18,5,100
-unsupervised_inference_distinctobj_surf_agent,100,99,21,10,100
+unsupervised_inference_distinctobj_dist_agent,97.00,97,18,5,100
+unsupervised_inference_distinctobj_surf_agent,100.00,99,21,10,100


### PR DESCRIPTION
## Notes
- `unsupervised_inference_distinctobj_surf_agent` has match_steps of 98 instead of 99 
- `world_image_on_scanned_model` has several differences
- `bright_world_image_on_scanned_model` has several differences
- `hand_intrusion_world_image_on_scanned_model` has 280 match_steps

I think the rest are same. I didn't change any benchmark numbers, just added num_episodes. 

## Benchmarks Comparison

### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 2.86 | 2.86 | 0 | ⬜ |
| match_steps | 34 | 34 | 0 | ⬜ |
| rotation_error (deg) | 8.64 | 8.64 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 8 | 8 | 0 | ⬜ |
| num_episodes | 0 | 140 | 140 | ✅ |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 3.87 | 3.87 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 12 | 12 | 0 | ⬜ |
| num_episodes | 0 | 140 | 140 | ✅ |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 2 | 2 | 0 | ⬜ |
| match_steps | 35 | 35 | 0 | ⬜ |
| rotation_error (deg) | 13.23 | 13.23 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 13 | 13 | 0 | ⬜ |
| num_episodes | 0 | 100 | 100 | ✅ |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 3 | 3 | 0 | ⬜ |
| match_steps | 31 | 31 | 0 | ⬜ |
| rotation_error (deg) | 15.42 | 15.42 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 13 | 12 | -1 | ✅ |
| num_episodes | 0 | 100 | 100 | ✅ |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 10.37 | 10.37 | 0 | ⬜ |
| runtime (min) | 3 | 4 | 1 | ❌ |
| episode_runtime (sec) | 23 | 24 | 1 | ❌ |
| num_episodes | 0 | 100 | 100 | ✅ |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 5.16 | 5.16 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 11 | 13 | 2 | ❌ |
| num_episodes | 0 | 100 | 100 | ✅ |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 1 | 1 | 0 | ⬜ |
| match_steps | 50 | 50 | 0 | ⬜ |
| rotation_error (deg) | 56.65 | 56.65 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 37 | 33 | -4 | ✅ |
| num_episodes | 0 | 100 | 100 | ✅ |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.57 | 98.57 | 0 | ⬜ |
| used_mlh (%) | 4.29 | 4.29 | 0 | ⬜ |
| match_steps | 53 | 53 | 0 | ⬜ |
| rotation_error (deg) | 3.53 | 3.53 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 23 | 21 | -2 | ✅ |
| num_episodes | 0 | 140 | 140 | ✅ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 88 | 88 | 0 | ⬜ |
| used_mlh (%) | 32 | 32 | 0 | ⬜ |
| match_steps | 202 | 202 | 0 | ⬜ |
| rotation_error (deg) | 30.3 | 30.3 | 0 | ⬜ |
| runtime (min) | 12 | 11 | -1 | ✅ |
| episode_runtime (sec) | 81 | 80 | -1 | ✅ |
| num_episodes | 0 | 100 | 100 | ✅ |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| used_mlh (%) | 28 | 28 | 0 | ⬜ |
| match_steps | 157 | 157 | 0 | ⬜ |
| rotation_error (deg) | 18.01 | 18.01 | 0 | ⬜ |
| runtime (min) | 18 | 19 | 1 | ❌ |
| episode_runtime (sec) | 146 | 151 | 5 | ❌ |
| num_episodes | 0 | 100 | 100 | ✅ |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 72 | 72 | 0 | ⬜ |
| used_mlh (%) | 68 | 68 | 0 | ⬜ |
| match_steps | 14 | 14 | 0 | ⬜ |
| rotation_error (deg) | 103.01 | 103.01 | 0 | ⬜ |
| runtime (min) | 5 | 4 | -1 | ✅ |
| episode_runtime (sec) | 7 | 7 | 0 | ⬜ |
| num_episodes | 0 | 100 | 100 | ✅ |

### base_10multi_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 47.14 | 47.14 | 0 | ⬜ |
| used_mlh (%) | 4.29 | 4.29 | 0 | ⬜ |
| match_steps | 33 | 33 | 0 | ⬜ |
| rotation_error (deg) | 18.42 | 18.42 | 0 | ⬜ |
| runtime (min) | 40 | 38 | -2 | ✅ |
| episode_runtime (sec) | 2 | 2 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 93.94 | 93.94 | 0 | ⬜ |
| used_mlh (%) | 10.39 | 10.39 | 0 | ⬜ |
| match_steps | 78 | 78 | 0 | ⬜ |
| rotation_error (deg) | 11.1 | 11.1 | 0 | ⬜ |
| runtime (min) | 15 | 16 | 1 | ❌ |
| episode_runtime (sec) | 40 | 44 | 4 | ❌ |
| num_episodes | 0 | 231 | 231 | ✅ |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 4.33 | 4.33 | 0 | ⬜ |
| match_steps | 45 | 45 | 0 | ⬜ |
| rotation_error (deg) | 4.08 | 4.08 | 0 | ⬜ |
| runtime (min) | 13 | 13 | 0 | ⬜ |
| episode_runtime (sec) | 30 | 31 | 1 | ❌ |
| num_episodes | 0 | 231 | 231 | ✅ |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 88.74 | 88.74 | 0 | ⬜ |
| used_mlh (%) | 17.75 | 17.75 | 0 | ⬜ |
| match_steps | 120 | 120 | 0 | ⬜ |
| rotation_error (deg) | 33.03 | 33.03 | 0 | ⬜ |
| runtime (min) | 30 | 32 | 2 | ❌ |
| episode_runtime (sec) | 86 | 93 | 7 | ❌ |
| num_episodes | 0 | 231 | 231 | ✅ |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99.57 | 99.57 | 0 | ⬜ |
| used_mlh (%) | 20.35 | 20.35 | 0 | ⬜ |
| match_steps | 109 | 109 | 0 | ⬜ |
| rotation_error (deg) | 23.73 | 23.73 | 0 | ⬜ |
| runtime (min) | 40 | 37 | -3 | ✅ |
| episode_runtime (sec) | 127 | 121 | -6 | ✅ |
| num_episodes | 0 | 231 | 231 | ✅ |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96.1 | 96.1 | 0 | ⬜ |
| used_mlh (%) | 1.3 | 1.3 | 0 | ⬜ |
| match_steps | 68 | 68 | 0 | ⬜ |
| rotation_error (deg) | 57.04 | 57.04 | 0 | ⬜ |
| runtime (min) | 16 | 17 | 1 | ❌ |
| episode_runtime (sec) | 145 | 148 | 3 | ❌ |
| num_episodes | 0 | 77 | 77 | ✅ |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| match_steps | 97 | 97 | 0 | ⬜ |
| runtime (min) | 18 | 14 | -4 | ✅ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |
| num_episodes | 0 | 100 | 100 | ✅ |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| match_steps | 99 | 98 | -1 | ✅ |
| runtime (min) | 21 | 27 | 6 | ❌ |
| episode_runtime (sec) | 10 | 12 | 2 | ❌ |
| num_episodes | 0 | 100 | 100 | ✅ |

### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 89.17 | 89.17 | 0 | ⬜ |
| used_mlh (%) | 88.33 | 88.33 | 0 | ⬜ |
| match_steps | 445 | 445 | 0 | ⬜ |
| runtime (min) | 47 | 53 | 6 | ❌ |
| episode_runtime (sec) | 23 | 26 | 3 | ❌ |
| num_episodes | 0 | 120 | 120 | ✅ |

### world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 68.75 | 66.67 | -2.08 | ❌ |
| used_mlh (%) | 70.83 | 68.75 | -2.08 | ✅ |
| match_steps | 415 | 401 | -14 | ✅ |
| runtime (min) | 12 | 11 | -1 | ✅ |
| episode_runtime (sec) | 14 | 12 | -2 | ✅ |
| num_episodes | 0 | 48 | 48 | ✅ |

### dark_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 25 | 25 | 0 | ⬜ |
| used_mlh (%) | 14.58 | 14.58 | 0 | ⬜ |
| match_steps | 235 | 235 | 0 | ⬜ |
| runtime (min) | 8 | 9 | 1 | ❌ |
| episode_runtime (sec) | 9 | 10 | 1 | ❌ |
| num_episodes | 0 | 48 | 48 | ✅ |

### bright_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 39.58 | 39.58 | 0 | ⬜ |
| used_mlh (%) | 66.67 | 64.58 | -2.09 | ✅ |
| match_steps | 414 | 400 | -14 | ✅ |
| runtime (min) | 12 | 11 | -1 | ✅ |
| episode_runtime (sec) | 14 | 13 | -1 | ✅ |
| num_episodes | 0 | 48 | 48 | ✅ |

### hand_intrusion_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 37.5 | 37.5 | 0 | ⬜ |
| used_mlh (%) | 25 | 25 | 0 | ⬜ |
| match_steps | 284 | 280 | -4 | ✅ |
| runtime (min) | 10 | 11 | 1 | ❌ |
| episode_runtime (sec) | 12 | 12 | 0 | ⬜ |
| num_episodes | 0 | 48 | 48 | ✅ |

### multi_object_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 22.92 | 22.92 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 157 | 157 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 6 | -1 | ✅ |
| num_episodes | 0 | 48 | 48 | ✅ |

### infer_comp_lvl1_with_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 61.9 | 61.9 | 0 | ⬜ |
| used_mlh (%) | 53.57 | 53.57 | 0 | ⬜ |
| match_steps | 320 | 320 | 0 | ⬜ |
| rotation_error (deg) | 68.97 | 68.97 | 0 | ⬜ |
| avg_prediction_error | 0.37 | 0.37 | 0 | ⬜ |
| runtime (min) | 26 | 31 | 5 | ❌ |
| num_episodes | 0 | 84 | 84 | ✅ |

### infer_comp_lvl1_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 82.14 | 82.14 | 0 | ⬜ |
| used_mlh (%) | 40.48 | 40.48 | 0 | ⬜ |
| match_steps | 44 | 44 | 0 | ⬜ |
| rotation_error (deg) | 24.11 | 24.11 | 0 | ⬜ |
| avg_prediction_error | 0.33 | 0.33 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| num_episodes | 0 | 84 | 84 | ✅ |

### infer_comp_lvl2_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 76.67 | 76.67 | 0 | ⬜ |
| used_mlh (%) | 43.33 | 43.33 | 0 | ⬜ |
| match_steps | 36 | 36 | 0 | ⬜ |
| rotation_error (deg) | 50.76 | 50.76 | 0 | ⬜ |
| avg_prediction_error | 0.34 | 0.34 | 0 | ⬜ |
| runtime (min) | 14 | 14 | 0 | ⬜ |
| num_episodes | 0 | 210 | 210 | ✅ |

### infer_comp_lvl3_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 59.14 | 59.14 | 0 | ⬜ |
| used_mlh (%) | 55.14 | 55.14 | 0 | ⬜ |
| match_steps | 37 | 37 | 0 | ⬜ |
| rotation_error (deg) | 42.04 | 42.04 | 0 | ⬜ |
| avg_prediction_error | 0.34 | 0.34 | 0 | ⬜ |
| runtime (min) | 15 | 17 | 2 | ❌ |
| num_episodes | 0 | 350 | 350 | ✅ |

### infer_comp_lvl4_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 56.32 | 56.32 | 0 | ⬜ |
| used_mlh (%) | 57.97 | 57.97 | 0 | ⬜ |
| match_steps | 32 | 32 | 0 | ⬜ |
| rotation_error (deg) | 38.72 | 38.72 | 0 | ⬜ |
| avg_prediction_error | 0.34 | 0.34 | 0 | ⬜ |
| runtime (min) | 15 | 16 | 1 | ❌ |
| num_episodes | 0 | 364 | 364 | ✅ |
