### PR TITLE
fix: Cast object positions to magnum.Vector3 in Habitat simulator

### DIFF
--- a/src/tbp/monty/simulators/habitat/simulator.py
+++ b/src/tbp/monty/simulators/habitat/simulator.py
@@ -272,7 +272,7 @@ class HabitatSim(HabitatActuator, Simulator):
         obj = rigid_mgr.add_object_by_template_handle(obj_handle)
 
         # Update pose
-        obj.translation = position
+        obj.translation = mn.Vector3d(position)
         if isinstance(rotation, (list, tuple)):
             rotation = qt.quaternion(*rotation)
         obj.rotation = sim_utils.quat_to_magnum(rotation)


### PR DESCRIPTION
This PR fixes a bug in the habitat simulator when defining object positions.

Normally, we don't specify object positions in our configs w/ the Predefined object initializer, and the default arguments work fine. But if we do try to specify positions (which should be allowed), we get the following error:
```
File "/Users/scott/tbp/tbp.monty/src/tbp/monty/simulators/habitat/simulator.py", line 276, in add_object
    obj.translation = position
TypeError: (): incompatible function arguments. The following argument types are supported:
    1. (arg0: habitat_sim._ext.habitat_sim_bindings.ManagedRigidObject_PhysicsObjectWrapper, arg1: _magnum.Vector3) -> None

Invoked with: <habitat_sim._ext.habitat_sim_bindings.ManagedBulletRigidObject object at 0x199c58d70>, [0, 1.5, -0.1]
```
This PR is a one-line fix that converts the position to a `magnum.Vector3` object before setting the object translation.

Apparently we don't test for using non-default object positions for the habitat simulator.

Benchmarks Unchanged:

### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 2.86 | 2.86 | 0 | ⬜ |
| match_steps | 34 | 34 | 0 | ⬜ |
| rotation_error (deg) | 8.64 | 8.64 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 8 | 8 | 0 | ⬜ |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 3.87 | 3.87 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 11 | 11 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 2 | 2 | 0 | ⬜ |
| match_steps | 35 | 35 | 0 | ⬜ |
| rotation_error (deg) | 13.23 | 13.23 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 13 | 14 | 1 | ❌ |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 3 | 3 | 0 | ⬜ |
| match_steps | 31 | 31 | 0 | ⬜ |
| rotation_error (deg) | 15.42 | 15.42 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 12 | 12 | 0 | ⬜ |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 10.37 | 10.37 | 0 | ⬜ |
| runtime (min) | 3 | 4 | 1 | ❌ |
| episode_runtime (sec) | 23 | 25 | 2 | ❌ |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 5.16 | 5.16 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 13 | 13 | 0 | ⬜ |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 1 | 1 | 0 | ⬜ |
| match_steps | 50 | 50 | 0 | ⬜ |
| rotation_error (deg) | 56.65 | 56.65 | 0 | ⬜ |
| runtime (min) | 5 | 6 | 1 | ❌ |
| episode_runtime (sec) | 33 | 37 | 4 | ❌ |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.57 | 98.57 | 0 | ⬜ |
| used_mlh (%) | 4.29 | 4.29 | 0 | ⬜ |
| match_steps | 53 | 53 | 0 | ⬜ |
| rotation_error (deg) | 3.53 | 3.53 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 22 | 23 | 1 | ❌ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 88 | 88 | 0 | ⬜ |
| used_mlh (%) | 32 | 32 | 0 | ⬜ |
| match_steps | 202 | 202 | 0 | ⬜ |
| rotation_error (deg) | 30.3 | 30.3 | 0 | ⬜ |
| runtime (min) | 10 | 9 | -1 | ✅ |
| episode_runtime (sec) | 72 | 68 | -4 | ✅ |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| used_mlh (%) | 28 | 28 | 0 | ⬜ |
| match_steps | 157 | 157 | 0 | ⬜ |
| rotation_error (deg) | 18.01 | 18.01 | 0 | ⬜ |
| runtime (min) | 18 | 16 | -2 | ✅ |
| episode_runtime (sec) | 153 | 135 | -18 | ✅ |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 67 | 67 | 0 | ⬜ |
| used_mlh (%) | 75 | 75 | 0 | ⬜ |
| match_steps | 13 | 13 | 0 | ⬜ |
| rotation_error (deg) | 105.66 | 105.66 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 7 | 0 | ⬜ |

### base_10multi_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 47.14 | 47.14 | 0 | ⬜ |
| used_mlh (%) | 4.29 | 4.29 | 0 | ⬜ |
| match_steps | 33 | 33 | 0 | ⬜ |
| rotation_error (deg) | 18.42 | 18.42 | 0 | ⬜ |
| runtime (min) | 37 | 38 | 1 | ❌ |
| episode_runtime (sec) | 2 | 2 | 0 | ⬜ |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 93.94 | 93.94 | 0 | ⬜ |
| used_mlh (%) | 10.39 | 10.39 | 0 | ⬜ |
| match_steps | 78 | 78 | 0 | ⬜ |
| rotation_error (deg) | 11.1 | 11.1 | 0 | ⬜ |
| runtime (min) | 14 | 17 | 3 | ❌ |
| episode_runtime (sec) | 39 | 45 | 6 | ❌ |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 4.33 | 4.33 | 0 | ⬜ |
| match_steps | 45 | 45 | 0 | ⬜ |
| rotation_error (deg) | 4.08 | 4.08 | 0 | ⬜ |
| runtime (min) | 12 | 13 | 1 | ❌ |
| episode_runtime (sec) | 29 | 32 | 3 | ❌ |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 88.74 | 88.74 | 0 | ⬜ |
| used_mlh (%) | 17.75 | 17.75 | 0 | ⬜ |
| match_steps | 120 | 120 | 0 | ⬜ |
| rotation_error (deg) | 33.03 | 33.03 | 0 | ⬜ |
| runtime (min) | 30 | 32 | 2 | ❌ |
| episode_runtime (sec) | 87 | 93 | 6 | ❌ |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99.57 | 99.57 | 0 | ⬜ |
| used_mlh (%) | 20.35 | 20.35 | 0 | ⬜ |
| match_steps | 109 | 109 | 0 | ⬜ |
| rotation_error (deg) | 23.73 | 23.73 | 0 | ⬜ |
| runtime (min) | 34 | 36 | 2 | ❌ |
| episode_runtime (sec) | 110 | 114 | 4 | ❌ |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96.1 | 96.1 | 0 | ⬜ |
| used_mlh (%) | 1.3 | 1.3 | 0 | ⬜ |
| match_steps | 68 | 68 | 0 | ⬜ |
| rotation_error (deg) | 57.04 | 57.04 | 0 | ⬜ |
| runtime (min) | 15 | 17 | 2 | ❌ |
| episode_runtime (sec) | 138 | 154 | 16 | ❌ |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| match_steps | 97 | 97 | 0 | ⬜ |
| runtime (min) | 12 | 13 | 1 | ❌ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 25 | 27 | 2 | ❌ |
| episode_runtime (sec) | 12 | 12 | 0 | ⬜ |

### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | — | — | — | — |
| used_mlh (%) | — | — | — | — |
| match_steps | — | — | — | — |
| runtime (min) | — | — | — | — |
| episode_runtime (sec) | — | — | — | — |

### world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | — | — | — | — |
| used_mlh (%) | — | — | — | — |
| match_steps | — | — | — | — |
| runtime (min) | — | — | — | — |
| episode_runtime (sec) | — | — | — | — |

### dark_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | — | — | — | — |
| used_mlh (%) | — | — | — | — |
| match_steps | — | — | — | — |
| runtime (min) | — | — | — | — |
| episode_runtime (sec) | — | — | — | — |

### bright_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | — | — | — | — |
| used_mlh (%) | — | — | — | — |
| match_steps | — | — | — | — |
| runtime (min) | — | — | — | — |
| episode_runtime (sec) | — | — | — | — |

### hand_intrusion_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | — | — | — | — |
| used_mlh (%) | — | — | — | — |
| match_steps | — | — | — | — |
| runtime (min) | — | — | — | — |
| episode_runtime (sec) | — | — | — | — |

### multi_object_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | — | — | — | — |
| used_mlh (%) | — | — | — | — |
| match_steps | — | — | — | — |
| runtime (min) | — | — | — | — |
| episode_runtime (sec) | — | — | — | — |

### infer_comp_lvl1_with_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 89.29 | 89.29 | 0 | ⬜ |
| used_mlh (%) | 84.52 | 84.52 | 0 | ⬜ |
| match_steps | 415 | 415 | 0 | ⬜ |
| rotation_error (deg) | 56.28 | 56.28 | 0 | ⬜ |
| avg_prediction_error | 0.35 | 0.35 | 0 | ⬜ |
| runtime (min) | 35 | 32 | -3 | ✅ |

### infer_comp_lvl1_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 85.71 | 85.71 | 0 | ⬜ |
| used_mlh (%) | 35.71 | 35.71 | 0 | ⬜ |
| match_steps | 35 | 35 | 0 | ⬜ |
| rotation_error (deg) | 51.47 | 51.47 | 0 | ⬜ |
| avg_prediction_error | 0.34 | 0.34 | 0 | ⬜ |
| runtime (min) | 4 | 3 | -1 | ✅ |

### infer_comp_lvl2_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 85.71 | 85.71 | 0 | ⬜ |
| used_mlh (%) | 35.71 | 35.71 | 0 | ⬜ |
| match_steps | 40 | 40 | 0 | ⬜ |
| rotation_error (deg) | 53.9 | 53.9 | 0 | ⬜ |
| avg_prediction_error | 0.33 | 0.33 | 0 | ⬜ |
| runtime (min) | 11 | 12 | 1 | ❌ |

### infer_comp_lvl3_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 64 | 64 | 0 | ⬜ |
| used_mlh (%) | 52.86 | 52.86 | 0 | ⬜ |
| match_steps | 34 | 34 | 0 | ⬜ |
| rotation_error (deg) | 50.29 | 50.29 | 0 | ⬜ |
| avg_prediction_error | 0.34 | 0.34 | 0 | ⬜ |
| runtime (min) | 16 | 15 | -1 | ✅ |

### infer_comp_lvl4_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | — | — | — | — |
| used_mlh (%) | — | — | — | — |
| match_steps | — | — | — | — |
| rotation_error (deg) | — | — | — | — |
| avg_prediction_error | — | — | — | — |
| runtime (min) | — | — | — | — |
