### PR TITLE
fix: live plotter search for agent_id in observations

### DIFF
--- a/src/tbp/monty/frameworks/utils/live_plotter.py
+++ b/src/tbp/monty/frameworks/utils/live_plotter.py
@@ -6,10 +6,14 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
+from __future__ import annotations
 
 import matplotlib.pyplot as plt
 import numpy as np
 
+from tbp.monty.frameworks.agents import AgentID
+from tbp.monty.frameworks.models.abstract_monty_classes import Monty, Observations
+from tbp.monty.frameworks.sensors import SensorID
 from tbp.monty.frameworks.utils.plot_utils import add_patch_outline_to_view_finder
 
 # turn interactive plotting off -- call plt.show() to open all figures
@@ -41,7 +45,7 @@ class LivePlotter:
         self.setup_sensor_ax()
         self.setup_mlh_ax()
 
-    def hardcoded_assumptions(self, observation, model):
+    def hardcoded_assumptions(self, observation: Observations, model: Monty):
         """Extract some of the hardcoded assumptions from the observation.
 
         TODO: Don't do this. It is here for now to highlight the fragility of the
@@ -57,15 +61,25 @@ class LivePlotter:
             observations, the patch depth, and the view finder rgba.
         """
         first_learning_module = model.learning_modules[0]
-        first_sensor_module_raw_observations = model.sensor_modules[
-            0
-        ]._snapshot_telemetry.raw_observations
-        first_sensor_module_id = model.sensor_modules[0].sensor_module_id
-        first_sensor_depth = observation[model.motor_system._policy.agent_id][
+        first_sensor_module = model.sensor_modules[0]
+        first_sensor_module_raw_observations = (
+            first_sensor_module._snapshot_telemetry.raw_observations
+        )
+        first_sensor_module_id = first_sensor_module.sensor_module_id
+
+        # Find agent_id corresponding to the first_sensor_module_id
+        first_sensor_module_agent_id: AgentID | None = None
+        for agent_id, agent_observations in observation.items():
+            if first_sensor_module_id in agent_observations:
+                first_sensor_module_agent_id = agent_id
+                break
+        assert first_sensor_module_agent_id is not None
+
+        first_sensor_depth = observation[first_sensor_module_agent_id][
             first_sensor_module_id
         ]["depth"]
-        view_finder_rgba = observation[model.motor_system._policy.agent_id][
-            "view_finder"
+        view_finder_rgba = observation[first_sensor_module_agent_id][
+            SensorID("view_finder")
         ]["rgba"]
         if hasattr(first_learning_module, "get_current_mlh"):
             mlh = first_learning_module.get_current_mlh()


### PR DESCRIPTION
This makes the live plotter display again when `experiment.config.show_sensor_output: true`.