### PR TITLE
test: fix failing test_blur_reduces_tv

### DIFF
--- a/tests/unit/frameworks/environment_utils/transforms_test.py
+++ b/tests/unit/frameworks/environment_utils/transforms_test.py
@@ -239,7 +239,7 @@ class GaussianBlurRGBTest(unittest.TestCase):
             )
 
         input_tv = total_variation(rgba[:, :, :3])
-        assume(input_tv > 0.0) # Exclude solid images
+        assume(input_tv > 0.0)  # Exclude solid images
 
         obs = Observations()
         obs[AGENT_ID] = AgentObservations()

--- a/tests/unit/frameworks/environment_utils/transforms_test.py
+++ b/tests/unit/frameworks/environment_utils/transforms_test.py
@@ -13,7 +13,7 @@ from unittest.mock import Mock
 
 import numpy as np
 import pytest
-from hypothesis import given
+from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 
@@ -233,10 +233,13 @@ class GaussianBlurRGBTest(unittest.TestCase):
         rgba, sigma, kernel_size = params
 
         def total_variation(img):
-            img = img.astype(np.float64)
+            img = img.astype(np.float32)
             return np.sum(np.abs(np.diff(img, axis=0))) + np.sum(
                 np.abs(np.diff(img, axis=1))
             )
+
+        input_tv = total_variation(rgba[:, :, :3])
+        assume(input_tv > 0.0) # Exclude solid images
 
         obs = Observations()
         obs[AGENT_ID] = AgentObservations()
@@ -245,9 +248,6 @@ class GaussianBlurRGBTest(unittest.TestCase):
             agent_id=AGENT_ID, sigma=sigma, kernel_size=kernel_size
         )
         result_rgba = gaussian_smoother(obs, ctx=Mock())[AGENT_ID][SENSOR_ID]["rgba"]
-        result_rgb = result_rgba[:, :, :3]
+        result_tv = total_variation(result_rgba[:, :, :3])
 
-        input_tv = total_variation(rgba[:, :, :3])
-        result_tv = total_variation(result_rgb)
-
-        self.assertTrue(result_tv < input_tv or np.allclose(result_tv, input_tv))
+        self.assertLessEqual(result_tv, input_tv)


### PR DESCRIPTION
This fixes the failing test that @ramyamounir has noticed. 

Reason for failing: 
1. Our input was `np.float64` while `cv2` computes convolution (the Gaussian Blur) in `float32`. It's not really appropriate to upscale the input precision.
2. (Speculative) The `cv2` binaries between macOS and Ubuntu are likely different, hence why it failed on Github Actions and not locally. This may affect floating point error accumulation. 

How I fixed it:
1. The failed cases were all when the input image were solid (i.e. same values). Since this case is already covered by `test_blur_solid_image_returns_identical`, I used `assume` to filter these out. 