### PR TITLE
test!: improved NormalizeTest and ProjectOntoTangentPlane test

### DIFF
--- a/src/tbp/monty/frameworks/utils/spatial_arithmetics.py
+++ b/src/tbp/monty/frameworks/utils/spatial_arithmetics.py
@@ -21,21 +21,24 @@ from scipy.spatial.transform import Rotation
 logger = logging.getLogger(__name__)
 
 
-def normalize(v: ArrayLike, epsilon: float = 1e-12) -> np.ndarray:
+def normalize(v: ArrayLike, epsilon: float = None) -> np.ndarray:
     """Normalize a vector to unit length.
 
     Args:
         v: Input vector to normalize.
         epsilon: Small epsilon value below which the vector is considered zero.
+                Defaults to the smallest normal for the input dtype.
 
     Returns:
-        Unit vector in the direction of v.
+        Unit vector in the direction of v in v's dtype.
 
     Raises:
         ValueError: If the vector has near-zero length (norm < epsilon).
     """
     v = np.asarray(v)
-    n = np.linalg.norm(v)
+    if epsilon is None:
+        epsilon = np.finfo(v.dtype).smallest_normal
+    n = np.linalg.norm(v)  # float64
     if n < epsilon:
         raise ValueError(f"Cannot normalize near-zero vector (norm={n:.2e})")
     return v / n

--- a/tests/unit/frameworks/utils/spatial_arithmetics_test.py
+++ b/tests/unit/frameworks/utils/spatial_arithmetics_test.py
@@ -10,7 +10,7 @@
 import unittest
 
 import numpy as np
-from hypothesis import given
+from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.extra.numpy import arrays
 
@@ -19,59 +19,93 @@ from tbp.monty.frameworks.utils.spatial_arithmetics import (
     project_onto_tangent_plane,
 )
 
-finite_vectors = arrays(
-    dtype=np.float64,
+# Machine Epsilon for values on order of 1
+_FLOAT32_EPS = np.finfo(np.float32).eps  # 1.1920929e-07
+_FLOAT32_TOL = (
+    10 * _FLOAT32_EPS
+)  # give few ULP for slack for accumulated rounding error
+_FLOAT32_NORM_EPSILON = np.finfo(np.float32).smallest_normal  # 1.1754944e-38
+
+float32_array = arrays(
+    dtype=np.float32,
     shape=3,
-    elements=st.floats(min_value=-1e6, max_value=1e6),
-)
-non_zero_magnitude_vectors = finite_vectors.filter(lambda v: np.linalg.norm(v) >= 1e-12)
+    elements=st.floats(min_value=-1e6, max_value=1e6, width=32),
+)  # note to self: was renamed from finite_vectors
+
+# Open to normalizable_vectors for naming (for semantic meaning)
+# nondegenerate is more math-term
+nondegenerate_vectors = float32_array.filter(
+    lambda v: np.linalg.norm(v) >= _FLOAT32_NORM_EPSILON
+)  # note to self: renamed from non_zero_magnitude_vectors
+unit_vectors = nondegenerate_vectors.map(lambda v: normalize(v))
 
 
 @st.composite
-def perpendicular_vectors(draw):
-    random_base = normalize(draw(non_zero_magnitude_vectors))
-    n = normalize(draw(non_zero_magnitude_vectors))
+def nondegenerate_orthogonal_vectors(draw):
+    # Renamed from perpendicular_vectors
+    # Updated to exclude drawing zero vectdor for v because that's always perpendicular to everything
+    # Nondegenerate excludes v = [0.0, 0.0, 0.0]
+    random_base = normalize(draw(nondegenerate_vectors))
+    n = normalize(draw(nondegenerate_vectors))
     v = np.cross(random_base, n)
+    assume(np.linalg.norm(v) >= _FLOAT32_NORM_EPSILON)
+    # using this would result in orthonormal_vectors
+    # separate strategy
+    # v = normalize(v)
     return v, n
 
 
 class NormalizeTest(unittest.TestCase):
-    @given(non_zero_magnitude_vectors)
+    @given(nondegenerate_vectors)
     def test_preserves_direction(self, v):
         norm = np.linalg.norm(v)
         result = normalize(v)
         np.testing.assert_array_almost_equal(result * norm, v)
 
-    @given(non_zero_magnitude_vectors)
+    @given(nondegenerate_vectors)
     def test_idempotent(self, v):
         once = normalize(v)
         twice = normalize(once)
         np.testing.assert_array_almost_equal(twice, once)
 
-    @given(
-        arrays(
-            dtype=np.float64,
-            shape=3,
-            elements=st.floats(min_value=-1e-13, max_value=1e-13),
-        )
-    )
-    def test_near_zero_vector_raises(self, v):
+    # @given(
+    #     arrays(
+    #         dtype=np.float64,
+    #         shape=3,
+    #         elements=st.floats(min_value=-1e-13, max_value=1e-13),
+    #     )
+    # )
+    # def test_near_zero_vector_raises(self, v):
+    #     with self.assertRaises(ValueError):
+    #         normalize(v)
+
+    # The below test replaces the above
+    # Trying to generate near zero in hypothesis is a lost cause
+    # and also assumes things about dtype, hardware, etc.
+    # just testing zero is the right way to go
+    def test_zero_vector_raises(self):
+        zero_float32 = np.zeros(3, dtype=np.float32)
+        zero_float64 = np.zeros(3, dtype=np.float64)
         with self.assertRaises(ValueError):
-            normalize(v)
+            normalize(zero_float32)
+        with self.assertRaises(ValueError):
+            normalize(zero_float64)
 
     @given(
-        epsilon=st.floats(min_value=1e-12, max_value=1e-2),
+        epsilon=st.floats(min_value=_FLOAT32_NORM_EPSILON, max_value=1e-2),
         scale=st.floats(min_value=0.01, max_value=0.99),
     )
-    def test_custom_epsilon(self, epsilon, scale):
-        v = np.array([epsilon * scale, 0.0, 0.0])
+    def test_custom_epsilon_raises_below_threshold(self, epsilon, scale):
+        v = np.array([epsilon * scale, 0.0, 0.0], dtype=np.float32)
         with self.assertRaises(ValueError):
             normalize(v, epsilon=epsilon)
 
-    @given(non_zero_magnitude_vectors)
+    @given(nondegenerate_vectors)
     def test_result_has_unit_norm(self, v):
         result = normalize(v)
-        self.assertAlmostEqual(np.linalg.norm(result), 1.0)
+        np.testing.assert_allclose(
+            np.linalg.norm(result), 1.0, atol=_FLOAT32_TOL, rtol=_FLOAT32_TOL
+        )
 
 
 class ProjectOntoTangentPlaneTest(unittest.TestCase):

--- a/tests/unit/frameworks/utils/spatial_arithmetics_test.py
+++ b/tests/unit/frameworks/utils/spatial_arithmetics_test.py
@@ -110,29 +110,41 @@ class NormalizeTest(unittest.TestCase):
 
 class ProjectOntoTangentPlaneTest(unittest.TestCase):
     @given(
-        a_vector=non_zero_magnitude_vectors,
-        a_scalar=st.floats(
-            min_value=-1e3, max_value=1e3, allow_infinity=False, allow_nan=False
-        ),
+        a_vector=nondegenerate_vectors,
+        a_scalar=st.floats(min_value=-1e3, max_value=1e3, allow_nan=False),
     )
     def test_a_vector_parallel_to_normal(self, a_vector, a_scalar):
         parallel_vector = a_scalar * a_vector
         result = project_onto_tangent_plane(parallel_vector, a_vector)
-        np.testing.assert_array_almost_equal(result, [0.0, 0.0, 0.0])
+        atol = max(
+            _FLOAT32_TOL * np.linalg.norm(parallel_vector) * np.linalg.norm(a_vector),
+            _FLOAT32_TOL,
+        )
+        np.testing.assert_allclose(result, [0.0, 0.0, 0.0], atol=atol, rtol=0)
 
-    @given(perpendicular_vectors())
+    @given(nondegenerate_orthogonal_vectors())
     def test_a_vector_perpendicular_to_normal(self, orthogonal_vectors):
         a_vector, a_normal = orthogonal_vectors
         result = project_onto_tangent_plane(a_vector, a_normal)
-        np.testing.assert_array_almost_equal(result, a_vector)
+        atol = max(_FLOAT32_TOL * np.linalg.norm(a_vector), _FLOAT32_TOL)
+        np.testing.assert_allclose(result, a_vector, atol=atol, rtol=_FLOAT32_TOL)
 
-    @given(a_vector=finite_vectors, a_normal=non_zero_magnitude_vectors)
+    @given(a_vector=float32_array, a_normal=nondegenerate_vectors)
     def test_result_is_orthogonal_to_normal(self, a_vector, a_normal):
         result = project_onto_tangent_plane(a_vector, a_normal)
-        np.testing.assert_array_almost_equal(np.dot(result, normalize(a_normal)), 0.0)
+        atol = max(
+            _FLOAT32_TOL * np.linalg.norm(a_vector),
+            _FLOAT32_TOL,
+        )
+        np.testing.assert_allclose(
+            np.dot(result, normalize(a_normal)), 0.0, atol=atol, rtol=0
+        )
 
-    @given(a_vector=finite_vectors, a_normal=non_zero_magnitude_vectors)
+    @given(a_vector=float32_array, a_normal=nondegenerate_vectors)
     def test_projection_is_idempotent(self, a_vector, a_normal):
         once = project_onto_tangent_plane(a_vector, a_normal)
         twice = project_onto_tangent_plane(once, a_normal)
-        np.testing.assert_array_almost_equal(twice, once)
+        atol = max(
+            _FLOAT32_TOL * np.linalg.norm(once) * np.linalg.norm(a_normal), _FLOAT32_TOL
+        )
+        np.testing.assert_allclose(twice, once, atol=atol, rtol=_FLOAT32_TOL)


### PR DESCRIPTION
After digging into floating point precisions, `hypothesis`, `numpy.testing`, and rtol/atol -- ended up refactoring NormalizeTest and ProjectOntoTangentPlane test. Wasn't intentional but because these two functions are quite load bearing. I was actually trying to add tests for other classes/functions, but fiddling around with tolerances would break these two. 

Attaching the write-up about floating point precision et al. here for others as well. 

Note to self:
1. Small reminder to explain why `project_onto_tangent_plane` is actually quite load bearing (relates to [Gram-Schmidt process](https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process) or making vectors orthogonal). 
2. Strategies for generating orthogonal vectors (taking into account of numerical stability):
- 2D: Use analytical construction
- 3D: cross product
- 4D+: gram-schmidt (via `np.linalg.qr`)