### PR TITLE
test: hypothesis doesn't do well generating large arrays

### DIFF
--- a/tests/unit/frameworks/environment_utils/transforms_test.py
+++ b/tests/unit/frameworks/environment_utils/transforms_test.py
@@ -15,7 +15,6 @@ import numpy as np
 import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
-from hypothesis.extra.numpy import arrays
 
 from tbp.monty.frameworks.agents import AgentID
 from tbp.monty.frameworks.environment_utils.transforms import (
@@ -40,18 +39,17 @@ BLUR_KERNEL_SIZES = [n for n in range(MAX_KERNEL + 1) if n == 0 or n % 2 == 1]
 def rgba_and_blur_params(draw):
     """Generate a random RGBA float32 image with valid blur parameters.
 
+    Uses a seeded NumPy RNG for fast bulk array generation instead of
+    per-element Hypothesis sampling. Trades per-pixel shrinking for speed.
+
     Returns:
         Tuple of (rgba array, sigma, kernel_size).
     """
-    height = draw(st.integers(1, 128))
-    width = draw(st.integers(1, 128))
-    rgba = draw(
-        arrays(
-            dtype=np.float32,
-            shape=(height, width, 4),
-            elements=st.floats(min_value=0.0, max_value=255.0, width=32),
-        )
-    )
+    height = draw(st.integers(1, 64))
+    width = draw(st.integers(1, 64))
+    seed = draw(st.integers(min_value=0, max_value=2**32 - 1))
+    rng = np.random.default_rng(seed)
+    rgba = rng.uniform(0.0, 255.0, size=(height, width, 4)).astype(np.float32)
     sigma = draw(st.floats(min_value=0.1, max_value=10.0))
     kernel_size = draw(st.sampled_from(BLUR_KERNEL_SIZES))
     return rgba, sigma, kernel_size


### PR DESCRIPTION
This fixes the failed test from here: https://github.com/thousandbrainsproject/tbp.monty/actions/runs/24351728573/job/71108470336?pr=901

Reason for Failure:
- Hypothesis was taking too long to generate examples.
- That was because we were creating arrays up to size (128, 128, 4). According to [the docs on hypothesis' arrays](https://hypothesis.readthedocs.io/en/latest/reference/strategies.html#numpy), Hypothesis doesn't do well in generating arrays with hundreds or more elements (presumably it is generating elements one by one).  
<img width="1089" height="148" alt="CleanShot 2026-04-13 at 10 11 32" src="https://github.com/user-attachments/assets/b977cd80-d20b-43e5-9159-79c4dbc528bf" />

The Fix:
- I changed the max size of the array to be 64x64 since that is our patch size.
- I updated the `rgba_and_blur_params` strategy to use numpy to generate random arrays. 
