### PR TITLE
refactor!: policy selector calls policy

### DIFF
--- a/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
+++ b/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
@@ -586,9 +586,9 @@ class DetailedGraphMatchingLogger(BasicGraphMatchingLogger):
         buffer_data["motor_system"]["action_details"] = dict(
             model.motor_system._telemetry_surface_action_details.__dict__
         )
-        buffer_data["motor_system"]["selected_goals"] = (
-            model.motor_system._selected_goals
-        )
+        buffer_data["motor_system"]["policy_selector"] = {
+            "selected_goals": model.motor_system._policy_selector._selected_goals,
+        }
 
         self.data["DETAILED"][episodes] = buffer_data
 

--- a/src/tbp/monty/frameworks/models/motor_policy_selectors.py
+++ b/src/tbp/monty/frameworks/models/motor_policy_selectors.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Protocol
 
-from tbp.monty.cmp import Goal
-from tbp.monty.frameworks.models.motor_policies import MotorPolicy
+from tbp.monty.cmp import Goal, Message
+from tbp.monty.context import RuntimeContext
+from tbp.monty.frameworks.models.abstract_monty_classes import Observations
+from tbp.monty.frameworks.models.motor_policies import MotorPolicy, MotorPolicyResult
+from tbp.monty.frameworks.models.motor_system_state import MotorSystemState
 
 if TYPE_CHECKING:
     from tbp.monty.frameworks.models.motor_system import MotorSystem
@@ -25,28 +28,48 @@ __all__ = [
 
 
 class MotorPolicySelector(Protocol):
-    def pre_episode(self, motor_system: MotorSystem) -> None:
-        pass
+    def pre_episode(self, motor_system: MotorSystem) -> None: ...
 
-    def state_dict(self) -> dict[str, Any]:
-        pass
+    def state_dict(self) -> dict[str, Any]: ...
 
-    def __call__(self, goals: list[Goal]) -> tuple[MotorPolicy, Goal | None]:
-        pass
+    def __call__(
+        self,
+        ctx: RuntimeContext,
+        observations: Observations,
+        state: MotorSystemState,
+        percept: Message,
+        goals: list[Goal],
+    ) -> MotorPolicyResult: ...
 
 
 class SinglePolicySelector(MotorPolicySelector):
     def __init__(self, policy: MotorPolicy):
         self._policy = policy
+        # TODO: Get rid of this once we have another path for telemetry.
+        self._selected_goals: list[Goal | None] = []
 
     def pre_episode(self, motor_system: MotorSystem) -> None:
         self._policy.pre_episode(motor_system)
+        self._selected_goals = []
 
     def state_dict(self) -> dict[str, Any]:
-        return self._policy.state_dict()
+        return {
+            "policy": self._policy.state_dict(),
+            "selected_goals": self._selected_goals,
+        }
 
-    def __call__(self, goals: list[Goal]) -> tuple[MotorPolicy, Goal | None]:
+    def __call__(
+        self,
+        ctx: RuntimeContext,
+        observations: Observations,
+        state: MotorSystemState,
+        percept: Message,
+        goals: list[Goal],
+    ) -> MotorPolicyResult:
         if goals:
             sorted_goals = sorted(goals, key=lambda x: x.confidence, reverse=True)
-            return self._policy, sorted_goals[0]
-        return self._policy, None
+            goal = sorted_goals[0]
+        else:
+            goal = None
+        self._selected_goals.append(goal)
+        return self._policy(ctx, observations, state, percept, goal)

--- a/src/tbp/monty/frameworks/models/motor_system.py
+++ b/src/tbp/monty/frameworks/models/motor_system.py
@@ -60,9 +60,6 @@ class MotorSystem:
             z_defined_pc=[],
         )
 
-        # TODO: Get rid of this once we have another path for telemetry.
-        self._selected_goals: list[Goal | None] = []
-
     @property
     def action_sequence(self) -> list[tuple[list[Action], dict[AgentID, Any] | None]]:
         return self._action_sequence
@@ -82,7 +79,6 @@ class MotorSystem:
             avoidance_heading=[],
             z_defined_pc=[],
         )
-        self._selected_goals = []
 
     def state_dict(self) -> dict[str, Any]:
         return self._policy_selector.state_dict()
@@ -111,11 +107,10 @@ class MotorSystem:
             The action to take.
         """
         motor_system_state = MotorSystemState(proprioceptive_state)
-        policy, goal = self._policy_selector(goals)
+        policy_result = self._policy_selector(
+            ctx, observations, motor_system_state, percept, goals
+        )
 
-        self._selected_goals.append(goal)
-
-        policy_result = policy(ctx, observations, motor_system_state, percept, goal)
         self.motor_only_step = policy_result.motor_only_step
 
         state_copy = motor_system_state.convert_motor_state()

--- a/tests/unit/frameworks/models/motor_policy_selectors_test.py
+++ b/tests/unit/frameworks/models/motor_policy_selectors_test.py
@@ -18,33 +18,71 @@ class SinglePolicySelectorTest(unittest.TestCase):
     def setUp(self):
         self.policy = Mock()
         self.selector = SinglePolicySelector(self.policy)
+        self.ctx = Mock()
+        self.observations = Mock()
+        self.state = Mock()
+        self.percept = Mock()
+        self.expected_result = Mock()
+        self.policy.return_value = self.expected_result
 
-    def test_returns_configured_policy(self):
-        policy, _ = self.selector([])
-        self.assertIs(policy, self.policy)
+    def test_delegates_to_configured_policy(self):
+        self.selector(self.ctx, self.observations, self.state, self.percept, [])
+        self.policy.assert_called_once_with(
+            self.ctx,
+            self.observations,
+            self.state,
+            self.percept,
+            None,
+        )
 
-    def test_returns_none_if_no_goals_given(self):
-        _, goal = self.selector([])
-        self.assertIsNone(goal)
+    def test_returns_result_from_policy(self):
+        result = self.selector(
+            self.ctx, self.observations, self.state, self.percept, []
+        )
+        self.assertIs(result, self.expected_result)
 
-    def test_returns_goal_with_highest_confidence(self):
+    def test_calls_policy_with_goal_of_highest_confidence(self):
         best_goal = Mock(confidence=0.9)
         second_best_goal = Mock(confidence=0.8)
-        _, goal = self.selector([second_best_goal, best_goal])
-        self.assertIs(goal, best_goal)
+        self.selector(
+            self.ctx,
+            self.observations,
+            self.state,
+            self.percept,
+            [second_best_goal, best_goal],
+        )
+        self.policy.assert_called_once_with(
+            self.ctx,
+            self.observations,
+            self.state,
+            self.percept,
+            best_goal,
+        )
 
-    def test_returns_first_goal_with_highest_confidence_if_ties(self):
+    def test_calls_policy_with_first_goal_when_confidence_tied(self):
         first_goal = Mock(confidence=0.9)
         second_goal = Mock(confidence=0.9)
-        _, goal = self.selector([first_goal, second_goal])
-        self.assertIs(goal, first_goal)
+        self.selector(
+            self.ctx,
+            self.observations,
+            self.state,
+            self.percept,
+            [first_goal, second_goal],
+        )
+        self.policy.assert_called_once_with(
+            self.ctx,
+            self.observations,
+            self.state,
+            self.percept,
+            first_goal,
+        )
 
     def test_pre_episode_calls_pre_episode_on_policy(self):
         motor_system = Mock()
         self.selector.pre_episode(motor_system)
         self.policy.pre_episode.assert_called_once_with(motor_system)
 
-    def test_state_dict_returns_state_dict_of_policy(self):
+    def test_state_dict_includes_policy_state_dict(self):
         state_dict = Mock()
         self.policy.state_dict.return_value = state_dict
-        self.assertIs(self.selector.state_dict(), state_dict)
+        self.assertIs(self.selector.state_dict()["policy"], state_dict)


### PR DESCRIPTION
This PR changes the interface to `MotorPolicySelector` so that it now calls the policy itself (as opposed to returning a policy that the `MotorSystem` then calls).

This will be needed when we select multiple policies. This PR should have no impact on current functionality.

Benchmarks unchanged:

### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 2.86 | 2.86 | 0 | ⬜ |
| match_steps | 34 | 34 | 0 | ⬜ |
| rotation_error (deg) | 8.64 | 8.64 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 8 | 8 | 0 | ⬜ |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 3.87 | 3.87 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 11 | 12 | 1 | ❌ |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 2 | 2 | 0 | ⬜ |
| match_steps | 35 | 35 | 0 | ⬜ |
| rotation_error (deg) | 13.23 | 13.23 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 13 | 13 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 3 | 3 | 0 | ⬜ |
| match_steps | 31 | 31 | 0 | ⬜ |
| rotation_error (deg) | 15.42 | 15.42 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 12 | 14 | 2 | ❌ |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 10.37 | 10.37 | 0 | ⬜ |
| runtime (min) | 3 | 4 | 1 | ❌ |
| episode_runtime (sec) | 23 | 24 | 1 | ❌ |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 5.16 | 5.16 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 13 | 13 | 0 | ⬜ |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 1 | 1 | 0 | ⬜ |
| match_steps | 50 | 50 | 0 | ⬜ |
| rotation_error (deg) | 56.65 | 56.65 | 0 | ⬜ |
| runtime (min) | 5 | 6 | 1 | ❌ |
| episode_runtime (sec) | 33 | 33 | 0 | ⬜ |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.57 | 98.57 | 0 | ⬜ |
| used_mlh (%) | 4.29 | 4.29 | 0 | ⬜ |
| match_steps | 53 | 53 | 0 | ⬜ |
| rotation_error (deg) | 3.53 | 3.53 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 22 | 23 | 1 | ❌ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 88 | 88 | 0 | ⬜ |
| used_mlh (%) | 32 | 32 | 0 | ⬜ |
| match_steps | 202 | 202 | 0 | ⬜ |
| rotation_error (deg) | 30.3 | 30.3 | 0 | ⬜ |
| runtime (min) | 10 | 11 | 1 | ❌ |
| episode_runtime (sec) | 72 | 81 | 9 | ❌ |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| used_mlh (%) | 28 | 28 | 0 | ⬜ |
| match_steps | 157 | 157 | 0 | ⬜ |
| rotation_error (deg) | 18.01 | 18.01 | 0 | ⬜ |
| runtime (min) | 18 | 15 | -3 | ✅ |
| episode_runtime (sec) | 153 | 118 | -35 | ✅ |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 67 | 67 | 0 | ⬜ |
| used_mlh (%) | 75 | 75 | 0 | ⬜ |
| match_steps | 13 | 13 | 0 | ⬜ |
| rotation_error (deg) | 105.66 | 105.66 | 0 | ⬜ |
| runtime (min) | 5 | 4 | -1 | ✅ |
| episode_runtime (sec) | 7 | 6 | -1 | ✅ |

### base_10multi_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 47.14 | 47.14 | 0 | ⬜ |
| used_mlh (%) | 4.29 | 4.29 | 0 | ⬜ |
| match_steps | 33 | 33 | 0 | ⬜ |
| rotation_error (deg) | 18.42 | 18.42 | 0 | ⬜ |
| runtime (min) | 37 | 42 | 5 | ❌ |
| episode_runtime (sec) | 2 | 2 | 0 | ⬜ |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 93.94 | 93.94 | 0 | ⬜ |
| used_mlh (%) | 10.39 | 10.39 | 0 | ⬜ |
| match_steps | 78 | 78 | 0 | ⬜ |
| rotation_error (deg) | 11.1 | 11.1 | 0 | ⬜ |
| runtime (min) | 14 | 16 | 2 | ❌ |
| episode_runtime (sec) | 39 | 41 | 2 | ❌ |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 4.33 | 4.33 | 0 | ⬜ |
| match_steps | 45 | 45 | 0 | ⬜ |
| rotation_error (deg) | 4.08 | 4.08 | 0 | ⬜ |
| runtime (min) | 12 | 12 | 0 | ⬜ |
| episode_runtime (sec) | 29 | 28 | -1 | ✅ |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 88.74 | 88.74 | 0 | ⬜ |
| used_mlh (%) | 17.75 | 17.75 | 0 | ⬜ |
| match_steps | 120 | 120 | 0 | ⬜ |
| rotation_error (deg) | 33.03 | 33.03 | 0 | ⬜ |
| runtime (min) | 30 | 29 | -1 | ✅ |
| episode_runtime (sec) | 87 | 84 | -3 | ✅ |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99.57 | 99.57 | 0 | ⬜ |
| used_mlh (%) | 20.35 | 20.35 | 0 | ⬜ |
| match_steps | 109 | 109 | 0 | ⬜ |
| rotation_error (deg) | 23.73 | 23.73 | 0 | ⬜ |
| runtime (min) | 34 | 39 | 5 | ❌ |
| episode_runtime (sec) | 110 | 122 | 12 | ❌ |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96.1 | 96.1 | 0 | ⬜ |
| used_mlh (%) | 1.3 | 1.3 | 0 | ⬜ |
| match_steps | 68 | 68 | 0 | ⬜ |
| rotation_error (deg) | 57.04 | 57.04 | 0 | ⬜ |
| runtime (min) | 15 | 16 | 1 | ❌ |
| episode_runtime (sec) | 138 | 140 | 2 | ❌ |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| match_steps | 97 | 97 | 0 | ⬜ |
| runtime (min) | 12 | 14 | 2 | ❌ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 25 | 26 | 1 | ❌ |
| episode_runtime (sec) | 12 | 12 | 0 | ⬜ |

### infer_comp_lvl1_with_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 89.29 | 89.29 | 0 | ⬜ |
| used_mlh (%) | 84.52 | 84.52 | 0 | ⬜ |
| match_steps | 415 | 415 | 0 | ⬜ |
| rotation_error (deg) | 56.28 | 56.28 | 0 | ⬜ |
| avg_prediction_error | 0.35 | 0.35 | 0 | ⬜ |
| runtime (min) | 35 | 38 | 3 | ❌ |

### infer_comp_lvl1_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 85.71 | 85.71 | 0 | ⬜ |
| used_mlh (%) | 35.71 | 35.71 | 0 | ⬜ |
| match_steps | 35 | 35 | 0 | ⬜ |
| rotation_error (deg) | 51.47 | 51.47 | 0 | ⬜ |
| avg_prediction_error | 0.34 | 0.34 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |

### infer_comp_lvl2_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 85.71 | 85.71 | 0 | ⬜ |
| used_mlh (%) | 35.71 | 35.71 | 0 | ⬜ |
| match_steps | 40 | 40 | 0 | ⬜ |
| rotation_error (deg) | 53.9 | 53.9 | 0 | ⬜ |
| avg_prediction_error | 0.33 | 0.33 | 0 | ⬜ |
| runtime (min) | 11 | 11 | 0 | ⬜ |

### infer_comp_lvl3_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 64 | 64 | 0 | ⬜ |
| used_mlh (%) | 52.86 | 52.86 | 0 | ⬜ |
| match_steps | 34 | 34 | 0 | ⬜ |
| rotation_error (deg) | 50.29 | 50.29 | 0 | ⬜ |
| avg_prediction_error | 0.34 | 0.34 | 0 | ⬜ |
| runtime (min) | 16 | 17 | 1 | ❌ |

