### PR TITLE
feat!: suppress_runtime_error flag in RuntimeContext

### DIFF
--- a/src/tbp/monty/context.py
+++ b/src/tbp/monty/context.py
@@ -17,7 +17,15 @@ class RuntimeContext:
     """Monty's runtime context.
 
     The RuntimeContext carries runtime-scoped values used throughout Monty.
+
+    Attributes:
+        rng: The random number generator.
+        suppress_runtime_errors: Whether to suppress runtime errors. Runtime errors
+            can be raised when goal is None or invalid. When in an experimental
+            mode, we want to raise runtime errors by default. When in a production
+            mode, we want to suppress runtime errors by default. Currently, we run
+            a lot of experiments, so the current default is to raise runtime errors.
     """
 
     rng: np.random.RandomState
-    """Random number generator."""
+    suppress_runtime_errors: bool = False

--- a/src/tbp/monty/frameworks/models/salience/motor_policy.py
+++ b/src/tbp/monty/frameworks/models/salience/motor_policy.py
@@ -32,6 +32,18 @@ from tbp.monty.frameworks.sensors import SensorID
 logger = logging.getLogger(__name__)
 
 
+class NoGoalProvided(RuntimeError):
+    """Raised when no goal is provided."""
+
+    pass
+
+
+class GoalCollocatedWithSensor(RuntimeError):
+    """Raised when a goal is collocated with a sensor."""
+
+    pass
+
+
 class LookAtGoal(MotorPolicy):
     """A policy that looks at a target.
 
@@ -48,7 +60,6 @@ class LookAtGoal(MotorPolicy):
         self,
         agent_id: AgentID,
         sensor_id: SensorID,
-        suppress_runtime_errors: bool = False,
     ):
         """Initialize the look at policy.
 
@@ -63,12 +74,10 @@ class LookAtGoal(MotorPolicy):
         """
         self._agent_id = agent_id
         self._sensor_id = sensor_id
-        self._suppress_runtime_errors = suppress_runtime_errors
 
     def load_state_dict(self, state_dict: dict[str, Any]) -> None:
         self._agent_id = state_dict["agent_id"]
         self._sensor_id = state_dict["sensor_id"]
-        self._suppress_runtime_errors = state_dict["suppress_runtime_errors"]
 
     def pre_episode(self, motor_system: MotorSystem) -> None:
         pass
@@ -77,12 +86,11 @@ class LookAtGoal(MotorPolicy):
         return {
             "agent_id": self._agent_id,
             "sensor_id": self._sensor_id,
-            "suppress_runtime_errors": self._suppress_runtime_errors,
         }
 
     def __call__(
         self,
-        ctx: RuntimeContext,  # noqa: ARG002
+        ctx: RuntimeContext,
         observations: Observations,  # noqa: ARG002
         state: MotorSystemState,
         percept: Message,  # noqa: ARG002
@@ -102,13 +110,14 @@ class LookAtGoal(MotorPolicy):
             The motor policy result.
 
         Raises:
-            RuntimeError: If no goal is provided.
+            NoGoalProvided: If no goal is provided.
+            GoalCollocatedWithSensor: If the goal is collocated with the sensor.
         """
         if goal is None:
-            if self._suppress_runtime_errors:
+            if ctx.suppress_runtime_errors:
                 logger.warning("No goal provided")
                 return MotorPolicyResult([])
-            raise RuntimeError("No goal provided")
+            raise NoGoalProvided
 
         # Collect necessary agent and sensor pose information.
         agent_state: AgentState = state[self._agent_id]
@@ -146,10 +155,10 @@ class LookAtGoal(MotorPolicy):
             inverse=True,
         )
         if np.isclose(np.linalg.norm(target_rel_sensor), 0.0):
-            if self._suppress_runtime_errors:
+            if ctx.suppress_runtime_errors:
                 logger.warning("Goal is collocated with sensor")
                 return MotorPolicyResult([])
-            raise RuntimeError("Goal is collocated with sensor")
+            raise GoalCollocatedWithSensor
 
         # Compute the target's azimuth, relative to the agent. This value is used to
         # compute the yaw action to be performed by the agent.

--- a/tests/integration/frameworks/models/salience/motor_policy_test.py
+++ b/tests/integration/frameworks/models/salience/motor_policy_test.py
@@ -6,34 +6,35 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
+
 from __future__ import annotations
 
-import unittest
-
-import numpy as np
 import pytest
-from hypothesis import given
-from hypothesis import strategies as st
-
-from tbp.monty.cmp import Goal
-from tbp.monty.frameworks.agents import AgentID
-from tbp.monty.frameworks.environments.embodied_data import (
-    EnvironmentInterfacePerObject,
-)
-from tbp.monty.frameworks.environments.object_init_samplers import Predefined
-from tbp.monty.frameworks.models.salience.motor_policy import LookAtGoal
-from tbp.monty.frameworks.sensors import SensorID
 
 pytest.importorskip(
     "habitat_sim",
     reason="Habitat Sim optional dependency not installed.",
 )
 
+import unittest
+
+import numpy as np
+from hypothesis import given
+from hypothesis import strategies as st
+
+from tbp.monty.cmp import Goal
+from tbp.monty.frameworks.agents import AgentID
 from tbp.monty.frameworks.environment_utils.transforms import (
     DepthTo3DLocations,
     MissingToMaxDepth,
 )
+from tbp.monty.frameworks.environments.embodied_data import (
+    EnvironmentInterfacePerObject,
+)
+from tbp.monty.frameworks.environments.object_init_samplers import Predefined
 from tbp.monty.frameworks.experiments.monty_experiment import ExperimentMode
+from tbp.monty.frameworks.models.salience.motor_policy import LookAtGoal
+from tbp.monty.frameworks.sensors import SensorID
 from tbp.monty.simulators.habitat.agents import MultiSensorAgent
 from tbp.monty.simulators.habitat.environment import HabitatEnvironment
 

--- a/tests/unit/frameworks/models/salience/motor_policy_test.py
+++ b/tests/unit/frameworks/models/salience/motor_policy_test.py
@@ -19,6 +19,7 @@ from hypothesis import strategies as st
 from scipy.spatial.transform import Rotation
 
 from tbp.monty.cmp import Goal
+from tbp.monty.context import RuntimeContext
 from tbp.monty.frameworks.actions.actions import LookUp, TurnLeft
 from tbp.monty.frameworks.agents import AgentID
 from tbp.monty.frameworks.models.motor_system_state import (
@@ -26,7 +27,11 @@ from tbp.monty.frameworks.models.motor_system_state import (
     MotorSystemState,
     SensorState,
 )
-from tbp.monty.frameworks.models.salience.motor_policy import LookAtGoal
+from tbp.monty.frameworks.models.salience.motor_policy import (
+    GoalCollocatedWithSensor,
+    LookAtGoal,
+    NoGoalProvided,
+)
 from tbp.monty.frameworks.sensors import SensorID
 from tbp.monty.frameworks.utils.spatial_arithmetics import normalize
 from tbp.monty.math import VectorXYZ
@@ -60,9 +65,11 @@ class LookAtGoalTest(unittest.TestCase):
         self,
     ) -> None:
         policy = LookAtGoal(AGENT_ID, SENSOR_ID)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(NoGoalProvided):
             policy(
-                ctx=Mock(),
+                ctx=RuntimeContext(
+                    rng=np.random.RandomState(42), suppress_runtime_errors=False
+                ),
                 observations=Mock(),
                 state=MotorSystemState(),
                 percept=Mock(),
@@ -72,9 +79,11 @@ class LookAtGoalTest(unittest.TestCase):
     def test_returns_empty_result_if_no_goal_is_provided_if_suppressing_runtime_errors(
         self,
     ) -> None:
-        policy = LookAtGoal(AGENT_ID, SENSOR_ID, suppress_runtime_errors=True)
+        policy = LookAtGoal(AGENT_ID, SENSOR_ID)
         result = policy(
-            ctx=Mock(),
+            ctx=RuntimeContext(
+                rng=np.random.RandomState(42), suppress_runtime_errors=True
+            ),
             observations=Mock(),
             state=MotorSystemState(),
             percept=Mock(),
@@ -86,9 +95,11 @@ class LookAtGoalTest(unittest.TestCase):
         self,
     ) -> None:
         policy = LookAtGoal(AGENT_ID, SENSOR_ID)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(GoalCollocatedWithSensor):
             policy(
-                ctx=Mock(),
+                ctx=RuntimeContext(
+                    rng=np.random.RandomState(42), suppress_runtime_errors=False
+                ),
                 observations=Mock(),
                 state=self.motor_system_state,
                 percept=Mock(),
@@ -108,9 +119,11 @@ class LookAtGoalTest(unittest.TestCase):
     def test_returns_empty_result_if_goal_collocated_with_sensor_and_suppressing_runtime_errors(  # noqa: E501
         self,
     ) -> None:
-        policy = LookAtGoal(AGENT_ID, SENSOR_ID, suppress_runtime_errors=True)
+        policy = LookAtGoal(AGENT_ID, SENSOR_ID)
         result = policy(
-            ctx=Mock(),
+            ctx=RuntimeContext(
+                rng=np.random.RandomState(42), suppress_runtime_errors=True
+            ),
             observations=Mock(),
             state=self.motor_system_state,
             percept=Mock(),
@@ -174,7 +187,9 @@ class LookAtGoalTest(unittest.TestCase):
             return
 
         result = policy(
-            ctx=Mock(),
+            ctx=RuntimeContext(
+                rng=np.random.RandomState(42), suppress_runtime_errors=False
+            ),
             observations=Mock(),
             state=self.motor_system_state,
             percept=Mock(),


### PR DESCRIPTION
This PR moves the `suppress_runtime_error` flag from `LookAtGoal` to the `RuntimeContext`.