### PR TITLE
ci: don't allow `test!` labels on PRs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -13,9 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title format
+        env:
+          # Store in an environment variable to prevent trying to
+          # run backticked strings in the title.
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           pattern="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|rfc|style|test)!?:.+"
-          if [[ ! "${{ github.event.pull_request.title }}" =~ $pattern ]]; then
+          if [[ ! $PR_TITLE =~ $pattern ]]; then
             echo "This PR title is missing a Conventional Commits label."
             echo "A maintainer will update it appropriately during triage."
             echo "See https://thousandbrainsproject.readme.io/docs/triage#title-1"
@@ -23,7 +27,7 @@ jobs:
           fi
           
           pattern="^test!:.+"
-          if [[ ! "${{ github.event.pull_request.title }}" =~ $pattern ]]; then
+          if [[ ! $PR_TITLE =~ $pattern ]]; then
             echo "This PR title indicates it is only changing tests, and"
             echo "that those changes are breaking changes. Changes that"
             echo "only change files in 'tests' cannot produce breaking"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -21,3 +21,14 @@ jobs:
             echo "See https://thousandbrainsproject.readme.io/docs/triage#title-1"
             exit 1
           fi
+          
+          pattern="^test!:.+"
+          if [[ ! "${{ github.event.pull_request.title }}" =~ $pattern ]]; then
+            echo "This PR title indicates it is only changing tests, and"
+            echo "that those changes are breaking changes. Changes that"
+            echo "only change files in `tests` cannot produce breaking"
+            echo "changes."
+            echo "  If this PR has non-test changes, then `test` is not the"
+            echo "correct label for this PR."
+            exit 1
+          fi

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -27,7 +27,7 @@ jobs:
           fi
           
           pattern="^test!:.+"
-          if [[ ! $PR_TITLE =~ $pattern ]]; then
+          if [[ $PR_TITLE =~ $pattern ]]; then
             echo "This PR title indicates it is only changing tests, and"
             echo "that those changes are breaking changes. Changes that"
             echo "only change files in 'tests' cannot produce breaking"

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,6 +1,6 @@
 name: Triage
 on:
-  pull_request_target:
+  pull_request:
     branches:
     - main
     types:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -26,9 +26,9 @@ jobs:
           if [[ ! "${{ github.event.pull_request.title }}" =~ $pattern ]]; then
             echo "This PR title indicates it is only changing tests, and"
             echo "that those changes are breaking changes. Changes that"
-            echo "only change files in `tests` cannot produce breaking"
+            echo "only change files in 'tests' cannot produce breaking"
             echo "changes."
-            echo "  If this PR has non-test changes, then `test` is not the"
+            echo "  If this PR has non-test changes, then 'test' is not the"
             echo "correct label for this PR."
             exit 1
           fi

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,6 +1,6 @@
 name: Triage
 on:
-  pull_request:
+  pull_request_target:
     branches:
     - main
     types:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -18,6 +18,8 @@ jobs:
           # run backticked strings in the title.
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          set -e
+          
           pattern="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|rfc|style|test)!?:.+"
           if [[ ! $PR_TITLE =~ $pattern ]]; then
             echo "This PR title is missing a Conventional Commits label."


### PR DESCRIPTION
It doesn't make sense to allow `test!` labels on PRs, as changes that are limited to `tests` are by definition non-breaking changes.

This adds a check to our `triage` title check workflow and provides instructions for how to correct the problem.