### PR TITLE
fix: handle near-zero vectors in vector comparison logic

### DIFF
--- a/src/tbp/monty/frameworks/utils/spatial_arithmetics.py
+++ b/src/tbp/monty/frameworks/utils/spatial_arithmetics.py
@@ -244,7 +244,7 @@ def get_angle_beefed_up(v1, v2):
     if v1 is None or v2 is None:
         return np.inf
 
-    if np.all(v1 == 0) or np.all(v2 == 0):
+    if np.linalg.norm(v1) < DEFAULT_TOLERANCE or np.linalg.norm(v2) < DEFAULT_TOLERANCE:
         return np.inf
 
     v1_u = normalize(v1)


### PR DESCRIPTION
Hotfix to the following failing benchmark experiment on main branch:

```python
File "/Users/dschumacher/tbp/tbp.monty/src/tbp/monty/frameworks/models/motor_policies.py", line 1981, in conflict_check
  get_angle_beefed_up(self.tangential_vec, rotated_locs[ii])
 File "/Users/dschumacher/tbp/tbp.monty/src/tbp/monty/frameworks/utils/spatial_arithmetics.py", line 155, in get_angle_beefed_up
  v2_u = normalize(v2)
 File "/Users/dschumacher/tbp/tbp.monty/src/tbp/monty/frameworks/utils/spatial_arithmetics.py", line 42, in normalize
  raise ValueError(f"Cannot normalize near-zero vector (norm={n:.2e})")
ValueError: Cannot normalize near-zero vector (norm=1.44e-07)

Set the environment variable HYDRA_FULL_ERROR=1 for a complete stack trace.
```