### PR TITLE
fix: configure positioning procedure for `randrot_noise_sim_on_scan_monty_world`

### DIFF
--- a/src/tbp/monty/conf/experiment/randrot_noise_sim_on_scan_monty_world.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_noise_sim_on_scan_monty_world.yaml
@@ -8,6 +8,7 @@ defaults:
   - /monty/connectivity: 1lm_1sm
   - /environment: habitat_numentalab_dist_agent_semantics0
   - /env_interface: eval_montymeetsworld_random
+  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
   - /env_interface/transform: missing_depthto3d_sensor2_semantic0
   - /logging: basic_warning_wandb_evidence_eval_runs
 

--- a/tests/conf/snapshots/randrot_noise_sim_on_scan_monty_world.yaml
+++ b/tests/conf/snapshots/randrot_noise_sim_on_scan_monty_world.yaml
@@ -177,6 +177,15 @@ experiment:
       - hot_sauce
       object_init_sampler:
         _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
+      positioning_procedures:
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: view_finder
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: patch
+        allow_translation: false
+        max_orientation_attempts: 3
     eval_env_interface_class: ${monty.class:tbp.monty.frameworks.environments.embodied_data.EnvironmentInterfacePerObject}
     logging:
       monty_log_level: BASIC


### PR DESCRIPTION
When we switched to having configurable positioning procedures, we neglected to add a get-good-view configuration for the Monty Meets World experiment `randrot_noise_sim_on_scan_monty_world`.

The change in this PR does not change benchmarks. Sort of. The benchmark results were out of sync with actual behavior since we don't routinely update the monty-meets-world experiments. This PR returns behavior to expected.

Here's the comparison between this branch and the results stored in main's CSV files:

### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 89.17 | 89.17 | 0 | ⬜ |
| used_mlh (%) | 88.33 | 88.33 | 0 | ⬜ |
| match_steps | 445 | 445 | 0 | ⬜ |
| runtime (min) | 47 | 25 | -22 | ✅ |
| episode_runtime (sec) | 23 | 178 | 155 | ❌ |
| num_episodes | 120 |120 |0 | ⬜ |

Runtime went down (considerably), and episode runtime went up (paradoxically). I'm not sure what to trust here. @ramyamounir any thoughts? I wondered if there might be changes to `tbp.benchmarks` that could be responsible.

