### PR TITLE
test: exclude MuJoCo configs from update_snapshots.py

### DIFF
--- a/src/tbp/monty/conf/update_snapshots.py
+++ b/src/tbp/monty/conf/update_snapshots.py
@@ -46,6 +46,10 @@ def update_snapshots(
         existing_snapshot.unlink()
 
     for file_path in config_dir.glob("*.yaml"):
+        # Exclude MuJoCo experiments
+        # TODO: Revert once we convert to MuJoCo
+        if file_path.stem.endswith("mujoco"):
+            continue
         print(f"Updating snapshot: {file_path}")
         with hydra.initialize(version_base=None, config_path="."):
             print(f"experiment={override_prefix}{file_path.stem}")


### PR DESCRIPTION
We want to temporarily exclude the MuJoCo configs from the update_snapshots script because it requires `mujoco` to be installed to load the config with Hydra.