### PR TITLE
chore: update outdated benchmark results

### DIFF
--- a/benchmarks/logos_on_objects.csv
+++ b/benchmarks/logos_on_objects.csv
@@ -1,6 +1,6 @@
 Experiment,Correct Child or Parent (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Avg Prediction Error|align right,Run Time (mins)|align right,Num Episodes|hidden
-infer_comp_lvl1_with_monolithic_models,89.29,84.52,415,56.28,0.35,35,84
-infer_comp_lvl1_with_comp_models,85.71,35.71,35,51.47,0.34,4,84
-infer_comp_lvl2_with_comp_models,85.71,35.71,40,53.90,0.33,11,210
-infer_comp_lvl3_with_comp_models,64.00,52.86,34,50.29,0.34,16,350
+infer_comp_lvl1_with_monolithic_models,89.29,84.52,415,56.28,0.35,34,84
+infer_comp_lvl1_with_comp_models,85.71,35.71,35,51.47,0.34,3,84
+infer_comp_lvl2_with_comp_models,85.71,35.71,40,53.90,0.33,10,210
+infer_comp_lvl3_with_comp_models,64.00,52.86,34,50.29,0.34,15,350
 infer_comp_lvl4_with_comp_models,56.32,57.97,32,38.72,0.34,15,364

--- a/benchmarks/ycb_10objs.csv
+++ b/benchmarks/ycb_10objs.csv
@@ -1,13 +1,13 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-base_config_10distinctobj_dist_agent,100.00,2.86,34,8.64,3,8,140
-base_config_10distinctobj_surf_agent,100.00,0.00,28,3.87,3,11,140
-randrot_noise_10distinctobj_dist_agent,100.00,2.00,35,13.23,3,13,100
+base_config_10distinctobj_dist_agent,100.00,2.86,34,8.64,3,7,140
+base_config_10distinctobj_surf_agent,100.00,0.00,28,3.87,3,12,140
+randrot_noise_10distinctobj_dist_agent,100.00,2.00,35,13.23,3,14,100
 randrot_noise_10distinctobj_dist_on_distm,100.00,3.00,31,15.42,3,12,100
-randrot_noise_10distinctobj_surf_agent,100.00,0.00,29,10.37,3,23,100
-randrot_10distinctobj_surf_agent,100.00,0.00,29,5.16,2,13,100
-randrot_noise_10distinctobj_5lms_dist_agent,100.00,1.00,50,56.65,5,33,100
-base_10simobj_surf_agent,98.57,4.29,53,3.53,5,22,100
-randrot_noise_10simobj_dist_agent,88.00,32.00,202,30.3,10,72,100
-randrot_noise_10simobj_surf_agent,97.00,28.00,157,18.01,18,153,100
-randomrot_rawnoise_10distinctobj_surf_agent,67.00,75.00,13,105.66,5,7,100
-base_10multi_distinctobj_dist_agent,47.14,4.29,33,18.42,37,2,140
+randrot_noise_10distinctobj_surf_agent,100.00,0.00,29,10.37,4,25,100
+randrot_10distinctobj_surf_agent,100.00,0.00,29,5.16,2,12,100
+randrot_noise_10distinctobj_5lms_dist_agent,100.00,1.00,50,56.65,6,37,100
+base_10simobj_surf_agent,98.57,4.29,53,3.53,5,21,140
+randrot_noise_10simobj_dist_agent,88.00,32.00,202,30.3,9,68,100
+randrot_noise_10simobj_surf_agent,97.00,28.00,157,18.01,16,128,100
+randomrot_rawnoise_10distinctobj_surf_agent,67.00,75.00,13,105.66,4,6,100
+base_10multi_distinctobj_dist_agent,47.14,4.29,33,18.42,41,2,140

--- a/benchmarks/ycb_77objs.csv
+++ b/benchmarks/ycb_77objs.csv
@@ -1,6 +1,6 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-base_77obj_dist_agent,93.94,10.39,78,11.10,14,39,231
-base_77obj_surf_agent,100.00,4.33,45,4.08,12,29,231
+base_77obj_dist_agent,93.94,10.39,78,11.10,15,40,231
+base_77obj_surf_agent,100.00,4.33,45,4.14,12,28,231
 randrot_noise_77obj_dist_agent,88.74,17.75,120,33.03,30,87,231
-randrot_noise_77obj_surf_agent,99.57,20.35,109,23.73,34,110,231
-randrot_noise_77obj_5lms_dist_agent,96.10,1.3,68,57.04,15,138,77
+randrot_noise_77obj_surf_agent,99.57,20.35,109,23.73,36,117,231
+randrot_noise_77obj_5lms_dist_agent,96.10,1.3,68,57.04,17,156,77

--- a/benchmarks/ycb_unsupervised_inference.csv
+++ b/benchmarks/ycb_unsupervised_inference.csv
@@ -1,3 +1,3 @@
 Experiment,Correct (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-unsupervised_inference_distinctobj_dist_agent,97.00,97,12,5,100
-unsupervised_inference_distinctobj_surf_agent,100.00,98,25,12,100
+unsupervised_inference_distinctobj_dist_agent,97.00,97,13,5,100
+unsupervised_inference_distinctobj_surf_agent,100.00,98,23,11,100


### PR DESCRIPTION
Running `base_77obj_surf_agent` yields ever so slightly different results from currently documented benchmarks. It is a tiny difference in rotation error.

I've determined that [PR 918: refactor!: change epsilon default and refactor NormalizeTest](https://github.com/thousandbrainsproject/tbp.monty/pull/918) is the culprit. It changed the default tolerance value used by `normalize`, and `normalize` is used quite a bit. Apparently the tolerance change was enough to change maybe 1 function call across all benchmark runs. Neat.

`num_episodes` was also off for `base_10simobj_surf_agent`. I didn't track that down though.


## Benchmarks

❌: Changed
ns: Not Significant (runtimes only)

### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 |   |
| used_mlh (%) | 2.86 | 2.86 | 0 |   |
| match_steps | 34 | 34 | 0 |   |
| rotation_error (deg) | 8.64 | 8.64 | 0 |   |
| runtime (min) | 3 | 3 | 0 |   |
| episode_runtime (sec) | 8 | 7 | -1 | ns |
| num_episodes | 140 | 140 | 0 |   |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 |   |
| used_mlh (%) | 0 | 0 | 0 |   |
| match_steps | 28 | 28 | 0 |   |
| rotation_error (deg) | 3.87 | 3.87 | 0 |   |
| runtime (min) | 3 | 3 | 0 |   |
| episode_runtime (sec) | 11 | 12 | 1 | ns |
| num_episodes | 140 | 140 | 0 |   |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 |   |
| used_mlh (%) | 2 | 2 | 0 |   |
| match_steps | 35 | 35 | 0 |   |
| rotation_error (deg) | 13.23 | 13.23 | 0 |   |
| runtime (min) | 3 | 3 | 0 |   |
| episode_runtime (sec) | 13 | 14 | 1 | ns |
| num_episodes | 100 | 100 | 0 |   |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 |   |
| used_mlh (%) | 3 | 3 | 0 |   |
| match_steps | 31 | 31 | 0 |   |
| rotation_error (deg) | 15.42 | 15.42 | 0 |   |
| runtime (min) | 3 | 3 | 0 |   |
| episode_runtime (sec) | 12 | 12 | 0 |   |
| num_episodes | 100 | 100 | 0 |   |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 |   |
| used_mlh (%) | 0 | 0 | 0 |   |
| match_steps | 29 | 29 | 0 |   |
| rotation_error (deg) | 10.37 | 10.37 | 0 |   |
| runtime (min) | 3 | 4 | 1 | ns |
| episode_runtime (sec) | 23 | 25 | 2 | ns |
| num_episodes | 100 | 100 | 0 |   |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 |   |
| used_mlh (%) | 0 | 0 | 0 |   |
| match_steps | 29 | 29 | 0 |   |
| rotation_error (deg) | 5.16 | 5.16 | 0 |   |
| runtime (min) | 2 | 2 | 0 |   |
| episode_runtime (sec) | 13 | 12 | -1 | ns |
| num_episodes | 100 | 100 | 0 |   |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 |   |
| used_mlh (%) | 1 | 1 | 0 |   |
| match_steps | 50 | 50 | 0 |   |
| rotation_error (deg) | 56.65 | 56.65 | 0 |   |
| runtime (min) | 5 | 6 | 1 | ns |
| episode_runtime (sec) | 33 | 37 | 4 | ns |
| num_episodes | 100 | 100 | 0 |   |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.57 | 98.57 | 0 |   |
| used_mlh (%) | 4.29 | 4.29 | 0 |   |
| match_steps | 53 | 53 | 0 |   |
| rotation_error (deg) | 3.53 | 3.53 | 0 |   |
| runtime (min) | 5 | 5 | 0 |   |
| episode_runtime (sec) | 22 | 21 | -1 | ns |
| num_episodes | 100 | 140 | 40 | ❌ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 88 | 88 | 0 |   |
| used_mlh (%) | 32 | 32 | 0 |   |
| match_steps | 202 | 202 | 0 |   |
| rotation_error (deg) | 30.3 | 30.3 | 0 |   |
| runtime (min) | 10 | 9 | -1 | ns |
| episode_runtime (sec) | 72 | 68 | -4 | ns |
| num_episodes | 100 | 100 | 0 |   |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 |   |
| used_mlh (%) | 28 | 28 | 0 |   |
| match_steps | 157 | 157 | 0 |   |
| rotation_error (deg) | 18.01 | 18.01 | 0 |   |
| runtime (min) | 18 | 16 | -2 | ns |
| episode_runtime (sec) | 153 | 128 | -25 | ns |
| num_episodes | 100 | 100 | 0 |   |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 67 | 67 | 0 |   |
| used_mlh (%) | 75 | 75 | 0 |   |
| match_steps | 13 | 13 | 0 |   |
| rotation_error (deg) | 105.66 | 105.66 | 0 |   |
| runtime (min) | 5 | 4 | -1 | ns |
| episode_runtime (sec) | 7 | 6 | -1 | ns |
| num_episodes | 100 | 100 | 0 |   |

### base_10multi_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 47.14 | 47.14 | 0 |   |
| used_mlh (%) | 4.29 | 4.29 | 0 |   |
| match_steps | 33 | 33 | 0 |   |
| rotation_error (deg) | 18.42 | 18.42 | 0 |   |
| runtime (min) | 37 | 41 | 4 | ns |
| episode_runtime (sec) | 2 | 2 | 0 |   |
| num_episodes | 140 | 140 | 0 |   |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 93.94 | 93.94 | 0 |   |
| used_mlh (%) | 10.39 | 10.39 | 0 |   |
| match_steps | 78 | 78 | 0 |   |
| rotation_error (deg) | 11.1 | 11.1 | 0 |   |
| runtime (min) | 14 | 15 | 1 | ns |
| episode_runtime (sec) | 39 | 40 | 1 | ns |
| num_episodes | 231 | 231 | 0 |   |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 |   |
| used_mlh (%) | 4.33 | 4.33 | 0 |   |
| match_steps | 45 | 45 | 0 |   |
| rotation_error (deg) | 4.08 | 4.14 | 0.06 | ❌ |
| runtime (min) | 12 | 12 | 0 |   |
| episode_runtime (sec) | 29 | 28 | -1 | ns |
| num_episodes | 231 | 231 | 0 |   |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 88.74 | 88.74 | 0 |   |
| used_mlh (%) | 17.75 | 17.75 | 0 |   |
| match_steps | 120 | 120 | 0 |   |
| rotation_error (deg) | 33.03 | 33.03 | 0 |   |
| runtime (min) | 30 | 30 | 0 |   |
| episode_runtime (sec) | 87 | 87 | 0 |   |
| num_episodes | 231 | 231 | 0 |   |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99.57 | 99.57 | 0 |   |
| used_mlh (%) | 20.35 | 20.35 | 0 |   |
| match_steps | 109 | 109 | 0 |   |
| rotation_error (deg) | 23.73 | 23.73 | 0 |   |
| runtime (min) | 34 | 36 | 2 | ns |
| episode_runtime (sec) | 110 | 117 | 7 | ns |
| num_episodes | 231 | 231 | 0 |   |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96.1 | 96.1 | 0 |   |
| used_mlh (%) | 1.3 | 1.3 | 0 |   |
| match_steps | 68 | 68 | 0 |   |
| rotation_error (deg) | 57.04 | 57.04 | 0 |   |
| runtime (min) | 15 | 17 | 2 | ns |
| episode_runtime (sec) | 138 | 156 | 18 | ns |
| num_episodes | 77 | 77 | 0 |   |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 |   |
| match_steps | 97 | 97 | 0 |   |
| runtime (min) | 12 | 13 | 1 | ns |
| episode_runtime (sec) | 5 | 5 | 0 |   |
| num_episodes | 100 | 100 | 0 |   |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 |   |
| match_steps | 98 | 98 | 0 |   |
| runtime (min) | 25 | 23 | -2 | ns |
| episode_runtime (sec) | 12 | 11 | -1 | ns |
| num_episodes | 100 | 100 | 0 |   |

### infer_comp_lvl1_with_monolithic_models

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 89.29 | 89.29 | 0 |   |
| used_mlh (%) | 84.52 | 84.52 | 0 |   |
| match_steps | 415 | 415 | 0 |   |
| rotation_error (deg) | 56.28 | 56.28 | 0 |   |
| avg_prediction_error | 0.35 | 0.35 | 0 |   |
| runtime (min) | 35 | 34 | -1 | ns |
| num_episodes | 84 | 84 | 0 |   |

### infer_comp_lvl1_with_comp_models

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 85.71 | 85.71 | 0 |   |
| used_mlh (%) | 35.71 | 35.71 | 0 |   |
| match_steps | 35 | 35 | 0 |   |
| rotation_error (deg) | 51.47 | 51.47 | 0 |   |
| avg_prediction_error | 0.34 | 0.34 | 0 |   |
| runtime (min) | 4 | 3 | -1 | ns |
| num_episodes | 84 | 84 | 0 |   |

### infer_comp_lvl2_with_comp_models

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 85.71 | 85.71 | 0 |   |
| used_mlh (%) | 35.71 | 35.71 | 0 |   |
| match_steps | 40 | 40 | 0 |   |
| rotation_error (deg) | 53.9 | 53.9 | 0 |   |
| avg_prediction_error | 0.33 | 0.33 | 0 |   |
| runtime (min) | 11 | 10 | -1 | ns |
| num_episodes | 210 | 210 | 0 |   |

### infer_comp_lvl3_with_comp_models

| Metric | Baseline | Proposed | Δ | Changed |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 64 | 64 | 0 |   |
| used_mlh (%) | 52.86 | 52.86 | 0 |   |
| match_steps | 34 | 34 | 0 |   |
| rotation_error (deg) | 50.29 | 50.29 | 0 |   |
| avg_prediction_error | 0.34 | 0.34 | 0 |   |
| runtime (min) | 16 | 15 | -1 | ns |
| num_episodes | 350 | 350 | 0 |   |
