### PR TITLE
fix!: update MMW environment interface classes to use quat tuple for rotation

### DIFF
--- a/src/tbp/monty/frameworks/environments/embodied_data.py
+++ b/src/tbp/monty/frameworks/environments/embodied_data.py
@@ -15,7 +15,6 @@ from pprint import pformat
 from typing import Mapping, Sequence, cast
 
 import numpy as np
-import quaternion as qt
 from omegaconf import ListConfig
 
 from tbp.monty.frameworks.actions.actions import (
@@ -494,7 +493,7 @@ class OmniglotEnvironmentInterface(EnvironmentInterfacePerObject):
         self.current_object = idx
         self.primary_target = {
             "object": self.object_names[idx],
-            "rotation": qt.quaternion(0, 0, 0, 1),
+            "rotation": (0.0, 0.0, 0.0, 1.0),
             "euler_rotation": np.array([0, 0, 0]),
             "quat_rotation": [0, 0, 0, 1],
             "position": np.array([0, 0, 0]),
@@ -592,7 +591,7 @@ class SaccadeOnImageEnvironmentInterface(EnvironmentInterfacePerObject):
         target_object_formatted = "_".join(target_object.split("_")[1:])
         self.primary_target = {
             "object": target_object_formatted,
-            "rotation": qt.quaternion(0, 0, 0, 1),
+            "rotation": (0.0, 0.0, 0.0, 1.0),
             "euler_rotation": np.array([0, 0, 0]),
             "quat_rotation": [0, 0, 0, 1],
             "position": np.array([0, 0, 0]),
@@ -667,7 +666,7 @@ class SaccadeOnImageFromStreamEnvironmentInterface(SaccadeOnImageEnvironmentInte
         # targets corresponding to the current scene ?
         self.primary_target = {
             "object": "no_label",
-            "rotation": qt.quaternion(0, 0, 0, 1),
+            "rotation": (0.0, 0.0, 0.0, 1.0),
             "euler_rotation": np.array([0, 0, 0]),
             "quat_rotation": [0, 0, 0, 1],
             "position": np.array([0, 0, 0]),


### PR DESCRIPTION
In the commit [ce9ad8c7c6ac](https://github.com/thousandbrainsproject/tbp.monty/commit/ce9ad8c7c6ac24afe51212a8a7252f477277071f#diff-f8505253614619f74769d6b8402efe46cb03a96e8d42ca823df6067fcda626e5), we modified the `logging_utils` such that it now assumes the primary target rotation is a Quaternion WXYZ tuple. While this is true for `EnvironmentInterfacePerObject`, it is false for the other Environment Interface classes that are used by Monty Meets World experiments, e.g., `SaccadeOnImageEnvironmentInterface`.

This PR updates the other environment interfaces to use the Quaternion WXYZ tuple in the primary target rotation fields.