### PR TITLE
docs: update Monty Meets World benchmarks

### DIFF
--- a/benchmarks/montymeetsworld.csv
+++ b/benchmarks/montymeetsworld.csv
@@ -1,7 +1,7 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-randrot_noise_sim_on_scan_monty_world,89.17,88.33,445,47,23,120
-world_image_on_scanned_model,68.75,70.83,415,12,14,48
-dark_world_image_on_scanned_model,25.00,14.58,235,8,9,48
-bright_world_image_on_scanned_model,39.58,66.67,414,12,14,48
-hand_intrusion_world_image_on_scanned_model,37.50,25.00,284,10,12,48
-multi_object_world_image_on_scanned_model,22.92,0.00,157,6,7,48
+randrot_noise_sim_on_scan_monty_world,89.17,88.33,445,25,179,120
+world_image_on_scanned_model,66.67,68.75,401,11,12,48
+dark_world_image_on_scanned_model,25.00,14.58,235,10,11,48
+bright_world_image_on_scanned_model,39.58,64.58,400,12,14,48
+hand_intrusion_world_image_on_scanned_model,37.50,25.00,280,12,13,48
+multi_object_world_image_on_scanned_model,22.92,0.00,157,7,8,48

--- a/docs/overview/benchmark-experiments.md
+++ b/docs/overview/benchmark-experiments.md
@@ -219,7 +219,7 @@ curl -O https://tbp-data-public-5e789bd48e75350c.s3.us-east-2.amazonaws.com/tbp.
 unzip worldimages.zip
 ```
 
-Finally, note that the world_image experimental runs **do not support running with multi-processing, so you cannot use the run_parallel.py script** when running these. This is because an appropriate object_init_sampler has yet to be defined for this experimental setup. All experiments are run with 16 CPUs for benchmarking purposes.
+Finally, note that the world_image experimental runs **do not support running with multi-processing, so you cannot use the run_parallel.py script** when running these. This is because an appropriate object_init_sampler has yet to be defined for this experimental setup. Note that this restriction does not apply to `randrot_noise_sim_on_scan_monty_world`, which can still be parallelized with `run_parallel.py`. All experiments are run with 16 CPUs for benchmarking purposes.
 
 See the [monty_lab project folder](https://github.com/thousandbrainsproject/monty_lab/tree/main/monty_meets_world) for the code.
 


### PR DESCRIPTION
This PR updates the MMW benchmark numbers since they have slightly changed with the last batch of refactoring. I also added a clarification on running one of the experiments with `run_parallel.py`.

Runs tagged with `PR#940` on WandB.

### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 89.17 | 89.17 | 0 | ⬜ |
| used_mlh (%) | 88.33 | 88.33 | 0 | ⬜ |
| match_steps | 445 | 445 | 0 | ⬜ |
| runtime (min) | 47 | 25 | -22 | ✅ |
| episode_runtime (sec) | 23 | 179 | 156 | ❌ |
| num_episodes | 120 | 120 | 0 | ⬜ |

### world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 68.75 | 66.67 | -2.08 | ❌ |
| used_mlh (%) | 70.83 | 68.75 | -2.08 | ✅ |
| match_steps | 415 | 401 | -14 | ✅ |
| runtime (min) | 12 | 11 | -1 | ✅ |
| episode_runtime (sec) | 14 | 12 | -2 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### dark_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 25 | 25 | 0 | ⬜ |
| used_mlh (%) | 14.58 | 14.58 | 0 | ⬜ |
| match_steps | 235 | 235 | 0 | ⬜ |
| runtime (min) | 8 | 10 | 2 | ❌ |
| episode_runtime (sec) | 9 | 11 | 2 | ❌ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### bright_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 39.58 | 39.58 | 0 | ⬜ |
| used_mlh (%) | 66.67 | 64.58 | -2.09 | ✅ |
| match_steps | 414 | 400 | -14 | ✅ |
| runtime (min) | 12 | 12 | 0 | ⬜ |
| episode_runtime (sec) | 14 | 14 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### hand_intrusion_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 37.5 | 37.5 | 0 | ⬜ |
| used_mlh (%) | 25 | 25 | 0 | ⬜ |
| match_steps | 284 | 280 | -4 | ✅ |
| runtime (min) | 10 | 12 | 2 | ❌ |
| episode_runtime (sec) | 12 | 13 | 1 | ❌ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### multi_object_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 22.92 | 22.92 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 157 | 157 | 0 | ⬜ |
| runtime (min) | 6 | 7 | 1 | ❌ |
| episode_runtime (sec) | 7 | 8 | 1 | ❌ |
| num_episodes | 48 | 48 | 0 | ⬜ |
