### PR TITLE
fix: update connectivity configuration for monolithic experiments

### DIFF
--- a/src/tbp/monty/conf/experiment/infer_comp_lvl1_with_monolithic_models.yaml
+++ b/src/tbp/monty/conf/experiment/infer_comp_lvl1_with_monolithic_models.yaml
@@ -5,7 +5,7 @@ defaults:
   - /monty/motor_system_config: informed_5_goal1
   - /monty/learning_module: evidence_2lm_gsg
   - /monty/sensor_module: 2sm_camera_dist
-  - /monty/connectivity: 2lm_2sm
+  - /monty/connectivity: 2lm_2sm_monolithic
   - /environment: habitat_dist_agent_sensors2
   - /env_interface: eval_compositional_lvl1_predefined
   - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch0

--- a/src/tbp/monty/conf/experiment/supervised_pre_training_objects_with_logos_lvl1_monolithic_models.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_objects_with_logos_lvl1_monolithic_models.yaml
@@ -5,7 +5,7 @@ defaults:
   - /monty/motor_system_config: naive_scan_5
   - /monty/learning_module: evidence_2lm
   - /monty/sensor_module: 2sm_camera_dist
-  - /monty/connectivity: 2lm_2sm
+  - /monty/connectivity: 2lm_2sm_monolithic
   - /environment: habitat_dist_agent_sensors2
   - /env_interface: train_lvl1_predefined
   - /env_interface/positioning_procedures_train: getgoodview_viewfinder_patch0

--- a/src/tbp/monty/conf/monty/connectivity/2lm_2sm_monolithic.yaml
+++ b/src/tbp/monty/conf/monty/connectivity/2lm_2sm_monolithic.yaml
@@ -1,0 +1,11 @@
+# @package experiment.config.monty_config
+
+sm_to_agent_dict:
+  patch_0: agent_id_0
+  patch_1: agent_id_0
+  view_finder: agent_id_0
+sm_to_lm_matrix:
+  - - 0
+  - - 1
+lm_to_lm_matrix: null
+lm_to_lm_vote_matrix: null

--- a/tests/conf/snapshots/infer_comp_lvl1_with_monolithic_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl1_with_monolithic_models.yaml
@@ -133,9 +133,7 @@ experiment:
       sm_to_lm_matrix:
       - - 0
       - - 1
-      lm_to_lm_matrix:
-      - []
-      - - 0
+      lm_to_lm_matrix: null
       lm_to_lm_vote_matrix: null
     environment:
       env_init_args:

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_monolithic_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_monolithic_models.yaml
@@ -118,9 +118,7 @@ experiment:
       sm_to_lm_matrix:
       - - 0
       - - 1
-      lm_to_lm_matrix:
-      - []
-      - - 0
+      lm_to_lm_matrix: null
       lm_to_lm_vote_matrix: null
     environment:
       env_init_args:


### PR DESCRIPTION
The monolithic logos on objects experiment currently uses the same heterarchy components and connectivity as the compositional experiments. During a monolithic learning run, we set the LL-LM to training mode and provide it with the parent graph_id. This will ideally prevent the LL-LM from sending its object hypothesis to the HL-LM but we have a statement in `switch_to_exploratory_mode` function that [increases the mlh evidence](https://github.com/thousandbrainsproject/tbp.monty/blob/c474e90087f786ee766e5f976a64030961488a9f/src/tbp/monty/frameworks/models/evidence_matching/model.py?plain=1#L103-L112) to above the `object_evidence_threshold` causing the LL-LM to send CMP messages to the HL-LM with the graph_id `no_observations_yet`. This is undesired and unexpected in the monolithic experiments because we don't want to store a graph in the HL-LM for the LL-LM input channel during learning.

A cleaner solution would be to modify the connectivity configurations, specifically the `lm_to_lm_matrix`, to remove any connections from the LL-LM to the HL-LM and keep everything else the same. This is the solution proposed here.

**Note that there is no expected change in the results other than a reduction in the prediction error. The prediction error is calculated as the [average over channels](https://github.com/thousandbrainsproject/tbp.monty/blob/c474e90087f786ee766e5f976a64030961488a9f/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py?plain=1#L1305-L1306), so removing this incorrect channel (LL-LM) should lower the prediction error.**

### Benchmark Experiments

I ran the benchmarks for the logos on objects and got similar results, as shown below. I will open another PR with changes to the documentations and updating the pretrained models to V3.

### infer_comp_lvl1_with_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 89.29 | 89.29 | 0 | ⬜ |
| used_mlh (%) | 84.52 | 84.52 | 0 | ⬜ |
| match_steps | 415 | 415 | 0 | ⬜ |
| rotation_error (deg) | 56.28 | 56.28 | 0 | ⬜ |
| avg_prediction_error | 0.35 | 0.25 | -0.1 | ✅ |
| runtime (min) | 34 | 37 | 3 | ❌ |
| num_episodes | 84 | 84 | 0 | ⬜ |
