### PR TITLE
chore: version 0.32.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,7 +8,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.31.0"
+__version__ = "0.32.0"
 
 import sys
 


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since 0.31.0.

<img width="2352" height="2410" alt="image" src="https://github.com/user-attachments/assets/534f01ff-7205-4f1c-be82-c3baf8175121" />

## feat!: Implement NoopAgent in MuJoCo #876
Implemented a NoopAgent that doesn't respond to actions for the MuJoCo simulator. Marked as breaking because of changes to the `ObjectEnvironment` protocol `add_object` method, and the removal of the `Simulator` protocol (it is the same as `SimulatedObjectEnvironment`)

## fix!: update MMW environment interface classes to use quat tuple for rotation #939
Marked as a breaking change by mistake.

## fix!: update connectivity configuration for monolithic experiments #942
Marked as a breaking change by mistake.