### PR TITLE
chore: remove unused gsg configuration from world benchmarks

### DIFF
--- a/benchmarks/montymeetsworld.csv
+++ b/benchmarks/montymeetsworld.csv
@@ -1,7 +1,7 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-randrot_noise_sim_on_scan_monty_world,89.17,88.33,445,25,179,120
-world_image_on_scanned_model,66.67,68.75,401,11,12,48
-dark_world_image_on_scanned_model,25.00,14.58,235,10,11,48
-bright_world_image_on_scanned_model,39.58,64.58,400,12,14,48
-hand_intrusion_world_image_on_scanned_model,37.50,25.00,280,12,13,48
-multi_object_world_image_on_scanned_model,22.92,0.00,157,7,8,48
+randrot_noise_sim_on_scan_monty_world,88.33,90.00,456,26,189,120
+world_image_on_scanned_model,68.75,68.75,403,12,13,48
+dark_world_image_on_scanned_model,29.17,14.58,234,8,9,48
+bright_world_image_on_scanned_model,37.50,62.50,400,12,14,48
+hand_intrusion_world_image_on_scanned_model,37.50,27.08,277,10,11,48
+multi_object_world_image_on_scanned_model,22.92,2.08,155,6,7,48

--- a/src/tbp/monty/conf/monty/learning_module/evidence_1lm_nn10_dod003_dts02.yaml
+++ b/src/tbp/monty/conf/monty/learning_module/evidence_1lm_nn10_dod003_dts02.yaml
@@ -19,12 +19,4 @@ learning_module_0:
     evidence_threshold_config: all
     max_graph_size: 0.3
     num_model_voxels_per_dim: 100
-    gsg:
-      _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
-      goal_tolerances:
-        location: 0.015
-      elapsed_steps_factor: 10
-      min_post_goal_success_steps: 5
-      x_percent_scale_factor: 0.75
-      desired_object_distance: 0.03
   learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}

--- a/tests/conf/snapshots/bright_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/bright_world_image_on_scanned_model.yaml
@@ -46,14 +46,6 @@ experiment:
             evidence_threshold_config: all
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
-            gsg:
-              _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
-              goal_tolerances:
-                location: 0.015
-              elapsed_steps_factor: 10
-              min_post_goal_success_steps: 5
-              x_percent_scale_factor: 0.75
-              desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_module_configs:
         sensor_module_0:

--- a/tests/conf/snapshots/dark_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/dark_world_image_on_scanned_model.yaml
@@ -46,14 +46,6 @@ experiment:
             evidence_threshold_config: all
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
-            gsg:
-              _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
-              goal_tolerances:
-                location: 0.015
-              elapsed_steps_factor: 10
-              min_post_goal_success_steps: 5
-              x_percent_scale_factor: 0.75
-              desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_module_configs:
         sensor_module_0:

--- a/tests/conf/snapshots/hand_intrusion_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/hand_intrusion_world_image_on_scanned_model.yaml
@@ -46,14 +46,6 @@ experiment:
             evidence_threshold_config: all
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
-            gsg:
-              _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
-              goal_tolerances:
-                location: 0.015
-              elapsed_steps_factor: 10
-              min_post_goal_success_steps: 5
-              x_percent_scale_factor: 0.75
-              desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_module_configs:
         sensor_module_0:

--- a/tests/conf/snapshots/multi_object_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/multi_object_world_image_on_scanned_model.yaml
@@ -46,14 +46,6 @@ experiment:
             evidence_threshold_config: all
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
-            gsg:
-              _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
-              goal_tolerances:
-                location: 0.015
-              elapsed_steps_factor: 10
-              min_post_goal_success_steps: 5
-              x_percent_scale_factor: 0.75
-              desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_module_configs:
         sensor_module_0:

--- a/tests/conf/snapshots/randrot_noise_sim_on_scan_monty_world.yaml
+++ b/tests/conf/snapshots/randrot_noise_sim_on_scan_monty_world.yaml
@@ -46,14 +46,6 @@ experiment:
             evidence_threshold_config: all
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
-            gsg:
-              _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
-              goal_tolerances:
-                location: 0.015
-              elapsed_steps_factor: 10
-              min_post_goal_success_steps: 5
-              x_percent_scale_factor: 0.75
-              desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_module_configs:
         sensor_module_0:

--- a/tests/conf/snapshots/world_image_from_stream_on_scanned_model.yaml
+++ b/tests/conf/snapshots/world_image_from_stream_on_scanned_model.yaml
@@ -46,14 +46,6 @@ experiment:
             evidence_threshold_config: all
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
-            gsg:
-              _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
-              goal_tolerances:
-                location: 0.015
-              elapsed_steps_factor: 10
-              min_post_goal_success_steps: 5
-              x_percent_scale_factor: 0.75
-              desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_module_configs:
         sensor_module_0:

--- a/tests/conf/snapshots/world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/world_image_on_scanned_model.yaml
@@ -46,14 +46,6 @@ experiment:
             evidence_threshold_config: all
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
-            gsg:
-              _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
-              goal_tolerances:
-                location: 0.015
-              elapsed_steps_factor: 10
-              min_post_goal_success_steps: 5
-              x_percent_scale_factor: 0.75
-              desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_module_configs:
         sensor_module_0:


### PR DESCRIPTION
For monty-meets-world benchmark experiments, the motor policy is configured to not use goal-driven actions. For example:
```yaml
#      motor_system_config:
#        policy_selector:
#          policy:
#            action_sampler:
#              _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
#              actions:
#              - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}
#              - ${monty.class:tbp.monty.frameworks.actions.actions.LookDown}
#              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
#              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
#              rotation_degrees: 20.0
#            _target_: tbp.monty.frameworks.models.motor_policies.InformedPolicy
             use_goal_driven_actions: false
#            agent_id: agent_id_0
#          _target_: tbp.monty.frameworks.models.motor_policy_selectors.SinglePolicySelector
#        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
```
However, the LMs in these experiments are still configured with a `gsg`. Therefore, all generated goals are ignored.

This pull request removes unused goal generator configuration from the learning modules, so we don't waste time generating goals that we then discard.

## Benchmarks

The benchmarks changed because [`EvidenceGoalGenerator` accesses `ctx.rng.uniform()`](https://github.com/thousandbrainsproject/tbp.monty/blob/9c49b957fefd873de2f69a64ab168215c6469f48/src/tbp/monty/frameworks/models/goal_generation.py#L940): 
```python
if (len(pm_smaller_thresh) == 1 and (ctx.rng.uniform() <= 0.5)) or len(
            pm_base_thresh
        ) == 1:
        # ...
```
With the removal, the RNG access sequence is changed, resulting in benchmark variation for monty-meets-world experiments.

Note: Only monty-meets-world experiments have been modified (see diff of snapshots), so benchmark updates are limited to those 6 experiments.


### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 88.33 | 89.17 | 0.84 | ✅ |
| used_mlh (%) | 90 | 88.33 | -1.67 | ✅ |
| match_steps | 456 | 445 | -11 | ✅ |
| runtime (min) | 26 | 25 | -1 | ✅ |
| episode_runtime (sec) | 189 | 179 | -10 | ✅ |
| num_episodes | 120 | 120 | 0 | ⬜ |

### world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 68.75 | 66.67 | -2.08 | ❌ |
| used_mlh (%) | 68.75 | 68.75 | 0 | ⬜ |
| match_steps | 403 | 401 | -2 | ✅ |
| runtime (min) | 12 | 11 | -1 | ✅ |
| episode_runtime (sec) | 13 | 12 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### dark_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 29.17 | 25 | -4.17 | ❌ |
| used_mlh (%) | 14.58 | 14.58 | 0 | ⬜ |
| match_steps | 234 | 235 | 1 | ❌ |
| runtime (min) | 8 | 10 | 2 | ❌ |
| episode_runtime (sec) | 9 | 11 | 2 | ❌ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### bright_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 37.5 | 39.58 | 2.08 | ✅ |
| used_mlh (%) | 62.5 | 64.58 | 2.08 | ❌ |
| match_steps | 400 | 400 | 0 | ⬜ |
| runtime (min) | 12 | 12 | 0 | ⬜ |
| episode_runtime (sec) | 14 | 14 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### hand_intrusion_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 37.5 | 37.5 | 0 | ⬜ |
| used_mlh (%) | 27.08 | 25 | -2.08 | ✅ |
| match_steps | 277 | 280 | 3 | ❌ |
| runtime (min) | 10 | 12 | 2 | ❌ |
| episode_runtime (sec) | 11 | 13 | 2 | ❌ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### multi_object_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 22.92 | 22.92 | 0 | ⬜ |
| used_mlh (%) | 2.08 | 0 | -2.08 | ✅ |
| match_steps | 155 | 157 | 2 | ❌ |
| runtime (min) | 6 | 7 | 1 | ❌ |
| episode_runtime (sec) | 7 | 8 | 1 | ❌ |
| num_episodes | 48 | 48 | 0 | ⬜ |
