### PR TITLE
fix: episode stats for burst frequency logging

### DIFF
--- a/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
+++ b/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
@@ -462,6 +462,7 @@ class BasicGraphMatchingLogger(BaseMontyLogger):
             "episode/goal_states_attempted": stats["goal_states_attempted"],
             "episode/goal_state_success_rate": stats["goal_state_success_rate"],
             "episode/avg_prediction_error": stats["episode_avg_prediction_error"],
+            "episode/num_bursts": stats["episode_num_bursts"],
         }
 
         for p in self.performance_options:


### PR DESCRIPTION
I missed a line in the [burst frequency logging PR](https://github.com/thousandbrainsproject/tbp.monty/pull/952). It is currently causing the experiments to fail during logging.