### PR TITLE
chore: version 0.33.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,7 +8,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.32.0"
+__version__ = "0.33.0"
 
 import sys
 


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since 0.32.0.

<img width="1033" height="952" alt="Screenshot 2026-04-30 at 13 39 25" src="https://github.com/user-attachments/assets/65305cae-6694-4bef-beba-95752a03a06a" />

## feat!: refactored InformedPolicy into JumpToGoal and InformedPolicyRandomWalk (#917)

Removed (unused) `use_goal_driven_actions` property from `PredefinedPolicy`.

## refactor!: remove channel tracking from hypothesis spaces (#851)

The PR changes many classes:
- `EvidenceGraphLM`: Removed `channel_hypothesis_mapping`, we are no longer tracking input channels.
- `DefaultHypothesesUpdater`: Modified the `update_hypotheses` to handle initializing new channels in the first step and in later steps. When a new channel is initialized later in the episode, it gets the mean of hypotheses evidence added to the initial evidence score. This is now handled in the hypothesis updater instead of in the LM.
- `BurstSamplingHypothesesUpdater`: The sampling multiplier is now in the range [0, 1], where 0 means no sampling and 1 means the total number of available informed hypothesis (graph nodes * hyps per node). Sampling is now computed proportionally per-channel based on the graph size and PC-defined.
- `DefaultHypothesesDisplacer`: It now takes multiple channels for features and displacements together. It displaces all hypotheses in a single step (possibly saving computations), then performs feature matching for every channel separately and sums up the evidence.
- `ChannelMapper`: Removed.
- `EvidenceSlopeTracker`: Simplified by removing the channel parameter from all functions. The tracker now operates on the full hypothesis space.
- Telemetry classes were updated and flattened. We do not log channel names in hypothesis spaces anymore. Will need to update visualizations.

## refactor!: environment interface is part of experiment code (#953)

- `tbp.monty.frameworks.environments.embodied_data.py` is moved to `tbp.monty.experiment.environment.py`
- `*EnvironmentInterface*` classes are renamed to `*Interface*` to reduce stuttering with `tbp.monty.experiment.environment` module they are now in.
