### PR TITLE
refactor!: rename world_camera to cam_to_world

### DIFF
--- a/src/tbp/monty/frameworks/environment_utils/transforms.py
+++ b/src/tbp/monty/frameworks/environment_utils/transforms.py
@@ -540,7 +540,7 @@ class DepthTo3DLocations(Transform):
                     reference frame and are in the sensor's reference frame otherwise.
                     It is structured as a 2D array with shape (n_pixels, 4) with
                     columns containing x-, y-, z-coordinates, and a semantic ID.
-                - "world_camera": Sensor-to-world coordinate frame transform. Included
+                - "cam_to_world": Sensor-to-world coordinate frame transform. Included
                     only when `self.world_coord` is `True` (default).
                 - "sensor_frame_data": 3D coordinates for each pixel relative to the
                     sensor. Has the same structure as "semantic_3d". Included only
@@ -627,14 +627,14 @@ class DepthTo3DLocations(Transform):
                 sensor_translation_rel_world = agent_position + rotated_sensor_position
                 # Apply the rotation and translation to get the world coordinates
                 rotation_matrix = qt.as_rotation_matrix(sensor_rotation_rel_world)
-                world_camera = np.eye(4)
-                world_camera[0:3, 0:3] = rotation_matrix
-                world_camera[0:3, 3] = sensor_translation_rel_world
-                xyz = np.matmul(world_camera, xyz)
+                cam_to_world = np.eye(4)
+                cam_to_world[0:3, 0:3] = rotation_matrix
+                cam_to_world[0:3, 3] = sensor_translation_rel_world
+                xyz = np.matmul(cam_to_world, xyz)
 
                 # Add sensor-to-world coordinate frame transform, used for surface
                 # normal extraction. View direction is the third column of the matrix.
-                observations[self.agent_id][sensor_id]["world_camera"] = world_camera
+                observations[self.agent_id][sensor_id]["cam_to_world"] = cam_to_world
 
             # Extract 3D coordinates of detected objects (semantic_id != 0)
             semantic = surface_patch.reshape(1, -1)

--- a/src/tbp/monty/frameworks/environment_utils/transforms.py
+++ b/src/tbp/monty/frameworks/environment_utils/transforms.py
@@ -627,10 +627,10 @@ class DepthTo3DLocations(Transform):
                 sensor_translation_rel_world = agent_position + rotated_sensor_position
                 # Apply the rotation and translation to get the world coordinates
                 rotation_matrix = qt.as_rotation_matrix(sensor_rotation_rel_world)
-                cam_to_world = np.eye(4)
+                cam_to_world = np.identity(4)
                 cam_to_world[0:3, 0:3] = rotation_matrix
                 cam_to_world[0:3, 3] = sensor_translation_rel_world
-                xyz = np.matmul(cam_to_world, xyz)
+                xyz = cam_to_world @ xyz
 
                 # Add sensor-to-world coordinate frame transform, used for surface
                 # normal extraction. View direction is the third column of the matrix.

--- a/src/tbp/monty/frameworks/environments/two_d_data.py
+++ b/src/tbp/monty/frameworks/environments/two_d_data.py
@@ -355,7 +355,7 @@ class SaccadeOnImageEnvironment(SimulatedEnvironment):
                                 "rgba": rgb_patch,
                                 "semantic_3d": depth3d_patch,
                                 "sensor_frame_data": sensor_frame_patch,
-                                "world_camera": self.world_camera,
+                                "cam_to_world": self.cam_to_world,
                                 # Save pixel loc for plotting
                                 "pixel_loc": self.current_loc,
                             }
@@ -439,7 +439,7 @@ class SaccadeOnImageEnvironment(SimulatedEnvironment):
                                 "rgba": rgb_patch,
                                 "semantic_3d": depth3d_patch,
                                 "sensor_frame_data": sensor_frame_patch,
-                                "world_camera": self.world_camera,
+                                "cam_to_world": self.cam_to_world,
                                 "pixel_loc": np.array(self.current_loc),
                             }
                         ),
@@ -586,7 +586,7 @@ class SaccadeOnImageEnvironment(SimulatedEnvironment):
         current_sf_scene_point_cloud = current_sf_scene_point_cloud.reshape(
             (image_shape[0], image_shape[1], 4)
         )
-        self.world_camera = obs_3d[agent_id][sensor_id]["world_camera"]
+        self.cam_to_world = obs_3d[agent_id][sensor_id]["cam_to_world"]
         return current_scene_point_cloud, current_sf_scene_point_cloud
 
     def get_3d_coordinates_from_pixel_indices(

--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -48,7 +48,7 @@ class SensorObservation(TypedDict, total=False):
     semantic: npt.NDArray[np.int_]  # TODO: Verify specific type
     semantic_3d: npt.NDArray[np.int_]  # TODO: Verify specific type
     sensor_frame_data: npt.NDArray[np.int_]  # TODO: Verify specific type
-    world_camera: npt.NDArray[np.float64]  # TODO: Verify specific type
+    cam_to_world: npt.NDArray[np.float64]  # TODO: Verify specific type
     pixel_loc: npt.NDArray[np.float64]  # TODO: Verify specific type
     raw: npt.NDArray[np.uint8]
 

--- a/src/tbp/monty/frameworks/models/sensor_modules.py
+++ b/src/tbp/monty/frameworks/models/sensor_modules.py
@@ -194,7 +194,7 @@ class ObservationProcessor:
         """
         obs_3d = observation["semantic_3d"]
         sensor_frame_data = observation["sensor_frame_data"]
-        world_camera = observation["world_camera"]
+        cam_to_world = observation["cam_to_world"]
         rgba_feat = observation["rgba"]
         depth_feat = (
             observation["depth"]
@@ -231,7 +231,7 @@ class ObservationProcessor:
                 center_id,
                 center_row_col,
                 sensor_frame_data,
-                world_camera,
+                cam_to_world,
             )
         else:
             valid_signals = False
@@ -270,7 +270,7 @@ class ObservationProcessor:
         center_id: int,
         center_row_col: int,
         sensor_frame_data: np.ndarray,
-        world_camera: np.ndarray,
+        cam_to_world: np.ndarray,
     ) -> tuple[dict[str, Any], dict[str, Any], bool]:
         """Extract features configured for extraction from sensor patch.
 
@@ -286,7 +286,7 @@ class ObservationProcessor:
         # ------------ Extract Morphological Features ------------
         # Get surface normal for graph matching with features
         surface_normal, valid_sn = self._get_surface_normals(
-            obs_3d, sensor_frame_data, center_id, world_camera
+            obs_3d, sensor_frame_data, center_id, cam_to_world
         )
 
         k1, k2, dir1, dir2, valid_pc = principal_curvatures(
@@ -362,15 +362,15 @@ class ObservationProcessor:
         obs_3d: np.ndarray,
         sensor_frame_data: np.ndarray,
         center_id: int,
-        world_camera: np.ndarray,
+        cam_to_world: np.ndarray,
     ) -> tuple[np.ndarray, bool]:
         if self._surface_normal_method == SurfaceNormalMethod.TLS:
             surface_normal, valid_sn = surface_normal_total_least_squares(
-                obs_3d, center_id, world_camera[:3, 2]
+                obs_3d, center_id, cam_to_world[:3, 2]
             )
         elif self._surface_normal_method == SurfaceNormalMethod.OLS:
             surface_normal, valid_sn = surface_normal_ordinary_least_squares(
-                sensor_frame_data, world_camera, center_id
+                sensor_frame_data, cam_to_world, center_id
             )
         elif self._surface_normal_method == SurfaceNormalMethod.NAIVE:
             surface_normal, valid_sn = surface_normal_naive(

--- a/src/tbp/monty/frameworks/models/two_d_sensor_module.py
+++ b/src/tbp/monty/frameworks/models/two_d_sensor_module.py
@@ -266,7 +266,7 @@ class TwoDSensorModule(SensorModule):
 
         pose_2d = _angle_to_pose_2d(
             edge.angle,
-            observation["world_camera"],
+            observation["cam_to_world"],
             surface_normal=surface_normal_3d,
             tangent_frame=self._tangent_frame,
         )

--- a/src/tbp/monty/frameworks/utils/edge_detection.py
+++ b/src/tbp/monty/frameworks/utils/edge_detection.py
@@ -45,7 +45,7 @@ def _gradient_to_tangent_angle(gradient_angle: float) -> float:
 
 def _angle_to_pose_2d(
     angle: float,
-    world_camera: np.ndarray,
+    cam_to_world: np.ndarray,
     surface_normal: np.ndarray,
     tangent_frame: TangentFrame,
 ) -> np.ndarray:
@@ -58,7 +58,7 @@ def _angle_to_pose_2d(
         angle: Edge angle in radians in image coordinates (y-down), measured
             from the image x-axis toward the image y-axis (i.e., toward the
             bottom of the image).
-        world_camera: 4x4 camera-to-world transformation matrix.
+        cam_to_world: 4x4 camera-to-world transformation matrix.
         surface_normal: Surface normal defining the local tangent plane.
         tangent_frame: Orthonormal local basis used for the 2D model.
 
@@ -66,7 +66,7 @@ def _angle_to_pose_2d(
         3x3 array whose rows are [normal, edge_tangent, edge_perp].
         Normal is always [0, 0, 1]; tangent and perp lie in local 2D coordinates.
     """
-    R = world_camera[:3, :3]  # noqa: N806
+    R = cam_to_world[:3, :3]  # noqa: N806
     image_x_world = R @ np.array([1.0, 0.0, 0.0])
     image_y_world = R @ np.array([0.0, -1.0, 0.0])
 

--- a/src/tbp/monty/frameworks/utils/sensor_processing.py
+++ b/src/tbp/monty/frameworks/utils/sensor_processing.py
@@ -328,7 +328,7 @@ def surface_normal_naive(point_cloud, patch_radius_frac=2.5):
 
 
 def surface_normal_ordinary_least_squares(
-    sensor_frame_data, world_camera, center_id, neighbor_patch_frac=3.2
+    sensor_frame_data, cam_to_world, center_id, neighbor_patch_frac=3.2
 ):
     """Extracts the surface normal direction from a noisy point cloud.
 
@@ -338,7 +338,7 @@ def surface_normal_ordinary_least_squares(
     Args:
         sensor_frame_data: Point cloud in sensor coordinates (assumes the full
             patch is provided, i.e., no preliminary filtering of off-object points).
-        world_camera: Matrix defining the sensor-to-world frame transformation.
+        cam_to_world: Matrix defining the sensor-to-world frame transformation.
         center_id: ID of the center point in the point cloud.
         neighbor_patch_frac: Fraction of the patch width that defines the
             local neighborhood within which to perform the least-squares fitting.
@@ -377,7 +377,7 @@ def surface_normal_ordinary_least_squares(
                 surface_normal *= -1
 
             # Express surface normal back to world coordinate frame
-            surface_normal = np.matmul(world_camera[:3, :3], surface_normal)
+            surface_normal = np.matmul(cam_to_world[:3, :3], surface_normal)
 
         else:  # Not enough point to compute
             surface_normal = np.array([0.0, 0.0, 1.0])

--- a/tests/unit/frameworks/environment_utils/habitat_transform_test.py
+++ b/tests/unit/frameworks/environment_utils/habitat_transform_test.py
@@ -234,11 +234,11 @@ class HabitatTransformTest(unittest.TestCase):
 
         translation = agent_position + agent_rotation_matrix @ sensor_position
 
-        world_camera = np.eye(4)
-        world_camera[0:3, 0:3] = rotation_matrix
-        world_camera[0:3, 3] = translation
+        cam_to_world = np.eye(4)
+        cam_to_world[0:3, 0:3] = rotation_matrix
+        cam_to_world[0:3, 3] = translation
 
-        points_world = (world_camera @ points_camera).T
+        points_world = (cam_to_world @ points_camera).T
 
         expected_semantic_id = np.unique(semantic_obs[semantic_obs.nonzero()])[0]
 

--- a/tests/unit/frameworks/environment_utils/habitat_transform_test.py
+++ b/tests/unit/frameworks/environment_utils/habitat_transform_test.py
@@ -234,7 +234,7 @@ class HabitatTransformTest(unittest.TestCase):
 
         translation = agent_position + agent_rotation_matrix @ sensor_position
 
-        cam_to_world = np.eye(4)
+        cam_to_world = np.identity(4)
         cam_to_world[0:3, 0:3] = rotation_matrix
         cam_to_world[0:3, 3] = translation
 

--- a/tests/unit/frameworks/models/two_d_sensor_module_test.py
+++ b/tests/unit/frameworks/models/two_d_sensor_module_test.py
@@ -117,7 +117,7 @@ def make_no_edge() -> EdgeFeatures:
 def make_raw_observation(
     *, center_location: np.ndarray, semantic_id: int
 ) -> SensorObservation:
-    obs = sensor_observation(angle=None, world_camera=np.identity(4))
+    obs = sensor_observation(angle=None, cam_to_world=np.identity(4))
 
     semantic_3d = np.zeros((PATCH_SIZE * PATCH_SIZE, 4), dtype=np.float64)
     semantic_3d[:, :3] = center_location

--- a/tests/unit/frameworks/utils/edge_detection_test.py
+++ b/tests/unit/frameworks/utils/edge_detection_test.py
@@ -48,7 +48,7 @@ a_scalar = st.floats(min_value=DEFAULT_TOLERANCE, max_value=100.0)
 class EdgeDetectorExpectedValues(NamedTuple):
     name: str
     angle: float
-    world_camera: np.ndarray  # 3x3
+    cam_to_world: np.ndarray
     surface_normal: np.ndarray
     expected_pose_2d: np.ndarray
 
@@ -57,7 +57,7 @@ CASES = [
     EdgeDetectorExpectedValues(
         name="identity_camera_vertical_edge",
         angle=np.pi / 2,
-        world_camera=np.identity(4),
+        cam_to_world=np.identity(4),
         surface_normal=np.array([0.0, 0.0, 1.0]),
         expected_pose_2d=np.array(
             [
@@ -70,7 +70,7 @@ CASES = [
     EdgeDetectorExpectedValues(
         name="identity_camera_diagonal_edge",
         angle=np.pi / 4,
-        world_camera=np.identity(4),
+        cam_to_world=np.identity(4),
         surface_normal=np.array([0.0, 0.0, 1.0]),
         expected_pose_2d=np.array(
             [
@@ -83,7 +83,7 @@ CASES = [
     EdgeDetectorExpectedValues(
         name="identity_camera_horizontal_edge",
         angle=np.pi,
-        world_camera=np.identity(4),
+        cam_to_world=np.identity(4),
         surface_normal=np.array([0.0, 0.0, 1.0]),
         expected_pose_2d=np.array(
             [
@@ -96,7 +96,7 @@ CASES = [
     EdgeDetectorExpectedValues(
         name="rotated_camera_surface_x_horizontal_edge",
         angle=np.pi,
-        world_camera=np.array(
+        cam_to_world=np.array(
             [
                 [0.0, -1.0, 0.0, 0.0],
                 [1.0, 0.0, 0.0, 0.0],
@@ -116,7 +116,7 @@ CASES = [
     EdgeDetectorExpectedValues(
         name="camera_y_to_world_z_surface_y_diagonal_edge",
         angle=np.pi / 4,
-        world_camera=np.array(
+        cam_to_world=np.array(
             [
                 [1.0, 0.0, 0.0, 0.0],
                 [0.0, 0.0, -1.0, 0.0],
@@ -199,7 +199,7 @@ def make_angled_edge_patch(angle_rad: float, size: int = PATCH_SIZE) -> np.ndarr
 
 def compute_expected_pose_2d(
     angle: float,
-    world_camera: np.ndarray,
+    cam_to_world: np.ndarray,
     surface_normal: np.ndarray,
     tangent_frame: TangentFrame,
 ) -> np.ndarray:
@@ -208,7 +208,7 @@ def compute_expected_pose_2d(
     Returns:
         Expected pose vectors expressed in the local tangent frame.
     """
-    rotation = world_camera[:3, :3]
+    rotation = cam_to_world[:3, :3]
     image_x_world = rotation @ np.array([1.0, 0.0, 0.0])
     image_y_world = rotation @ np.array([0.0, 1.0, 0.0])
 
@@ -267,14 +267,14 @@ def assert_pose_2d_is_orthonormal(pose_2d: np.ndarray) -> None:
 
 
 def sensor_observation(
-    angle: float | None = None, world_camera: np.ndarray | None = None
+    angle: float | None = None, cam_to_world: np.ndarray | None = None
 ) -> SensorObservation:
     """Build a minimal SensorObservation.
 
     Args:
         angle: If None, create a uniform rgb patch (no edge).
             Otherwise a Hypothesis strategy to draw from.
-        world_camera: If None, create an identity matrix.
+        cam_to_world: If None, create an identity matrix.
             Otherwise a 4x4 camera-to-world matrix.
 
     Returns:
@@ -286,11 +286,11 @@ def sensor_observation(
 
     depth = np.ones((PATCH_SIZE, PATCH_SIZE), dtype=np.float32)
 
-    world_camera = np.identity(4) if world_camera is None else world_camera
+    cam_to_world = np.identity(4) if cam_to_world is None else cam_to_world
     return SensorObservation(
         rgba=rgba,
         depth=depth,
-        world_camera=world_camera,
+        cam_to_world=cam_to_world,
     )
 
 
@@ -385,11 +385,11 @@ class TestEdgeDetector(ParametrizedTestCase):
 
     @given(
         angle=st.just(None),
-        world_camera=rotation_matrices,
+        cam_to_world=rotation_matrices,
     )
-    def test_uniform_patch_returns_no_edge(self, angle, world_camera):
+    def test_uniform_patch_returns_no_edge(self, angle, cam_to_world):
         detector = EdgeDetector()
-        obs = sensor_observation(angle=angle, world_camera=world_camera)
+        obs = sensor_observation(angle=angle, cam_to_world=cam_to_world)
         edge = detector(obs)
 
         assert edge.strength == 0.0
@@ -407,7 +407,7 @@ class TestEdgeDetector(ParametrizedTestCase):
         obs = SensorObservation(
             rgba=rgba,
             depth=np.ones((PATCH_SIZE, PATCH_SIZE), dtype=np.float32),
-            world_camera=np.identity(4),
+            cam_to_world=np.identity(4),
         )
         # Set radius to force total_weight > DEFAULT_TOLERANCE
         detector = EdgeDetector(radius=PATCH_SIZE // 2, max_center_offset=1)
@@ -419,42 +419,42 @@ class TestEdgeDetector(ParametrizedTestCase):
         assert edge.is_geometric_edge is False
         assert edge.has_edge is False
 
-    @parametrize("name,angle,world_camera,surface_normal,expected_pose_2d", CASES)
+    @parametrize("name,angle,cam_to_world,surface_normal,expected_pose_2d", CASES)
     def test_edge_detection_for_closed_form_solutions(
         self,
         name,
         angle,
-        world_camera,
+        cam_to_world,
         surface_normal,  # noqa: ARG002
         expected_pose_2d,  # noqa: ARG002
     ):
         detector = EdgeDetector()
-        obs = sensor_observation(angle, world_camera)
+        obs = sensor_observation(angle, cam_to_world)
         edge = detector(obs)
 
         assert angle_distance(edge.angle, angle) < 0.1, f"{name} case failed."
 
     @given(
         angle=edge_angles,
-        world_camera=rotation_matrices,
+        cam_to_world=rotation_matrices,
     )
-    def test_angled_edge_patch_reports_expected_angle(self, angle, world_camera):
+    def test_angled_edge_patch_reports_expected_angle(self, angle, cam_to_world):
         detector = EdgeDetector()
-        obs = sensor_observation(angle=angle, world_camera=world_camera)
+        obs = sensor_observation(angle=angle, cam_to_world=cam_to_world)
 
         edge = detector(obs)
         assert angle_distance(edge.angle, angle) < 0.1
 
 
 class TestAngleTo2DPose(ParametrizedTestCase):
-    @parametrize("name,angle,world_camera,surface_normal,expected_pose_2d", CASES)
+    @parametrize("name,angle,cam_to_world,surface_normal,expected_pose_2d", CASES)
     def test_angle_converts_to_expected_pose_2d(
-        self, name, angle, world_camera, surface_normal, expected_pose_2d
+        self, name, angle, cam_to_world, surface_normal, expected_pose_2d
     ):
         tangent_frame = TangentFrame(surface_normal)
         pose_2d = _angle_to_pose_2d(
             angle=angle,
-            world_camera=world_camera,
+            cam_to_world=cam_to_world,
             surface_normal=surface_normal,
             tangent_frame=tangent_frame,
         )
@@ -467,7 +467,7 @@ class TestAngleTo2DPose(ParametrizedTestCase):
 
     def test_angle_to_pose_2d_uses_transported_tangent_frame(self):
         angle = np.pi / 2
-        world_camera = np.identity(4)
+        cam_to_world = np.identity(4)
         surface_normal = np.array([1.0, 1.0, 1.0])
         tangent_frame = TangentFrame(surface_normal)
 
@@ -481,7 +481,7 @@ class TestAngleTo2DPose(ParametrizedTestCase):
 
         pose_2d = _angle_to_pose_2d(
             angle=angle,
-            world_camera=world_camera,
+            cam_to_world=cam_to_world,
             surface_normal=surface_normal,
             tangent_frame=tangent_frame,
         )
@@ -490,7 +490,7 @@ class TestAngleTo2DPose(ParametrizedTestCase):
             pose_2d,
             compute_expected_pose_2d(
                 angle,
-                world_camera,
+                cam_to_world,
                 surface_normal,
                 tangent_frame,
             ),


### PR DESCRIPTION
Renames the variable name `world_camera` to `cam_to_world` (short for camera-to-world). 

This rename was motivated by several of us asking what `world_camera` variable was during [IP] 2D Sensor Module. This is defined in `DepthTo3DLocations` transforms. Previously, I had also mistakenly described it as world-to-camera transformation (which is the [Camera Extrinsic Matrix](https://en.wikipedia.org/wiki/Camera_resectioning)), but upon closer inspection it is actually its transpose, or camera-to-world transformation. 

Niels has suggested to update the name to make it clearer during 1:1, this PR is the result of that. 

Edit:

## The Breaking Change 

Marking as breaking as it changes the API, especially around SensorObservation.