### PR TITLE
chore: update rsyncignore list

### DIFF
--- a/.rsyncignore
+++ b/.rsyncignore
@@ -1,5 +1,8 @@
+- .coverage
+- .cursor
 - .git
 - .github
+- .hypothesis
 - .idea
 - .mypy_cache
 - .pytest_cache
@@ -8,6 +11,7 @@
 - .venv
 - .vscode
 - docs
+- htmlcov
 - outputs
 - rfcs
 - *.pyc


### PR DESCRIPTION
I noticed some hypothesis files were being synced, prompting me to update the `.rsyncignore` list.