### PR TITLE
chore: version 0.34.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,7 +8,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.33.0"
+__version__ = "0.34.0"
 
 import sys
 


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since 0.33.0

<img width="2380" height="2065" alt="image" src="https://github.com/user-attachments/assets/ecc582f7-1120-4802-ad47-c3862d8088b3" />

## refactor!: combine hypotheses variables into a Hypotheses class #936 
This PR collapses the four dictionaries describing hypotheses (`evidence`, `possible_locations`, `possible_poses`, `possible_hyps`) into a single `self._hypotheses: dict[str, Hypotheses]`. Most of the changes are in `EvidenceGraphLM`, with a few other references elsewhere that needed updating too.

## refactor!: update tutorials/using-monty-in-a-custom-application #962 
Renamed `OmniglotEnvironment` and `SaccadeOnImageEnvironment .get_state()` methods to a `private ._state()` method, since `get_state()` is no longer the public API, as it is returned as part of `step()`.

## refactor!: rename world_camera to cam_to_world #965 
Marking as breaking as it changes the API, especially around SensorObservation.