### PR TITLE
refactor: use monty Rotation instead of scipy's Rotation in mujoco simulator

### DIFF
--- a/src/tbp/monty/simulators/mujoco/agents.py
+++ b/src/tbp/monty/simulators/mujoco/agents.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING, Protocol, cast
 import numpy as np
 import quaternion as qt
 from mujoco import MjsBody, mjtJoint
-from scipy.spatial.transform import Rotation
 
 from tbp.monty.frameworks.actions.actions import (
     LookDown,

--- a/src/tbp/monty/simulators/mujoco/agents.py
+++ b/src/tbp/monty/simulators/mujoco/agents.py
@@ -34,10 +34,7 @@ from tbp.monty.frameworks.models.abstract_monty_classes import (
 )
 from tbp.monty.frameworks.models.motor_system_state import AgentState, SensorState
 from tbp.monty.frameworks.sensors import SensorConfig, SensorID
-from tbp.monty.frameworks.utils.transform_utils import (
-    rotation_as_quat,
-    rotation_from_quat,
-)
+from tbp.monty.geometry import Rotation
 from tbp.monty.math import IDENTITY_QUATERNION, ZERO_VECTOR, QuaternionWXYZ, VectorXYZ
 
 if TYPE_CHECKING:
@@ -199,14 +196,12 @@ class Embodiment(Agent):
         # sensors, while individual sensor positions are calculated separately below.
         # Note: the sensor body position and rotation is returned relative to world
         # coordinates from the simulator.
-        sensor_body_rot = rotation_from_quat(
+        sensor_body_rot = Rotation.from_quat(
             self.sim.data.body(self.sensor_body_id).xquat
         )
-        agent_rotation = rotation_from_quat(self.rotation)
+        agent_rotation = Rotation.from_quat(self.rotation)
         sensor_body_rot_rel_agent = agent_rotation.inv() * sensor_body_rot
-        sensor_body_rot_quat = qt.quaternion(
-            *rotation_as_quat(sensor_body_rot_rel_agent)
-        )
+        sensor_body_rot_quat = qt.quaternion(*sensor_body_rot_rel_agent.as_quat())
 
         sensor_states = {}
         for sensor_id, sensor_cfg in self._sensor_configs.items():
@@ -235,7 +230,7 @@ class Embodiment(Agent):
 
     def move_along_local_axis(self, distance: float, axis: Axis) -> None:
         """Move the embodiment along an axis relative to its local basis."""
-        rotation = rotation_from_quat(self.rotation)
+        rotation = Rotation.from_quat(self.rotation)
         rotation_matrix = rotation.as_matrix()
         axis_vector = rotation_matrix[:, axis] * distance
         new_xyz = np.array(self.position) + axis_vector
@@ -244,9 +239,9 @@ class Embodiment(Agent):
     def yaw(self, delta_theta: float) -> None:
         """Yaw the embodiment by delta_theta degrees."""
         delta_theta_rot = Rotation.from_euler("xyz", (0, delta_theta, 0), degrees=True)
-        rotation = rotation_from_quat(self.rotation)
+        rotation = Rotation.from_quat(self.rotation)
         new_rotation = rotation * delta_theta_rot
-        self.rotation = rotation_as_quat(new_rotation)
+        self.rotation = new_rotation.as_quat()
 
     def pitch(self, delta_phi: float, constraint: float) -> None:
         """Pitch the sensor body by delta_phi degrees while remaining constrained.
@@ -278,7 +273,7 @@ class Embodiment(Agent):
         orientation outside the x-axis of the sensor body, i.e. the body can only
         pitch up and down.
         """
-        rotation = rotation_from_quat(rotation_quat)
+        rotation = Rotation.from_quat(rotation_quat)
         angles = rotation.as_euler("xyz", degrees=False)
         qpos_addr = self.sim.model.jnt_qposadr[self.pitch_joint.id]
         self.sim.data.qpos[qpos_addr] = angles[0]

--- a/tests/unit/simulators/mujoco/distant_agent_test.py
+++ b/tests/unit/simulators/mujoco/distant_agent_test.py
@@ -28,10 +28,7 @@ from tbp.monty.frameworks.actions.actions import (
     TurnLeft,
     TurnRight,
 )
-from tbp.monty.frameworks.utils.transform_utils import (
-    rotation_as_quat,
-    rotation_from_quat,
-)
+from tbp.monty.geometry import Rotation
 from tbp.monty.math import DEFAULT_TOLERANCE, QuaternionWXYZ, VectorXYZ
 from tbp.monty.simulators.mujoco import MuJoCoSimulator
 from tbp.monty.simulators.mujoco.agents import DistantAgent
@@ -64,7 +61,7 @@ def unit_quaternion(draw) -> QuaternionWXYZ:
     y_rad = draw(st.floats(min_value=0.0, max_value=np.pi * 2))
     z_rad = draw(st.floats(min_value=0.0, max_value=np.pi * 2))
     rotation = Rotation.from_euler("xyz", [x_rad, y_rad, z_rad], degrees=False)
-    normalized_rotation = rotation_as_quat(rotation)
+    normalized_rotation = rotation.as_quat()
     return cast("QuaternionWXYZ", tuple(normalized_rotation))
 
 
@@ -72,7 +69,7 @@ def unit_quaternion(draw) -> QuaternionWXYZ:
 def x_rotation_quaterion(draw) -> QuaternionWXYZ:
     x_rad = draw(st.floats(min_value=0.0, max_value=np.pi * 2))
     rotation = Rotation.from_euler("xyz", [x_rad, 0.0, 0.0], degrees=False)
-    normalized_rotation = rotation_as_quat(rotation)
+    normalized_rotation = rotation.as_quat()
     return cast("QuaternionWXYZ", tuple(normalized_rotation))
 
 
@@ -156,8 +153,8 @@ class DistantAgentTest(TestCase):
         # Due to the transformations that happen to sensor.rotation, some of the
         # quaternions are rotated to their negative, which represents the same rotation.
         # Changing to SciPy rotation side-steps that issue when testing the results.
-        sensor_rot = rotation_from_quat(qt.as_float_array(sensor_state.rotation))
-        expected_rot = rotation_from_quat(sensor_rotation)
+        sensor_rot = Rotation.from_quat(qt.as_float_array(sensor_state.rotation))
+        expected_rot = Rotation.from_quat(sensor_rotation)
         assert expected_rot.approx_equal(sensor_rot)
 
     @given(distance=st.floats(min_value=0.0, max_value=10.0))
@@ -180,7 +177,7 @@ class DistantAgentTest(TestCase):
             self.sim.step([action])
 
             agent_state = self.sim.states[TEST_AGENT_ID]
-            agent_rot = rotation_from_quat(qt.as_float_array(agent_state.rotation))
+            agent_rot = Rotation.from_quat(qt.as_float_array(agent_state.rotation))
             expected_rot = Rotation.from_euler(
                 "xyz", [0.0, -delta_theta, 0.0], degrees=True
             )
@@ -195,7 +192,7 @@ class DistantAgentTest(TestCase):
             self.sim.step([action])
 
             agent_state = self.sim.states[TEST_AGENT_ID]
-            agent_rot = rotation_from_quat(qt.as_float_array(agent_state.rotation))
+            agent_rot = Rotation.from_quat(qt.as_float_array(agent_state.rotation))
             expected_rot = Rotation.from_euler(
                 "xyz", [0.0, delta_theta, 0.0], degrees=True
             )
@@ -217,7 +214,7 @@ class DistantAgentTest(TestCase):
         with sim_resetter(self.sim):
             self.sim.step([action])
             sensor_state = self.sim.states[TEST_AGENT_ID].sensors[TEST_SENSOR_ID]
-            sensor_rot = rotation_from_quat(qt.as_float_array(sensor_state.rotation))
+            sensor_rot = Rotation.from_quat(qt.as_float_array(sensor_state.rotation))
 
             assert sensor_rot.approx_equal(expected_rot)
 
@@ -245,7 +242,7 @@ class DistantAgentTest(TestCase):
         with sim_resetter(self.sim):
             self.sim.step(actions)
             sensor_state = self.sim.states[TEST_AGENT_ID].sensors[TEST_SENSOR_ID]
-            sensor_rot = rotation_from_quat(qt.as_float_array(sensor_state.rotation))
+            sensor_rot = Rotation.from_quat(qt.as_float_array(sensor_state.rotation))
 
             pitch, _, _ = sensor_rot.as_euler("xyz", degrees=True)
             assert abs(pitch) <= phi_limit + DEFAULT_TOLERANCE
@@ -265,7 +262,7 @@ class DistantAgentTest(TestCase):
         with sim_resetter(self.sim):
             self.sim.step([action])
             sensor_state = self.sim.states[TEST_AGENT_ID].sensors[TEST_SENSOR_ID]
-            sensor_rot = rotation_from_quat(qt.as_float_array(sensor_state.rotation))
+            sensor_rot = Rotation.from_quat(qt.as_float_array(sensor_state.rotation))
 
             assert sensor_rot.approx_equal(expected_rot)
 
@@ -293,7 +290,7 @@ class DistantAgentTest(TestCase):
         with sim_resetter(self.sim):
             self.sim.step(actions)
             sensor_state = self.sim.states[TEST_AGENT_ID].sensors[TEST_SENSOR_ID]
-            sensor_rot = rotation_from_quat(qt.as_float_array(sensor_state.rotation))
+            sensor_rot = Rotation.from_quat(qt.as_float_array(sensor_state.rotation))
 
             pitch, _, _ = sensor_rot.as_euler("xyz", degrees=True)
             assert abs(pitch) <= phi_limit + DEFAULT_TOLERANCE

--- a/tests/unit/simulators/mujoco/distant_agent_test.py
+++ b/tests/unit/simulators/mujoco/distant_agent_test.py
@@ -17,7 +17,6 @@ import hypothesis.strategies as st
 import numpy as np
 import quaternion as qt
 from hypothesis import example, given, settings
-from scipy.spatial.transform import Rotation
 
 from tbp.monty.frameworks.actions.actions import (
     LookDown,


### PR DESCRIPTION
This PR swaps out usage of the scipy Rotation object and associated utilities for `tbp.monty.geometry.Rotation` which was introduced in [feat!: wxyz-friendly Rotation object #937](https://github.com/thousandbrainsproject/tbp.monty/pull/937).

There are no breaking changes.