### PR TITLE
refactor!: delegate SM construction to Hydra

### DIFF
--- a/docs/how-to-use-monty/tutorials/pretraining-a-model.md
+++ b/docs/how-to-use-monty/tutorials/pretraining-a-model.md
@@ -28,7 +28,7 @@ Monty experiments are defined and configured using [Hydra](https://hydra.cc/). T
     - `monty_config`: Configuration for the Monty model.
       - `monty_class`: `Monty` The type of Monty model to use, e.g. for evidence-based graph matching: `MontyForEvidenceGraphMatching`.
       - `monty_args`: Arguments supplied to the Monty class.
-      - `sensor_module_configs`: `Mapping[str:Mapping]` Sensor module configurations.
+      - `sensor_modules`: `Mapping[str:Mapping]` Sensor module configurations.
       - `learning_module_configs`: `Mapping[str:Mapping]` Learning module configurations.
       - `motor_system_config`: Configuration of the motor system and motor policies.
       - `sm_to_agent_dict`: Connectivity mapping of which sensors connect to which sensor modules.

--- a/docs/how-to-use-monty/tutorials/running-inference-with-a-pretrained-model.md
+++ b/docs/how-to-use-monty/tutorials/running-inference-with-a-pretrained-model.md
@@ -76,7 +76,7 @@ Since this config is going to be a bit more complex, we will build it up in piec
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch
   # Features that will be extracted and sent to LM
   # note: don't have to be all the features extracted during pretraining.
@@ -115,7 +115,7 @@ sensor_module_0:
       pose_fully_defined: 0.01 # flip bool in 1% of cases
     location: 0.002 # add gaussian noise with 0.002 std (0.2cm)
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: false
 ```

--- a/docs/how-to-use-monty/tutorials/running-inference-with-a-pretrained-model.md
+++ b/docs/how-to-use-monty/tutorials/running-inference-with-a-pretrained-model.md
@@ -73,53 +73,51 @@ eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObje
 Since this config is going to be a bit more complex, we will build it up in pieces. Here is the configuration for sensor modules from `src/tbp/monty/conf/monty/sensor_module/camera_tutorial_surf_agent_2obj.yaml`:
 
 ```yaml
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch
-    # Features that will be extracted and sent to LM
-    # note: don't have to be all the features extracted during pretraining.
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch
+  # Features that will be extracted and sent to LM
+  # note: don't have to be all the features extracted during pretraining.
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - min_depth
+  - mean_depth
+  - hsv
+  - principal_curvatures
+  - principal_curvatures_log
+  save_raw_obs: false
+  # CameraSM will only send an observation to the LM if features or location
+  # changed more than these amounts.
+  delta_thresholds:
+    on_object: 0
+    n_steps: 20
+    hsv:
+    - 0.1
+    - 0.1
+    - 0.1
+    pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+    principal_curvatures_log:
+    - 2
+    - 2
+    distance: 0.01
+  is_surface_sm: true # for surface agent
+  # Let's add some noise to the sensor module outputs to make the task more challenging.
+  noise_params:
     features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - min_depth
-    - mean_depth
-    - hsv
-    - principal_curvatures
-    - principal_curvatures_log
-    save_raw_obs: false
-    # CameraSM will only send an observation to the LM if features or location
-    # changed more than these amounts.
-    delta_thresholds:
-      on_object: 0
-      n_steps: 20
-      hsv:
-      - 0.1
-      - 0.1
-      - 0.1
-      pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-      principal_curvatures_log:
-      - 2
-      - 2
-      distance: 0.01
-    is_surface_sm: true # for surface agent
-    # Let's add some noise to the sensor module outputs to make the task more challenging.
-    noise_params:
-      features:
-        pose_vectors: 2 # rotate by random degrees along xyz
-        hsv: ${np.array:[0.1, 0.2, 0.2]} # add noise to each channel (the values here specify std. deviation of gaussian for each channel individually)
-        principal_curvatures_log: 0.1
-        pose_fully_defined: 0.01 # flip bool in 1% of cases
-      location: 0.002 # add gaussian noise with 0.002 std (0.2cm)
+      pose_vectors: 2 # rotate by random degrees along xyz
+      hsv: ${np.array:[0.1, 0.2, 0.2]} # add noise to each channel (the values here specify std. deviation of gaussian for each channel individually)
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01 # flip bool in 1% of cases
+    location: 0.002 # add gaussian noise with 0.002 std (0.2cm)
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: false
 ```
 
 There are two main differences between this config and the pretraining sensor module config. First, we are adding some noise to the sensor patch, so we define noise parameters and add them to `sensor_module_0`'s dictionary. Second, we're using `delta_threshold` parameters to only send an observation to the learning module if the features have changed significantly. Note that `CameraSM` can be used as either a surface or distant agent, for which `is_surface_sm` should be appropriately set.

--- a/src/tbp/monty/conf/monty/sensor_module/2sm_camera_dist.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/2sm_camera_dist.yaml
@@ -1,57 +1,54 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch_0
-    features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - min_depth
-    - mean_depth
-    - hsv
-    - principal_curvatures_log
-    delta_thresholds:
-      on_object: 0
-      n_steps: 20
-      hsv:
-      - 0.1
-      - 0.1
-      - 0.1
-      pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-      principal_curvatures_log:
-      - 2
-      - 2
-      distance: 0.01
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch_0
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - min_depth
+  - mean_depth
+  - hsv
+  - principal_curvatures_log
+  delta_thresholds:
+    on_object: 0
+    n_steps: 20
+    hsv:
+    - 0.1
+    - 0.1
+    - 0.1
+    pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+    principal_curvatures_log:
+    - 2
+    - 2
+    distance: 0.01
+  save_raw_obs: true
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch_1
-    features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - hsv
-    - principal_curvatures_log
-    delta_thresholds:
-      on_object: 0
-      n_steps: 100
-      hsv:
-      - 0.2
-      - 0.2
-      - 0.2
-      pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-      principal_curvatures_log:
-      - 4
-      - 4
-      distance: 0.05
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch_1
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - hsv
+  - principal_curvatures_log
+  delta_thresholds:
+    on_object: 0
+    n_steps: 100
+    hsv:
+    - 0.2
+    - 0.2
+    - 0.2
+    pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+    principal_curvatures_log:
+    - 4
+    - 4
+    distance: 0.05
+  save_raw_obs: true
 sensor_module_2:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/2sm_camera_dist.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/2sm_camera_dist.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch_0
   features:
   - pose_vectors
@@ -26,7 +26,7 @@ sensor_module_0:
     distance: 0.01
   save_raw_obs: true
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch_1
   features:
   - pose_vectors
@@ -49,6 +49,6 @@ sensor_module_1:
     distance: 0.05
   save_raw_obs: true
 sensor_module_2:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/2sm_camera_dist_d002.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/2sm_camera_dist_d002.yaml
@@ -1,57 +1,54 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch_0
-    features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - min_depth
-    - mean_depth
-    - hsv
-    - principal_curvatures_log
-    delta_thresholds:
-      on_object: 0
-      n_steps: 20
-      hsv:
-      - 0.1
-      - 0.1
-      - 0.1
-      pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-      principal_curvatures_log:
-      - 2
-      - 2
-      distance: 0.01
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch_0
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - min_depth
+  - mean_depth
+  - hsv
+  - principal_curvatures_log
+  delta_thresholds:
+    on_object: 0
+    n_steps: 20
+    hsv:
+    - 0.1
+    - 0.1
+    - 0.1
+    pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+    principal_curvatures_log:
+    - 2
+    - 2
+    distance: 0.01
+  save_raw_obs: true
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch_1
-    features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - hsv
-    - principal_curvatures_log
-    delta_thresholds:
-      on_object: 0
-      n_steps: 100
-      hsv:
-      - 0.2
-      - 0.2
-      - 0.2
-      pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-      principal_curvatures_log:
-      - 4
-      - 4
-      distance: 0.02
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch_1
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - hsv
+  - principal_curvatures_log
+  delta_thresholds:
+    on_object: 0
+    n_steps: 100
+    hsv:
+    - 0.2
+    - 0.2
+    - 0.2
+    pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+    principal_curvatures_log:
+    - 4
+    - 4
+    distance: 0.02
+  save_raw_obs: true
 sensor_module_2:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/2sm_camera_dist_d002.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/2sm_camera_dist_d002.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch_0
   features:
   - pose_vectors
@@ -26,7 +26,7 @@ sensor_module_0:
     distance: 0.01
   save_raw_obs: true
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch_1
   features:
   - pose_vectors
@@ -49,6 +49,6 @@ sensor_module_1:
     distance: 0.02
   save_raw_obs: true
 sensor_module_2:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/5sm_camera.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/5sm_camera.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   features:
   - on_object
   - rgba
@@ -16,7 +16,7 @@ sensor_module_0:
   sensor_module_id: patch_0
   save_raw_obs: false
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   features:
   - on_object
   - rgba
@@ -31,7 +31,7 @@ sensor_module_1:
   sensor_module_id: patch_1
   save_raw_obs: false
 sensor_module_2:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   features:
   - on_object
   - rgba
@@ -46,7 +46,7 @@ sensor_module_2:
   sensor_module_id: patch_2
   save_raw_obs: false
 sensor_module_3:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   features:
   - on_object
   - rgba
@@ -61,7 +61,7 @@ sensor_module_3:
   sensor_module_id: patch_3
   save_raw_obs: false
 sensor_module_4:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   features:
   - on_object
   - rgba
@@ -76,6 +76,6 @@ sensor_module_4:
   sensor_module_id: patch_4
   save_raw_obs: false
 sensor_module_5:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/5sm_camera.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/5sm_camera.yaml
@@ -1,87 +1,81 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_args:
-    features:
-    - on_object
-    - rgba
-    - hsv
-    - pose_vectors
-    - principal_curvatures
-    - principal_curvatures_log
-    - gaussian_curvature
-    - mean_curvature
-    - gaussian_curvature_sc
-    - mean_curvature_sc
-    sensor_module_id: patch_0
-    save_raw_obs: false
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  features:
+  - on_object
+  - rgba
+  - hsv
+  - pose_vectors
+  - principal_curvatures
+  - principal_curvatures_log
+  - gaussian_curvature
+  - mean_curvature
+  - gaussian_curvature_sc
+  - mean_curvature_sc
+  sensor_module_id: patch_0
+  save_raw_obs: false
 sensor_module_1:
-  sensor_module_args:
-    features:
-    - on_object
-    - rgba
-    - hsv
-    - pose_vectors
-    - principal_curvatures
-    - principal_curvatures_log
-    - gaussian_curvature
-    - mean_curvature
-    - gaussian_curvature_sc
-    - mean_curvature_sc
-    sensor_module_id: patch_1
-    save_raw_obs: false
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  features:
+  - on_object
+  - rgba
+  - hsv
+  - pose_vectors
+  - principal_curvatures
+  - principal_curvatures_log
+  - gaussian_curvature
+  - mean_curvature
+  - gaussian_curvature_sc
+  - mean_curvature_sc
+  sensor_module_id: patch_1
+  save_raw_obs: false
 sensor_module_2:
-  sensor_module_args:
-    features:
-    - on_object
-    - rgba
-    - hsv
-    - pose_vectors
-    - principal_curvatures
-    - principal_curvatures_log
-    - gaussian_curvature
-    - mean_curvature
-    - gaussian_curvature_sc
-    - mean_curvature_sc
-    sensor_module_id: patch_2
-    save_raw_obs: false
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  features:
+  - on_object
+  - rgba
+  - hsv
+  - pose_vectors
+  - principal_curvatures
+  - principal_curvatures_log
+  - gaussian_curvature
+  - mean_curvature
+  - gaussian_curvature_sc
+  - mean_curvature_sc
+  sensor_module_id: patch_2
+  save_raw_obs: false
 sensor_module_3:
-  sensor_module_args:
-    features:
-    - on_object
-    - rgba
-    - hsv
-    - pose_vectors
-    - principal_curvatures
-    - principal_curvatures_log
-    - gaussian_curvature
-    - mean_curvature
-    - gaussian_curvature_sc
-    - mean_curvature_sc
-    sensor_module_id: patch_3
-    save_raw_obs: false
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  features:
+  - on_object
+  - rgba
+  - hsv
+  - pose_vectors
+  - principal_curvatures
+  - principal_curvatures_log
+  - gaussian_curvature
+  - mean_curvature
+  - gaussian_curvature_sc
+  - mean_curvature_sc
+  sensor_module_id: patch_3
+  save_raw_obs: false
 sensor_module_4:
-  sensor_module_args:
-    features:
-    - on_object
-    - rgba
-    - hsv
-    - pose_vectors
-    - principal_curvatures
-    - principal_curvatures_log
-    - gaussian_curvature
-    - mean_curvature
-    - gaussian_curvature_sc
-    - mean_curvature_sc
-    sensor_module_id: patch_4
-    save_raw_obs: false
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  features:
+  - on_object
+  - rgba
+  - hsv
+  - pose_vectors
+  - principal_curvatures
+  - principal_curvatures_log
+  - gaussian_curvature
+  - mean_curvature
+  - gaussian_curvature_sc
+  - mean_curvature_sc
+  sensor_module_id: patch_4
+  save_raw_obs: false
 sensor_module_5:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/5sm_camera_dist_noise.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/5sm_camera_dist_noise.yaml
@@ -1,57 +1,51 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch_0
-    features: ${constants.default_sensor_features}
-    save_raw_obs: false
-    delta_thresholds:
-      on_object: 0
-      distance: 0.01
-    noise_params: ${constants.default_all_noise_params}
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch_0
+  features: ${constants.default_sensor_features}
+  save_raw_obs: false
+  delta_thresholds:
+    on_object: 0
+    distance: 0.01
+  noise_params: ${constants.default_all_noise_params}
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch_1
-    features: ${constants.default_sensor_features}
-    save_raw_obs: false
-    delta_thresholds:
-      on_object: 0
-      distance: 0.01
-    noise_params: ${constants.default_all_noise_params}
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch_1
+  features: ${constants.default_sensor_features}
+  save_raw_obs: false
+  delta_thresholds:
+    on_object: 0
+    distance: 0.01
+  noise_params: ${constants.default_all_noise_params}
 sensor_module_2:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch_2
-    features: ${constants.default_sensor_features}
-    save_raw_obs: false
-    delta_thresholds:
-      on_object: 0
-      distance: 0.01
-    noise_params: ${constants.default_all_noise_params}
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch_2
+  features: ${constants.default_sensor_features}
+  save_raw_obs: false
+  delta_thresholds:
+    on_object: 0
+    distance: 0.01
+  noise_params: ${constants.default_all_noise_params}
 sensor_module_3:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch_3
-    features: ${constants.default_sensor_features}
-    save_raw_obs: false
-    delta_thresholds:
-      on_object: 0
-      distance: 0.01
-    noise_params: ${constants.default_all_noise_params}
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch_3
+  features: ${constants.default_sensor_features}
+  save_raw_obs: false
+  delta_thresholds:
+    on_object: 0
+    distance: 0.01
+  noise_params: ${constants.default_all_noise_params}
 sensor_module_4:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch_4
-    features: ${constants.default_sensor_features}
-    save_raw_obs: false
-    delta_thresholds:
-      on_object: 0
-      distance: 0.01
-    noise_params: ${constants.default_all_noise_params}
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch_4
+  features: ${constants.default_sensor_features}
+  save_raw_obs: false
+  delta_thresholds:
+    on_object: 0
+    distance: 0.01
+  noise_params: ${constants.default_all_noise_params}
 sensor_module_5:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/5sm_camera_dist_noise.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/5sm_camera_dist_noise.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch_0
   features: ${constants.default_sensor_features}
   save_raw_obs: false
@@ -10,7 +10,7 @@ sensor_module_0:
     distance: 0.01
   noise_params: ${constants.default_all_noise_params}
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch_1
   features: ${constants.default_sensor_features}
   save_raw_obs: false
@@ -19,7 +19,7 @@ sensor_module_1:
     distance: 0.01
   noise_params: ${constants.default_all_noise_params}
 sensor_module_2:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch_2
   features: ${constants.default_sensor_features}
   save_raw_obs: false
@@ -28,7 +28,7 @@ sensor_module_2:
     distance: 0.01
   noise_params: ${constants.default_all_noise_params}
 sensor_module_3:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch_3
   features: ${constants.default_sensor_features}
   save_raw_obs: false
@@ -37,7 +37,7 @@ sensor_module_3:
     distance: 0.01
   noise_params: ${constants.default_all_noise_params}
 sensor_module_4:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch_4
   features: ${constants.default_sensor_features}
   save_raw_obs: false
@@ -46,6 +46,6 @@ sensor_module_4:
     distance: 0.01
   noise_params: ${constants.default_all_noise_params}
 sensor_module_5:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist.yaml
@@ -1,25 +1,23 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch
-    features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - rgba
-    - hsv
-    - principal_curvatures
-    - principal_curvatures_log
-    - gaussian_curvature
-    - mean_curvature
-    - gaussian_curvature_sc
-    - mean_curvature_sc
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - rgba
+  - hsv
+  - principal_curvatures
+  - principal_curvatures_log
+  - gaussian_curvature
+  - mean_curvature
+  - gaussian_curvature_sc
+  - mean_curvature_sc
+  save_raw_obs: true
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch
   features:
   - pose_vectors
@@ -18,6 +18,6 @@ sensor_module_0:
   - mean_curvature_sc
   save_raw_obs: true
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist_delta.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist_delta.yaml
@@ -1,31 +1,29 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch
-    features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - hsv
-    - principal_curvatures_log
-    delta_thresholds:
-      on_object: 0
-      n_steps: 20
-      hsv:
-      - 0.1
-      - 0.1
-      - 0.1
-      pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-      principal_curvatures_log:
-      - 2
-      - 2
-      distance: 0.01
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - hsv
+  - principal_curvatures_log
+  delta_thresholds:
+    on_object: 0
+    n_steps: 20
+    hsv:
+    - 0.1
+    - 0.1
+    - 0.1
+    pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+    principal_curvatures_log:
+    - 2
+    - 2
+    distance: 0.01
+  save_raw_obs: false
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist_delta.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist_delta.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch
   features:
   - pose_vectors
@@ -24,6 +24,6 @@ sensor_module_0:
     distance: 0.01
   save_raw_obs: false
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist_noise_raw0.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist_noise_raw0.yaml
@@ -1,28 +1,26 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - hsv
+  - principal_curvatures_log
+  delta_thresholds:
+    on_object: 0
+    distance: 0.01
+  save_raw_obs: false
+  noise_params:
     features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - hsv
-    - principal_curvatures_log
-    delta_thresholds:
-      on_object: 0
-      distance: 0.01
-    save_raw_obs: false
-    noise_params:
-      features:
-        pose_vectors: 2 # rotate by random degrees along xyz
-        hsv: 0.1 # add gaussian noise with 0.1 std
-        principal_curvatures_log: 0.1
-        pose_fully_defined: 0.01 # flip bool in 1% of cases
-      location: 0.002 # add gaussian noise with 0.002 std
+      pose_vectors: 2 # rotate by random degrees along xyz
+      hsv: 0.1 # add gaussian noise with 0.1 std
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01 # flip bool in 1% of cases
+    location: 0.002 # add gaussian noise with 0.002 std
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist_noise_raw0.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist_noise_raw0.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch
   features:
   - pose_vectors
@@ -21,6 +21,6 @@ sensor_module_0:
       pose_fully_defined: 0.01 # flip bool in 1% of cases
     location: 0.002 # add gaussian noise with 0.002 std
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist_noise_raw1.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist_noise_raw1.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch
   features:
   - pose_vectors
@@ -21,6 +21,6 @@ sensor_module_0:
       pose_fully_defined: 0.01 # flip bool in 1% of cases
     location: 0.002 # add gaussian noise with 0.002 std
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist_noise_raw1.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist_noise_raw1.yaml
@@ -1,28 +1,26 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - hsv
+  - principal_curvatures_log
+  delta_thresholds:
+    on_object: 0
+    distance: 0.01
+  save_raw_obs: false
+  noise_params:
     features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - hsv
-    - principal_curvatures_log
-    delta_thresholds:
-      on_object: 0
-      distance: 0.01
-    save_raw_obs: false
-    noise_params:
-      features:
-        pose_vectors: 2 # rotate by random degrees along xyz
-        hsv: 0.1 # add gaussian noise with 0.1 std
-        principal_curvatures_log: 0.1
-        pose_fully_defined: 0.01 # flip bool in 1% of cases
-      location: 0.002 # add gaussian noise with 0.002 std
+      pose_vectors: 2 # rotate by random degrees along xyz
+      hsv: 0.1 # add gaussian noise with 0.1 std
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01 # flip bool in 1% of cases
+    location: 0.002 # add gaussian noise with 0.002 std
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist_omniglot_tutorial.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist_omniglot_tutorial.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch
   features:
   - pose_vectors
@@ -11,6 +11,6 @@ sensor_module_0:
   save_raw_obs: false
   pc1_is_pc2_threshold: 1
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist_omniglot_tutorial.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist_omniglot_tutorial.yaml
@@ -1,18 +1,16 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch
-    features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - principal_curvatures_log
-    save_raw_obs: false
-    pc1_is_pc2_threshold: 1
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - principal_curvatures_log
+  save_raw_obs: false
+  pc1_is_pc2_threshold: 1
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist_wo_posefullydefined.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist_wo_posefullydefined.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch
   features:
   - on_object
@@ -17,6 +17,6 @@ sensor_module_0:
   - mean_curvature_sc
   save_raw_obs: false
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_dist_wo_posefullydefined.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_dist_wo_posefullydefined.yaml
@@ -1,24 +1,22 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch
-    features:
-    - on_object
-    - object_coverage
-    - rgba
-    - hsv
-    - pose_vectors
-    - principal_curvatures
-    - principal_curvatures_log
-    - gaussian_curvature
-    - mean_curvature
-    - gaussian_curvature_sc
-    - mean_curvature_sc
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch
+  features:
+  - on_object
+  - object_coverage
+  - rgba
+  - hsv
+  - pose_vectors
+  - principal_curvatures
+  - principal_curvatures_log
+  - gaussian_curvature
+  - mean_curvature
+  - gaussian_curvature_sc
+  - mean_curvature_sc
+  save_raw_obs: false
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf.yaml
@@ -1,27 +1,25 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    is_surface_sm: true
-    sensor_module_id: patch
-    features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - min_depth
-    - mean_depth
-    - hsv
-    - principal_curvatures
-    - principal_curvatures_log
-    - gaussian_curvature
-    - mean_curvature
-    - gaussian_curvature_sc
-    - mean_curvature_sc
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  is_surface_sm: true
+  sensor_module_id: patch
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - min_depth
+  - mean_depth
+  - hsv
+  - principal_curvatures
+  - principal_curvatures_log
+  - gaussian_curvature
+  - mean_curvature
+  - gaussian_curvature_sc
+  - mean_curvature_sc
+  save_raw_obs: true
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   is_surface_sm: true
   sensor_module_id: patch
   features:
@@ -20,6 +20,6 @@ sensor_module_0:
   - mean_curvature_sc
   save_raw_obs: true
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf_delta.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf_delta.yaml
@@ -1,35 +1,33 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    is_surface_sm: true
-    sensor_module_id: patch
-    features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - min_depth
-    - mean_depth
-    - hsv
-    - principal_curvatures
-    - principal_curvatures_log
-    delta_thresholds:
-      on_object: 0
-      n_steps: 20
-      hsv:
-      - 0.1
-      - 0.1
-      - 0.1
-      pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-      principal_curvatures_log:
-      - 2
-      - 2
-      distance: 0.01
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  is_surface_sm: true
+  sensor_module_id: patch
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - min_depth
+  - mean_depth
+  - hsv
+  - principal_curvatures
+  - principal_curvatures_log
+  delta_thresholds:
+    on_object: 0
+    n_steps: 20
+    hsv:
+    - 0.1
+    - 0.1
+    - 0.1
+    pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+    principal_curvatures_log:
+    - 2
+    - 2
+    distance: 0.01
+  save_raw_obs: false
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf_delta.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf_delta.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   is_surface_sm: true
   sensor_module_id: patch
   features:
@@ -28,6 +28,6 @@ sensor_module_0:
     distance: 0.01
   save_raw_obs: false
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf_noise_raw0.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf_noise_raw0.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   features:
   - pose_vectors
   - pose_fully_defined
@@ -26,6 +26,6 @@ sensor_module_0:
       pose_fully_defined: 0.01 # flip bool in 1% of cases
     location: 0.002 # add gaussian noise with 0.002 std
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf_noise_raw0.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf_noise_raw0.yaml
@@ -1,33 +1,31 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_args:
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - min_depth
+  - mean_depth
+  - hsv
+  - principal_curvatures
+  - principal_curvatures_log
+  sensor_module_id: patch
+  save_raw_obs: false
+  delta_thresholds:
+    on_object: 0
+    distance: 0.01
+  is_surface_sm: true
+  noise_params:
     features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - min_depth
-    - mean_depth
-    - hsv
-    - principal_curvatures
-    - principal_curvatures_log
-    sensor_module_id: patch
-    save_raw_obs: false
-    delta_thresholds:
-      on_object: 0
-      distance: 0.01
-    is_surface_sm: true
-    noise_params:
-      features:
-        pose_vectors: 2 # rotate by random degrees along xyz
-        hsv: 0.1 # add gaussian noise with 0.1 std
-        principal_curvatures_log: 0.1
-        pose_fully_defined: 0.01 # flip bool in 1% of cases
-      location: 0.002 # add gaussian noise with 0.002 std
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+      pose_vectors: 2 # rotate by random degrees along xyz
+      hsv: 0.1 # add gaussian noise with 0.1 std
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01 # flip bool in 1% of cases
+    location: 0.002 # add gaussian noise with 0.002 std
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf_noise_raw1.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf_noise_raw1.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   features:
   - pose_vectors
   - pose_fully_defined
@@ -26,6 +26,6 @@ sensor_module_0:
       pose_fully_defined: 0.01 # flip bool in 1% of cases
     location: 0.002 # add gaussian noise with 0.002 std
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf_noise_raw1.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf_noise_raw1.yaml
@@ -1,33 +1,31 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_args:
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - min_depth
+  - mean_depth
+  - hsv
+  - principal_curvatures
+  - principal_curvatures_log
+  sensor_module_id: patch
+  save_raw_obs: false
+  delta_thresholds:
+    on_object: 0
+    distance: 0.01
+  is_surface_sm: true
+  noise_params:
     features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - min_depth
-    - mean_depth
-    - hsv
-    - principal_curvatures
-    - principal_curvatures_log
-    sensor_module_id: patch
-    save_raw_obs: false
-    delta_thresholds:
-      on_object: 0
-      distance: 0.01
-    is_surface_sm: true
-    noise_params:
-      features:
-        pose_vectors: 2 # rotate by random degrees along xyz
-        hsv: 0.1 # add gaussian noise with 0.1 std
-        principal_curvatures_log: 0.1
-        pose_fully_defined: 0.01 # flip bool in 1% of cases
-      location: 0.002 # add gaussian noise with 0.002 std
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+      pose_vectors: 2 # rotate by random degrees along xyz
+      hsv: 0.1 # add gaussian noise with 0.1 std
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01 # flip bool in 1% of cases
+    location: 0.002 # add gaussian noise with 0.002 std
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf_rgba.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf_rgba.yaml
@@ -1,28 +1,26 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    is_surface_sm: true
-    sensor_module_id: patch
-    features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - rgba
-    - hsv
-    - min_depth
-    - mean_depth
-    - principal_curvatures
-    - principal_curvatures_log
-    - gaussian_curvature
-    - mean_curvature
-    - gaussian_curvature_sc
-    - mean_curvature_sc
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  is_surface_sm: true
+  sensor_module_id: patch
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - rgba
+  - hsv
+  - min_depth
+  - mean_depth
+  - principal_curvatures
+  - principal_curvatures_log
+  - gaussian_curvature
+  - mean_curvature
+  - gaussian_curvature_sc
+  - mean_curvature_sc
+  save_raw_obs: true
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf_rgba.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf_rgba.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   is_surface_sm: true
   sensor_module_id: patch
   features:
@@ -21,6 +21,6 @@ sensor_module_0:
   - mean_curvature_sc
   save_raw_obs: true
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf_rgba_raw0.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf_rgba_raw0.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   is_surface_sm: true
   sensor_module_id: patch
   features:
@@ -21,6 +21,6 @@ sensor_module_0:
   - mean_curvature_sc
   save_raw_obs: false
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_surf_rgba_raw0.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_surf_rgba_raw0.yaml
@@ -1,28 +1,26 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    is_surface_sm: true
-    sensor_module_id: patch
-    features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - rgba
-    - hsv
-    - min_depth
-    - mean_depth
-    - principal_curvatures
-    - principal_curvatures_log
-    - gaussian_curvature
-    - mean_curvature
-    - gaussian_curvature_sc
-    - mean_curvature_sc
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  is_surface_sm: true
+  sensor_module_id: patch
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - rgba
+  - hsv
+  - min_depth
+  - mean_depth
+  - principal_curvatures
+  - principal_curvatures_log
+  - gaussian_curvature
+  - mean_curvature
+  - gaussian_curvature_sc
+  - mean_curvature_sc
+  save_raw_obs: false
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_tutorial_surf_agent_2obj.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_tutorial_surf_agent_2obj.yaml
@@ -1,47 +1,45 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch
-    # Features that will be extracted and sent to LM
-    # note: don't have to be all the features extracted during pretraining.
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch
+  # Features that will be extracted and sent to LM
+  # note: don't have to be all the features extracted during pretraining.
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - min_depth
+  - mean_depth
+  - hsv
+  - principal_curvatures
+  - principal_curvatures_log
+  save_raw_obs: false
+  # CameraSM will only send an observation to the LM if features or location
+  # changed more than these amounts.
+  delta_thresholds:
+    on_object: 0
+    n_steps: 20
+    hsv:
+    - 0.1
+    - 0.1
+    - 0.1
+    pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+    principal_curvatures_log:
+    - 2
+    - 2
+    distance: 0.01
+  is_surface_sm: true # for surface agent
+  # Let's add some noise to the sensor module outputs to make the task more challenging.
+  noise_params:
     features:
-    - pose_vectors
-    - pose_fully_defined
-    - on_object
-    - object_coverage
-    - min_depth
-    - mean_depth
-    - hsv
-    - principal_curvatures
-    - principal_curvatures_log
-    save_raw_obs: false
-    # CameraSM will only send an observation to the LM if features or location
-    # changed more than these amounts.
-    delta_thresholds:
-      on_object: 0
-      n_steps: 20
-      hsv:
-      - 0.1
-      - 0.1
-      - 0.1
-      pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-      principal_curvatures_log:
-      - 2
-      - 2
-      distance: 0.01
-    is_surface_sm: true # for surface agent
-    # Let's add some noise to the sensor module outputs to make the task more challenging.
-    noise_params:
-      features:
-        pose_vectors: 2 # rotate by random degrees along xyz
-        hsv: ${np.array:[0.1, 0.2, 0.2]} # add noise to each channel (the values here specify std. deviation of gaussian for each channel individually)
-        principal_curvatures_log: 0.1
-        pose_fully_defined: 0.01 # flip bool in 1% of cases
-      location: 0.002 # add gaussian noise with 0.002 std (0.2cm)
+      pose_vectors: 2 # rotate by random degrees along xyz
+      hsv: ${np.array:[0.1, 0.2, 0.2]} # add noise to each channel (the values here specify std. deviation of gaussian for each channel individually)
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01 # flip bool in 1% of cases
+    location: 0.002 # add gaussian noise with 0.002 std (0.2cm)
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: false
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/camera_tutorial_surf_agent_2obj.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/camera_tutorial_surf_agent_2obj.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch
   # Features that will be extracted and sent to LM
   # note: don't have to be all the features extracted during pretraining.
@@ -40,6 +40,6 @@ sensor_module_0:
       pose_fully_defined: 0.01 # flip bool in 1% of cases
     location: 0.002 # add gaussian noise with 0.002 std (0.2cm)
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: false

--- a/src/tbp/monty/conf/monty/sensor_module/fake.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/fake.yaml
@@ -1,5 +1,5 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tests.unit.frameworks.models.fakes.sensor_modules.FakeSensorModule}
+  _target_: tests.unit.frameworks.models.fakes.sensor_modules.FakeSensorModule
   sensor_module_id: sensor_id_0

--- a/src/tbp/monty/conf/monty/sensor_module/fake.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/fake.yaml
@@ -1,6 +1,5 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tests.unit.frameworks.models.fakes.sensor_modules.FakeSensorModule}
-  sensor_module_args:
-    sensor_module_id: sensor_id_0
+  _target_: ${monty.class:tests.unit.frameworks.models.fakes.sensor_modules.FakeSensorModule}
+  sensor_module_id: sensor_id_0

--- a/src/tbp/monty/conf/monty/sensor_module/test_camera_dist.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/test_camera_dist.yaml
@@ -1,7 +1,7 @@
 # @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
   sensor_module_id: patch
   features:
   - on_object
@@ -19,6 +19,6 @@ sensor_module_0:
       curvature_directions: 2
     location: 0.002
 sensor_module_1:
-  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  _target_: tbp.monty.frameworks.models.sensor_modules.Probe
   sensor_module_id: view_finder
   save_raw_obs: true

--- a/src/tbp/monty/conf/monty/sensor_module/test_camera_dist.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/test_camera_dist.yaml
@@ -1,26 +1,24 @@
-# @package experiment.config.monty_config.sensor_module_configs
+# @package experiment.config.monty_config.sensor_modules
 
 sensor_module_0:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-  sensor_module_args:
-    sensor_module_id: patch
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+  sensor_module_id: patch
+  features:
+  - on_object
+  - hsv
+  - pose_vectors
+  - principal_curvatures_log
+  - pose_fully_defined
+  save_raw_obs: true
+  noise_params:
     features:
-    - on_object
-    - hsv
-    - pose_vectors
-    - principal_curvatures_log
-    - pose_fully_defined
-    save_raw_obs: true
-    noise_params:
-      features:
-        hsv: 0.1
-        principal_curvatures_log: 0.1
-        pose_fully_defined: 0.01
-        pose_vectors: 2
-        curvature_directions: 2
-      location: 0.002
+      hsv: 0.1
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01
+      pose_vectors: 2
+      curvature_directions: 2
+    location: 0.002
 sensor_module_1:
-  sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-  sensor_module_args:
-    sensor_module_id: view_finder
-    save_raw_obs: true
+  _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+  sensor_module_id: view_finder
+  save_raw_obs: true

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -36,10 +36,7 @@ from tbp.monty.frameworks.loggers.exp_logger import (
     LoggingCallbackHandler,
 )
 from tbp.monty.frameworks.loggers.wandb_handlers import WandbWrapper
-from tbp.monty.frameworks.models.abstract_monty_classes import (
-    LearningModule,
-    SensorModule,
-)
+from tbp.monty.frameworks.models.abstract_monty_classes import LearningModule
 from tbp.monty.frameworks.models.monty_base import MontyBase
 from tbp.monty.frameworks.utils.dataclass_utils import (
     get_subset_of_args,
@@ -153,16 +150,7 @@ class MontyExperiment:
             learning_modules[lm_id] = lm_class(**lm_args)
             learning_modules[lm_id].learning_module_id = lm_id
 
-        # Create sensor modules
-        sensor_module_configs = monty_config.pop("sensor_module_configs")
-        sensor_modules = {}
-        for sm_id, sm_cfg in sensor_module_configs.items():
-            sm_class = sm_cfg["sensor_module_class"]
-            sm_args = sm_cfg["sensor_module_args"]
-            assert issubclass(sm_class, SensorModule)
-            sensor_modules[sm_id] = sm_class(**sm_args)
-
-        # Create motor system
+        sensor_modules = monty_config.pop("sensor_modules")
         motor_system = monty_config.pop("motor_system_config")
 
         # Get mapping between sensor modules, learning modules and agents

--- a/tests/conf/snapshots/base_10multi_distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/base_10multi_distinctobj_dist_agent.yaml
@@ -63,7 +63,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -86,7 +86,7 @@ experiment:
             distance: 0.01
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/base_10multi_distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/base_10multi_distinctobj_dist_agent.yaml
@@ -61,36 +61,34 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/base_10simobj_surf_agent.yaml
+++ b/tests/conf/snapshots/base_10simobj_surf_agent.yaml
@@ -61,7 +61,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -88,7 +88,7 @@ experiment:
             distance: 0.01
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/base_10simobj_surf_agent.yaml
+++ b/tests/conf/snapshots/base_10simobj_surf_agent.yaml
@@ -59,40 +59,38 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.025
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/base_77obj_dist_agent.yaml
+++ b/tests/conf/snapshots/base_77obj_dist_agent.yaml
@@ -63,7 +63,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -86,7 +86,7 @@ experiment:
             distance: 0.01
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/base_77obj_dist_agent.yaml
+++ b/tests/conf/snapshots/base_77obj_dist_agent.yaml
@@ -61,36 +61,34 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/base_77obj_surf_agent.yaml
+++ b/tests/conf/snapshots/base_77obj_surf_agent.yaml
@@ -61,7 +61,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -88,7 +88,7 @@ experiment:
             distance: 0.01
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/base_77obj_surf_agent.yaml
+++ b/tests/conf/snapshots/base_77obj_surf_agent.yaml
@@ -59,40 +59,38 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.025
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/base_config_10distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/base_config_10distinctobj_dist_agent.yaml
@@ -63,7 +63,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -86,7 +86,7 @@ experiment:
             distance: 0.01
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/base_config_10distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/base_config_10distinctobj_dist_agent.yaml
@@ -61,36 +61,34 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/base_config_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/base_config_10distinctobj_surf_agent.yaml
@@ -61,7 +61,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -88,7 +88,7 @@ experiment:
             distance: 0.01
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/base_config_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/base_config_10distinctobj_surf_agent.yaml
@@ -59,40 +59,38 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.025
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/bright_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/bright_world_image_on_scanned_model.yaml
@@ -46,30 +46,28 @@ experiment:
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/bright_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/bright_world_image_on_scanned_model.yaml
@@ -48,7 +48,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -65,7 +65,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/dark_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/dark_world_image_on_scanned_model.yaml
@@ -46,30 +46,28 @@ experiment:
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/dark_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/dark_world_image_on_scanned_model.yaml
@@ -48,7 +48,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -65,7 +65,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/hand_intrusion_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/hand_intrusion_world_image_on_scanned_model.yaml
@@ -46,30 +46,28 @@ experiment:
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/hand_intrusion_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/hand_intrusion_world_image_on_scanned_model.yaml
@@ -48,7 +48,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -65,7 +65,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/infer_comp_lvl1_with_comp_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl1_with_comp_models.yaml
@@ -77,62 +77,59 @@ experiment:
               min_post_goal_success_steps: 5
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/infer_comp_lvl1_with_comp_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl1_with_comp_models.yaml
@@ -79,7 +79,7 @@ experiment:
               desired_object_distance: 0.03
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -104,7 +104,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -127,7 +127,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/infer_comp_lvl1_with_comp_models_and_burst_sampling.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl1_with_comp_models_and_burst_sampling.yaml
@@ -83,62 +83,59 @@ experiment:
             evidence_threshold_config: all
             object_evidence_threshold: 1
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/infer_comp_lvl1_with_comp_models_and_burst_sampling.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl1_with_comp_models_and_burst_sampling.yaml
@@ -85,7 +85,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -110,7 +110,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -133,7 +133,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/infer_comp_lvl1_with_monolithic_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl1_with_monolithic_models.yaml
@@ -77,62 +77,59 @@ experiment:
               min_post_goal_success_steps: 5
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/infer_comp_lvl1_with_monolithic_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl1_with_monolithic_models.yaml
@@ -79,7 +79,7 @@ experiment:
               desired_object_distance: 0.03
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -104,7 +104,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -127,7 +127,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/infer_comp_lvl2_with_comp_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl2_with_comp_models.yaml
@@ -77,62 +77,59 @@ experiment:
               min_post_goal_success_steps: 5
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/infer_comp_lvl2_with_comp_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl2_with_comp_models.yaml
@@ -79,7 +79,7 @@ experiment:
               desired_object_distance: 0.03
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -104,7 +104,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -127,7 +127,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/infer_comp_lvl3_with_comp_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl3_with_comp_models.yaml
@@ -77,62 +77,59 @@ experiment:
               min_post_goal_success_steps: 5
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/infer_comp_lvl3_with_comp_models.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl3_with_comp_models.yaml
@@ -79,7 +79,7 @@ experiment:
               desired_object_distance: 0.03
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -104,7 +104,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -127,7 +127,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/multi_object_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/multi_object_world_image_on_scanned_model.yaml
@@ -46,30 +46,28 @@ experiment:
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/multi_object_world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/multi_object_world_image_on_scanned_model.yaml
@@ -48,7 +48,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -65,7 +65,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/only_surf_agent_training_10obj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_10obj.yaml
@@ -50,7 +50,7 @@ experiment:
                 - 1
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -70,7 +70,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/only_surf_agent_training_10obj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_10obj.yaml
@@ -48,33 +48,31 @@ experiment:
                 - 0.1
                 - 1
                 - 1
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - min_depth
-            - mean_depth
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - min_depth
+          - mean_depth
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/only_surf_agent_training_10simobj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_10simobj.yaml
@@ -50,7 +50,7 @@ experiment:
                 - 1
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -70,7 +70,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/only_surf_agent_training_10simobj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_10simobj.yaml
@@ -48,33 +48,31 @@ experiment:
                 - 0.1
                 - 1
                 - 1
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - min_depth
-            - mean_depth
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - min_depth
+          - mean_depth
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/only_surf_agent_training_allobj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_allobj.yaml
@@ -50,7 +50,7 @@ experiment:
                 - 1
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -70,7 +70,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/only_surf_agent_training_allobj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_allobj.yaml
@@ -48,33 +48,31 @@ experiment:
                 - 0.1
                 - 1
                 - 1
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - min_depth
-            - mean_depth
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - min_depth
+          - mean_depth
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/only_surf_agent_training_numenta_lab_obj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_numenta_lab_obj.yaml
@@ -50,7 +50,7 @@ experiment:
                 - 1
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -70,7 +70,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/only_surf_agent_training_numenta_lab_obj.yaml
+++ b/tests/conf/snapshots/only_surf_agent_training_numenta_lab_obj.yaml
@@ -48,33 +48,31 @@ experiment:
                 - 0.1
                 - 1
                 - 1
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - min_depth
-            - mean_depth
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - min_depth
+          - mean_depth
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/randomrot_rawnoise_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randomrot_rawnoise_10distinctobj_surf_agent.yaml
@@ -59,38 +59,36 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.025
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_args:
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          sensor_module_id: patch
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          is_surface_sm: true
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            sensor_module_id: patch
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            is_surface_sm: true
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/randomrot_rawnoise_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randomrot_rawnoise_10distinctobj_surf_agent.yaml
@@ -61,7 +61,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - pose_vectors
           - pose_fully_defined
@@ -86,7 +86,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/randrot_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_10distinctobj_surf_agent.yaml
@@ -61,7 +61,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -88,7 +88,7 @@ experiment:
             distance: 0.01
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/randrot_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_10distinctobj_surf_agent.yaml
@@ -59,40 +59,38 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.025
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_5lms_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_5lms_dist_agent.yaml
@@ -195,7 +195,7 @@ experiment:
           tolerances: null
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features: ${constants.default_sensor_features}
           save_raw_obs: false
@@ -204,7 +204,7 @@ experiment:
             distance: 0.01
           noise_params: ${constants.default_all_noise_params}
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features: ${constants.default_sensor_features}
           save_raw_obs: false
@@ -213,7 +213,7 @@ experiment:
             distance: 0.01
           noise_params: ${constants.default_all_noise_params}
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_2
           features: ${constants.default_sensor_features}
           save_raw_obs: false
@@ -222,7 +222,7 @@ experiment:
             distance: 0.01
           noise_params: ${constants.default_all_noise_params}
         sensor_module_3:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_3
           features: ${constants.default_sensor_features}
           save_raw_obs: false
@@ -231,7 +231,7 @@ experiment:
             distance: 0.01
           noise_params: ${constants.default_all_noise_params}
         sensor_module_4:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_4
           features: ${constants.default_sensor_features}
           save_raw_obs: false
@@ -240,7 +240,7 @@ experiment:
             distance: 0.01
           noise_params: ${constants.default_all_noise_params}
         sensor_module_5:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_5lms_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_5lms_dist_agent.yaml
@@ -193,62 +193,56 @@ experiment:
               desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
           tolerances: null
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features: ${constants.default_sensor_features}
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            noise_params: ${constants.default_all_noise_params}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features: ${constants.default_sensor_features}
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            noise_params: ${constants.default_all_noise_params}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_2
-            features: ${constants.default_sensor_features}
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            noise_params: ${constants.default_all_noise_params}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_2
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
         sensor_module_3:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_3
-            features: ${constants.default_sensor_features}
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            noise_params: ${constants.default_all_noise_params}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_3
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
         sensor_module_4:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_4
-            features: ${constants.default_sensor_features}
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            noise_params: ${constants.default_all_noise_params}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_4
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
         sensor_module_5:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_dist_agent.yaml
@@ -61,33 +61,31 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          save_raw_obs: false
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            save_raw_obs: false
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_dist_agent.yaml
@@ -63,7 +63,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -83,7 +83,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_dist_on_distm.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_dist_on_distm.yaml
@@ -61,33 +61,31 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          save_raw_obs: false
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            save_raw_obs: false
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_dist_on_distm.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_dist_on_distm.yaml
@@ -63,7 +63,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -83,7 +83,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_surf_agent.yaml
@@ -59,38 +59,36 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.025
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_args:
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          sensor_module_id: patch
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          is_surface_sm: true
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            sensor_module_id: patch
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            is_surface_sm: true
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_surf_agent.yaml
@@ -61,7 +61,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - pose_vectors
           - pose_fully_defined
@@ -86,7 +86,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/randrot_noise_10simobj_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10simobj_dist_agent.yaml
@@ -61,33 +61,31 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          save_raw_obs: false
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            save_raw_obs: false
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/randrot_noise_10simobj_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10simobj_dist_agent.yaml
@@ -63,7 +63,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -83,7 +83,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/randrot_noise_10simobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10simobj_surf_agent.yaml
@@ -59,38 +59,36 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.025
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_args:
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          sensor_module_id: patch
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          is_surface_sm: true
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            sensor_module_id: patch
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            is_surface_sm: true
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/randrot_noise_10simobj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_10simobj_surf_agent.yaml
@@ -61,7 +61,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - pose_vectors
           - pose_fully_defined
@@ -86,7 +86,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/randrot_noise_77obj_5lms_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_5lms_dist_agent.yaml
@@ -195,7 +195,7 @@ experiment:
           tolerances: null
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features: ${constants.default_sensor_features}
           save_raw_obs: false
@@ -204,7 +204,7 @@ experiment:
             distance: 0.01
           noise_params: ${constants.default_all_noise_params}
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features: ${constants.default_sensor_features}
           save_raw_obs: false
@@ -213,7 +213,7 @@ experiment:
             distance: 0.01
           noise_params: ${constants.default_all_noise_params}
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_2
           features: ${constants.default_sensor_features}
           save_raw_obs: false
@@ -222,7 +222,7 @@ experiment:
             distance: 0.01
           noise_params: ${constants.default_all_noise_params}
         sensor_module_3:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_3
           features: ${constants.default_sensor_features}
           save_raw_obs: false
@@ -231,7 +231,7 @@ experiment:
             distance: 0.01
           noise_params: ${constants.default_all_noise_params}
         sensor_module_4:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_4
           features: ${constants.default_sensor_features}
           save_raw_obs: false
@@ -240,7 +240,7 @@ experiment:
             distance: 0.01
           noise_params: ${constants.default_all_noise_params}
         sensor_module_5:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/randrot_noise_77obj_5lms_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_5lms_dist_agent.yaml
@@ -193,62 +193,56 @@ experiment:
               desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
           tolerances: null
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features: ${constants.default_sensor_features}
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            noise_params: ${constants.default_all_noise_params}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features: ${constants.default_sensor_features}
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            noise_params: ${constants.default_all_noise_params}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_2
-            features: ${constants.default_sensor_features}
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            noise_params: ${constants.default_all_noise_params}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_2
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
         sensor_module_3:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_3
-            features: ${constants.default_sensor_features}
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            noise_params: ${constants.default_all_noise_params}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_3
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
         sensor_module_4:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_4
-            features: ${constants.default_sensor_features}
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            noise_params: ${constants.default_all_noise_params}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_4
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
         sensor_module_5:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/randrot_noise_77obj_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_dist_agent.yaml
@@ -61,33 +61,31 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          save_raw_obs: false
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            save_raw_obs: false
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/randrot_noise_77obj_dist_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_dist_agent.yaml
@@ -63,7 +63,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -83,7 +83,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/randrot_noise_77obj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_surf_agent.yaml
@@ -59,38 +59,36 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.025
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_args:
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          sensor_module_id: patch
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          is_surface_sm: true
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            sensor_module_id: patch
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            is_surface_sm: true
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/randrot_noise_77obj_surf_agent.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_surf_agent.yaml
@@ -61,7 +61,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - pose_vectors
           - pose_fully_defined
@@ -86,7 +86,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/randrot_noise_sim_on_scan_monty_world.yaml
+++ b/tests/conf/snapshots/randrot_noise_sim_on_scan_monty_world.yaml
@@ -46,33 +46,31 @@ experiment:
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          save_raw_obs: false
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            save_raw_obs: false
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/randrot_noise_sim_on_scan_monty_world.yaml
+++ b/tests/conf/snapshots/randrot_noise_sim_on_scan_monty_world.yaml
@@ -48,7 +48,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -68,7 +68,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/supervised_pre_training_5lms.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_5lms.yaml
@@ -53,7 +53,7 @@ experiment:
             match_attribute: displacement
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -68,7 +68,7 @@ experiment:
           sensor_module_id: patch_0
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -83,7 +83,7 @@ experiment:
           sensor_module_id: patch_1
           save_raw_obs: false
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -98,7 +98,7 @@ experiment:
           sensor_module_id: patch_2
           save_raw_obs: false
         sensor_module_3:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -113,7 +113,7 @@ experiment:
           sensor_module_id: patch_3
           save_raw_obs: false
         sensor_module_4:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -128,7 +128,7 @@ experiment:
           sensor_module_id: patch_4
           save_raw_obs: false
         sensor_module_5:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/supervised_pre_training_5lms.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_5lms.yaml
@@ -51,92 +51,86 @@ experiment:
           learning_module_args:
             k: 5
             match_attribute: displacement
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_0
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_0
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_1
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_1
+          save_raw_obs: false
         sensor_module_2:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_2
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_2
+          save_raw_obs: false
         sensor_module_3:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_3
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_3
+          save_raw_obs: false
         sensor_module_4:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_4
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_4
+          save_raw_obs: false
         sensor_module_5:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/supervised_pre_training_5lms_all_objects.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_5lms_all_objects.yaml
@@ -53,7 +53,7 @@ experiment:
             match_attribute: displacement
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -68,7 +68,7 @@ experiment:
           sensor_module_id: patch_0
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -83,7 +83,7 @@ experiment:
           sensor_module_id: patch_1
           save_raw_obs: false
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -98,7 +98,7 @@ experiment:
           sensor_module_id: patch_2
           save_raw_obs: false
         sensor_module_3:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -113,7 +113,7 @@ experiment:
           sensor_module_id: patch_3
           save_raw_obs: false
         sensor_module_4:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -128,7 +128,7 @@ experiment:
           sensor_module_id: patch_4
           save_raw_obs: false
         sensor_module_5:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/supervised_pre_training_5lms_all_objects.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_5lms_all_objects.yaml
@@ -51,92 +51,86 @@ experiment:
           learning_module_args:
             k: 5
             match_attribute: displacement
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_0
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_0
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_1
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_1
+          save_raw_obs: false
         sensor_module_2:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_2
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_2
+          save_raw_obs: false
         sensor_module_3:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_3
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_3
+          save_raw_obs: false
         sensor_module_4:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_4
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_4
+          save_raw_obs: false
         sensor_module_5:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/supervised_pre_training_base.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_base.yaml
@@ -43,30 +43,28 @@ experiment:
                 - 0.1
                 - 1
                 - 1
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/supervised_pre_training_base.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_base.yaml
@@ -45,7 +45,7 @@ experiment:
                 - 1
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -62,7 +62,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/supervised_pre_training_curved_objects_after_flat_and_logo.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_curved_objects_after_flat_and_logo.yaml
@@ -55,62 +55,59 @@ experiment:
             max_graph_size: 0.4
             num_model_voxels_per_dim: 200
             max_nodes_per_graph: 2000
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/supervised_pre_training_curved_objects_after_flat_and_logo.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_curved_objects_after_flat_and_logo.yaml
@@ -57,7 +57,7 @@ experiment:
             max_nodes_per_graph: 2000
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -82,7 +82,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -105,7 +105,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/supervised_pre_training_flat_objects_wo_logos.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_flat_objects_wo_logos.yaml
@@ -55,62 +55,59 @@ experiment:
             max_graph_size: 0.4
             num_model_voxels_per_dim: 200
             max_nodes_per_graph: 2000
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/supervised_pre_training_flat_objects_wo_logos.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_flat_objects_wo_logos.yaml
@@ -57,7 +57,7 @@ experiment:
             max_nodes_per_graph: 2000
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -82,7 +82,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -105,7 +105,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/supervised_pre_training_logos_after_flat_objects.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_logos_after_flat_objects.yaml
@@ -55,62 +55,59 @@ experiment:
             max_graph_size: 0.4
             num_model_voxels_per_dim: 200
             max_nodes_per_graph: 2000
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/supervised_pre_training_logos_after_flat_objects.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_logos_after_flat_objects.yaml
@@ -57,7 +57,7 @@ experiment:
             max_nodes_per_graph: 2000
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -82,7 +82,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -105,7 +105,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models.yaml
@@ -55,62 +55,59 @@ experiment:
             max_graph_size: 0.4
             num_model_voxels_per_dim: 200
             max_nodes_per_graph: 2000
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models.yaml
@@ -57,7 +57,7 @@ experiment:
             max_nodes_per_graph: 2000
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -82,7 +82,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -105,7 +105,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models_burst_sampling.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models_burst_sampling.yaml
@@ -73,62 +73,59 @@ experiment:
             max_graph_size: 0.4
             num_model_voxels_per_dim: 200
             max_nodes_per_graph: 2000
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models_burst_sampling.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_comp_models_burst_sampling.yaml
@@ -75,7 +75,7 @@ experiment:
             max_nodes_per_graph: 2000
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -100,7 +100,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -123,7 +123,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_monolithic_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_monolithic_models.yaml
@@ -55,62 +55,59 @@ experiment:
             max_graph_size: 0.4
             num_model_voxels_per_dim: 200
             max_nodes_per_graph: 2000
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_monolithic_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl1_monolithic_models.yaml
@@ -57,7 +57,7 @@ experiment:
             max_nodes_per_graph: 2000
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -82,7 +82,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -105,7 +105,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl2_comp_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl2_comp_models.yaml
@@ -55,62 +55,59 @@ experiment:
             max_graph_size: 0.4
             num_model_voxels_per_dim: 200
             max_nodes_per_graph: 2000
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl2_comp_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl2_comp_models.yaml
@@ -57,7 +57,7 @@ experiment:
             max_nodes_per_graph: 2000
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -82,7 +82,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -105,7 +105,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl3_comp_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl3_comp_models.yaml
@@ -55,62 +55,59 @@ experiment:
             max_graph_size: 0.4
             num_model_voxels_per_dim: 200
             max_nodes_per_graph: 2000
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_0
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch_1
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              n_steps: 100
-              hsv:
-              - 0.2
-              - 0.2
-              - 0.2
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 4
-              - 4
-              distance: 0.05
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: true
         sensor_module_2:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl3_comp_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_objects_with_logos_lvl3_comp_models.yaml
@@ -57,7 +57,7 @@ experiment:
             max_nodes_per_graph: 2000
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_0
           features:
           - pose_vectors
@@ -82,7 +82,7 @@ experiment:
             distance: 0.01
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch_1
           features:
           - pose_vectors
@@ -105,7 +105,7 @@ experiment:
             distance: 0.05
           save_raw_obs: true
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj.yaml
+++ b/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj.yaml
@@ -58,7 +58,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -77,7 +77,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj.yaml
+++ b/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj.yaml
@@ -56,32 +56,30 @@ experiment:
             hypotheses_updater_args:
               max_nneighbors: 5
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj_noise.yaml
+++ b/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj_noise.yaml
@@ -58,7 +58,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - pose_vectors
           - pose_fully_defined
@@ -83,7 +83,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj_noise.yaml
+++ b/tests/conf/snapshots/surf_agent_unsupervised_10distinctobj_noise.yaml
@@ -56,38 +56,36 @@ experiment:
             hypotheses_updater_args:
               max_nneighbors: 5
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_args:
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          sensor_module_id: patch
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          is_surface_sm: true
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            sensor_module_id: patch
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            is_surface_sm: true
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/surf_agent_unsupervised_10simobj.yaml
+++ b/tests/conf/snapshots/surf_agent_unsupervised_10simobj.yaml
@@ -58,7 +58,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -77,7 +77,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/surf_agent_unsupervised_10simobj.yaml
+++ b/tests/conf/snapshots/surf_agent_unsupervised_10simobj.yaml
@@ -56,32 +56,30 @@ experiment:
             hypotheses_updater_args:
               max_nneighbors: 5
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_eval.yaml
+++ b/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_eval.yaml
@@ -135,7 +135,7 @@ experiment:
                 principal_curvatures_log: ${np.ones:2}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -150,7 +150,7 @@ experiment:
           sensor_module_id: patch_0
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -165,7 +165,7 @@ experiment:
           sensor_module_id: patch_1
           save_raw_obs: false
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -180,7 +180,7 @@ experiment:
           sensor_module_id: patch_2
           save_raw_obs: false
         sensor_module_3:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -195,7 +195,7 @@ experiment:
           sensor_module_id: patch_3
           save_raw_obs: false
         sensor_module_4:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -210,7 +210,7 @@ experiment:
           sensor_module_id: patch_4
           save_raw_obs: false
         sensor_module_5:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_eval.yaml
+++ b/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_eval.yaml
@@ -133,92 +133,86 @@ experiment:
               patch_4:
                 hsv: ${np.array:[0.1, 0.2, 0.2]}
                 principal_curvatures_log: ${np.ones:2}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_0
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_0
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_1
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_1
+          save_raw_obs: false
         sensor_module_2:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_2
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_2
+          save_raw_obs: false
         sensor_module_3:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_3
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_3
+          save_raw_obs: false
         sensor_module_4:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_4
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_4
+          save_raw_obs: false
         sensor_module_5:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_train.yaml
+++ b/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_train.yaml
@@ -53,7 +53,7 @@ experiment:
             match_attribute: displacement
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -68,7 +68,7 @@ experiment:
           sensor_module_id: patch_0
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -83,7 +83,7 @@ experiment:
           sensor_module_id: patch_1
           save_raw_obs: false
         sensor_module_2:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -98,7 +98,7 @@ experiment:
           sensor_module_id: patch_2
           save_raw_obs: false
         sensor_module_3:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -113,7 +113,7 @@ experiment:
           sensor_module_id: patch_3
           save_raw_obs: false
         sensor_module_4:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - on_object
           - rgba
@@ -128,7 +128,7 @@ experiment:
           sensor_module_id: patch_4
           save_raw_obs: false
         sensor_module_5:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_train.yaml
+++ b/tests/conf/snapshots/tutorial/dist_agent_5lm_2obj_train.yaml
@@ -51,92 +51,86 @@ experiment:
           learning_module_args:
             k: 5
             match_attribute: displacement
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_0
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_0
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_1
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_1
+          save_raw_obs: false
         sensor_module_2:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_2
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_2
+          save_raw_obs: false
         sensor_module_3:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_3
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_3
+          save_raw_obs: false
         sensor_module_4:
-          sensor_module_args:
-            features:
-            - on_object
-            - rgba
-            - hsv
-            - pose_vectors
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            sensor_module_id: patch_4
-            save_raw_obs: false
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - on_object
+          - rgba
+          - hsv
+          - pose_vectors
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          sensor_module_id: patch_4
+          save_raw_obs: false
         sensor_module_5:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch_0: agent_id_0
         patch_1: agent_id_0

--- a/tests/conf/snapshots/tutorial/first_experiment.yaml
+++ b/tests/conf/snapshots/tutorial/first_experiment.yaml
@@ -30,30 +30,28 @@ experiment:
           learning_module_args:
             k: 5
             match_attribute: displacement
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/tutorial/first_experiment.yaml
+++ b/tests/conf/snapshots/tutorial/first_experiment.yaml
@@ -32,7 +32,7 @@ experiment:
             match_attribute: displacement
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -49,7 +49,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/tutorial/monty_meets_world_2dimage_inference.yaml
+++ b/tests/conf/snapshots/tutorial/monty_meets_world_2dimage_inference.yaml
@@ -46,30 +46,28 @@ experiment:
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/tutorial/monty_meets_world_2dimage_inference.yaml
+++ b/tests/conf/snapshots/tutorial/monty_meets_world_2dimage_inference.yaml
@@ -48,7 +48,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -65,7 +65,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/tutorial/omniglot_inference.yaml
+++ b/tests/conf/snapshots/tutorial/omniglot_inference.yaml
@@ -46,7 +46,7 @@ experiment:
                 - 0
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -56,7 +56,7 @@ experiment:
           save_raw_obs: false
           pc1_is_pc2_threshold: 1
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/tutorial/omniglot_inference.yaml
+++ b/tests/conf/snapshots/tutorial/omniglot_inference.yaml
@@ -44,23 +44,21 @@ experiment:
               - - 0
                 - 0
                 - 0
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - principal_curvatures_log
-            save_raw_obs: false
-            pc1_is_pc2_threshold: 1
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - principal_curvatures_log
+          save_raw_obs: false
+          pc1_is_pc2_threshold: 1
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/tutorial/omniglot_training.yaml
+++ b/tests/conf/snapshots/tutorial/omniglot_training.yaml
@@ -32,7 +32,7 @@ experiment:
             match_attribute: displacement
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -42,7 +42,7 @@ experiment:
           save_raw_obs: false
           pc1_is_pc2_threshold: 1
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/tutorial/omniglot_training.yaml
+++ b/tests/conf/snapshots/tutorial/omniglot_training.yaml
@@ -30,23 +30,21 @@ experiment:
           learning_module_args:
             k: 5
             match_attribute: displacement
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - principal_curvatures_log
-            save_raw_obs: false
-            pc1_is_pc2_threshold: 1
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - principal_curvatures_log
+          save_raw_obs: false
+          pc1_is_pc2_threshold: 1
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/tutorial/surf_agent_2obj_eval.yaml
+++ b/tests/conf/snapshots/tutorial/surf_agent_2obj_eval.yaml
@@ -53,47 +53,45 @@ experiment:
               min_post_goal_success_steps: 5
             hypotheses_updater_args:
               max_nneighbors: 10
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          is_surface_sm: true
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              n_steps: 20
-              hsv:
-              - 0.1
-              - 0.1
-              - 0.1
-              pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-              principal_curvatures_log:
-              - 2
-              - 2
-              distance: 0.01
-            is_surface_sm: true
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: ${np.array:[0.1, 0.2, 0.2]}
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
+              pose_vectors: 2
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/tutorial/surf_agent_2obj_eval.yaml
+++ b/tests/conf/snapshots/tutorial/surf_agent_2obj_eval.yaml
@@ -55,7 +55,7 @@ experiment:
               max_nneighbors: 10
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -89,7 +89,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/tutorial/surf_agent_2obj_train.yaml
+++ b/tests/conf/snapshots/tutorial/surf_agent_2obj_train.yaml
@@ -37,7 +37,7 @@ experiment:
           learning_module_args: {}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -57,7 +57,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: false
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/tutorial/surf_agent_2obj_train.yaml
+++ b/tests/conf/snapshots/tutorial/surf_agent_2obj_train.yaml
@@ -35,33 +35,31 @@ experiment:
         learning_module_0:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.graph_matching.GraphLM}
           learning_module_args: {}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - min_depth
-            - mean_depth
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - min_depth
+          - mean_depth
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: false
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/tutorial/surf_agent_2obj_unsupervised.yaml
+++ b/tests/conf/snapshots/tutorial/surf_agent_2obj_unsupervised.yaml
@@ -56,32 +56,30 @@ experiment:
             required_symmetry_evidence: 20
             hypotheses_updater_args:
               max_nneighbors: 5
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            is_surface_sm: true
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/tutorial/surf_agent_2obj_unsupervised.yaml
+++ b/tests/conf/snapshots/tutorial/surf_agent_2obj_unsupervised.yaml
@@ -58,7 +58,7 @@ experiment:
               max_nneighbors: 5
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           is_surface_sm: true
           sensor_module_id: patch
           features:
@@ -77,7 +77,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/unsupervised_inference_distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/unsupervised_inference_distinctobj_dist_agent.yaml
@@ -63,7 +63,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.no_reset_evidence_matching.NoResetEvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -83,7 +83,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/unsupervised_inference_distinctobj_dist_agent.yaml
+++ b/tests/conf/snapshots/unsupervised_inference_distinctobj_dist_agent.yaml
@@ -61,33 +61,31 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.03
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.no_reset_evidence_matching.NoResetEvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          save_raw_obs: false
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - hsv
-            - principal_curvatures_log
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            save_raw_obs: false
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/unsupervised_inference_distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/unsupervised_inference_distinctobj_surf_agent.yaml
@@ -61,7 +61,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.no_reset_evidence_matching.NoResetEvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           features:
           - pose_vectors
           - pose_fully_defined
@@ -86,7 +86,7 @@ experiment:
               pose_fully_defined: 0.01
             location: 0.002
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:

--- a/tests/conf/snapshots/unsupervised_inference_distinctobj_surf_agent.yaml
+++ b/tests/conf/snapshots/unsupervised_inference_distinctobj_surf_agent.yaml
@@ -59,38 +59,36 @@ experiment:
               x_percent_scale_factor: 0.75
               desired_object_distance: 0.025
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.no_reset_evidence_matching.NoResetEvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_args:
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          sensor_module_id: patch
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          is_surface_sm: true
+          noise_params:
             features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - min_depth
-            - mean_depth
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            sensor_module_id: patch
-            save_raw_obs: false
-            delta_thresholds:
-              on_object: 0
-              distance: 0.01
-            is_surface_sm: true
-            noise_params:
-              features:
-                pose_vectors: 2
-                hsv: 0.1
-                principal_curvatures_log: 0.1
-                pose_fully_defined: 0.01
-              location: 0.002
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: false
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/world_image_from_stream_on_scanned_model.yaml
+++ b/tests/conf/snapshots/world_image_from_stream_on_scanned_model.yaml
@@ -46,30 +46,28 @@ experiment:
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/world_image_from_stream_on_scanned_model.yaml
+++ b/tests/conf/snapshots/world_image_from_stream_on_scanned_model.yaml
@@ -48,7 +48,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -65,7 +65,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/conf/snapshots/world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/world_image_on_scanned_model.yaml
@@ -46,30 +46,28 @@ experiment:
             max_graph_size: 0.3
             num_model_voxels_per_dim: 100
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
-      sensor_module_configs:
+      sensor_modules:
         sensor_module_0:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
-          sensor_module_args:
-            sensor_module_id: patch
-            features:
-            - pose_vectors
-            - pose_fully_defined
-            - on_object
-            - object_coverage
-            - rgba
-            - hsv
-            - principal_curvatures
-            - principal_curvatures_log
-            - gaussian_curvature
-            - mean_curvature
-            - gaussian_curvature_sc
-            - mean_curvature_sc
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - rgba
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          - gaussian_curvature
+          - mean_curvature
+          - gaussian_curvature_sc
+          - mean_curvature_sc
+          save_raw_obs: true
         sensor_module_1:
-          sensor_module_class: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
-          sensor_module_args:
-            sensor_module_id: view_finder
-            save_raw_obs: true
+          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          sensor_module_id: view_finder
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0

--- a/tests/conf/snapshots/world_image_on_scanned_model.yaml
+++ b/tests/conf/snapshots/world_image_on_scanned_model.yaml
@@ -48,7 +48,7 @@ experiment:
           learning_module_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM}
       sensor_modules:
         sensor_module_0:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.CameraSM}
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
           sensor_module_id: patch
           features:
           - pose_vectors
@@ -65,7 +65,7 @@ experiment:
           - mean_curvature_sc
           save_raw_obs: true
         sensor_module_1:
-          _target_: ${monty.class:tbp.monty.frameworks.models.sensor_modules.Probe}
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: true
       sm_to_agent_dict:

--- a/tests/integration/frameworks/models/sensor_module_test.py
+++ b/tests/integration/frameworks/models/sensor_module_test.py
@@ -93,8 +93,8 @@ class SensorModuleTest(unittest.TestCase):
 
             # Dig the features list out of the hydra config
             config = self.sensor_feature_cfg.experiment.config
-            sensor_configs = config.monty_config.sensor_module_configs
-            tested_features = sensor_configs.sensor_module_0.sensor_module_args.features
+            sensor_modules = config.monty_config.sensor_modules
+            tested_features = sensor_modules.sensor_module_0.features
             for feature in tested_features:
                 if feature in ["pose_vectors", "pose_fully_defined", "on_object"]:
                     self.assertIn(


### PR DESCRIPTION
This pull request removes the `_class`/`_args` initialization pattern from `sensor_module_configs` and renames `sensor_module_configs` to `sensor_modules`.

Notably, Hydra creates Sensor Modules instead of Monty.

## Review Notes

Lots of lines changed, but most of them are because once I got rid of `sensor_module_args` in configs, the indentation of everything nested under those had to change. So, every single configured sensor module argument is part of this diff :/.

**suggestion**: Use the "hide whitespace" review mode.

## Breaking Changes
- `sensor_module_configs` configuration parameter renamed to `sensor_modules`
- `sensor_module_class` and `sensor_module_args` configuration replaced with `_target_` and the usual way of passing arguments to a `_target_`.

## Benchmarks

No changes

| Experiment | Metric | Baseline | Proposed | Change |
| --- | --- | --- | --- | --- |
| base_config_10distinctobj_dist_agent | percent_correct (%) | 100 | 100 | 0 |
|  | used_mlh (%) | 2.86 | 2.86 | 0 |
|  | match_steps | 34 | 34 | 0 |
|  | rotation_error (deg) | 8.64 | 8.64 | 0 |
|  | runtime (min) | 3 | 3 | 0 |
|  | episode_runtime (sec) | 7 | 8 | 1 |
|  | num_episodes | 140 | 140 | 0 |
| base_config_10distinctobj_surf_agent | percent_correct (%) | 100 | 100 | 0 |
|  | used_mlh (%) | 0 | 0 | 0 |
|  | match_steps | 28 | 28 | 0 |
|  | rotation_error (deg) | 3.87 | 3.87 | 0 |
|  | runtime (min) | 3 | 3 | 0 |
|  | episode_runtime (sec) | 11 | 11 | 0 |
|  | num_episodes | 140 | 140 | 0 |
| randrot_noise_10distinctobj_dist_agent | percent_correct (%) | 100 | 100 | 0 |
|  | used_mlh (%) | 2 | 2 | 0 |
|  | match_steps | 35 | 35 | 0 |
|  | rotation_error (deg) | 13.23 | 13.23 | 0 |
|  | runtime (min) | 3 | 3 | 0 |
|  | episode_runtime (sec) | 14 | 14 | 0 |
|  | num_episodes | 100 | 100 | 0 |
| randrot_noise_10distinctobj_dist_on_distm | percent_correct (%) | 100 | 100 | 0 |
|  | used_mlh (%) | 3 | 3 | 0 |
|  | match_steps | 31 | 31 | 0 |
|  | rotation_error (deg) | 15.42 | 15.42 | 0 |
|  | runtime (min) | 3 | 3 | 0 |
|  | episode_runtime (sec) | 13 | 13 | 0 |
|  | num_episodes | 100 | 100 | 0 |
| randrot_noise_10distinctobj_surf_agent | percent_correct (%) | 100 | 100 | 0 |
|  | used_mlh (%) | 0 | 0 | 0 |
|  | match_steps | 29 | 29 | 0 |
|  | rotation_error (deg) | 10.37 | 10.37 | 0 |
|  | runtime (min) | 4 | 4 | 0 |
|  | episode_runtime (sec) | 27 | 27 | 0 |
|  | num_episodes | 100 | 100 | 0 |
| randrot_10distinctobj_surf_agent | percent_correct (%) | 100 | 100 | 0 |
|  | used_mlh (%) | 0 | 0 | 0 |
|  | match_steps | 29 | 29 | 0 |
|  | rotation_error (deg) | 5.16 | 5.16 | 0 |
|  | runtime (min) | 2 | 2 | 0 |
|  | episode_runtime (sec) | 11 | 12 | 1 |
|  | num_episodes | 100 | 100 | 0 |
| randrot_noise_10distinctobj_5lms_dist_agent | percent_correct (%) | 100 | 100 | 0 |
|  | used_mlh (%) | 1 | 1 | 0 |
|  | match_steps | 50 | 50 | 0 |
|  | rotation_error (deg) | 56.65 | 56.65 | 0 |
|  | runtime (min) | 6 | 6 | 0 |
|  | episode_runtime (sec) | 37 | 33 | -4 |
|  | num_episodes | 100 | 100 | 0 |
| base_10simobj_surf_agent | percent_correct (%) | 98.57 | 98.57 | 0 |
|  | used_mlh (%) | 4.29 | 4.29 | 0 |
|  | match_steps | 53 | 53 | 0 |
|  | rotation_error (deg) | 3.53 | 3.53 | 0 |
|  | runtime (min) | 4 | 5 | 1 |
|  | episode_runtime (sec) | 18 | 22 | 4 |
|  | num_episodes | 140 | 140 | 0 |
| randrot_noise_10simobj_dist_agent | percent_correct (%) | 88 | 88 | 0 |
|  | used_mlh (%) | 32 | 32 | 0 |
|  | match_steps | 202 | 202 | 0 |
|  | rotation_error (deg) | 30.3 | 30.3 | 0 |
|  | runtime (min) | 10 | 11 | 1 |
|  | episode_runtime (sec) | 75 | 78 | 3 |
|  | num_episodes | 100 | 100 | 0 |
| randrot_noise_10simobj_surf_agent | percent_correct (%) | 97 | 97 | 0 |
|  | used_mlh (%) | 28 | 28 | 0 |
|  | match_steps | 157 | 157 | 0 |
|  | rotation_error (deg) | 18.01 | 18.01 | 0 |
|  | runtime (min) | 18 | 17 | -1 |
|  | episode_runtime (sec) | 144 | 135 | -9 |
|  | num_episodes | 100 | 100 | 0 |
| randomrot_rawnoise_10distinctobj_surf_agent | percent_correct (%) | 67 | 67 | 0 |
|  | used_mlh (%) | 75 | 75 | 0 |
|  | match_steps | 13 | 13 | 0 |
|  | rotation_error (deg) | 105.66 | 105.66 | 0 |
|  | runtime (min) | 5 | 5 | 0 |
|  | episode_runtime (sec) | 7 | 7 | 0 |
|  | num_episodes | 100 | 100 | 0 |
| base_10multi_distinctobj_dist_agent | percent_correct (%) | 47.14 | 47.14 | 0 |
|  | used_mlh (%) | 4.29 | 4.29 | 0 |
|  | match_steps | 33 | 33 | 0 |
|  | rotation_error (deg) | 18.42 | 18.42 | 0 |
|  | runtime (min) | 36 | 43 | 7 |
|  | episode_runtime (sec) | 2 | 2 | 0 |
|  | num_episodes | 140 | 140 | 0 |
| base_77obj_dist_agent | percent_correct (%) | 93.94 | 93.94 | 0 |
|  | used_mlh (%) | 10.39 | 10.39 | 0 |
|  | match_steps | 78 | 78 | 0 |
|  | rotation_error (deg) | 11.1 | 11.1 | 0 |
|  | runtime (min) | 16 | 14 | -2 |
|  | episode_runtime (sec) | 41 | 37 | -4 |
|  | num_episodes | 231 | 231 | 0 |
| base_77obj_surf_agent | percent_correct (%) | 100 | 100 | 0 |
|  | used_mlh (%) | 4.33 | 4.33 | 0 |
|  | match_steps | 45 | 45 | 0 |
|  | rotation_error (deg) | 4.14 | 4.14 | 0 |
|  | runtime (min) | 13 | 12 | -1 |
|  | episode_runtime (sec) | 31 | 27 | -4 |
|  | num_episodes | 231 | 231 | 0 |
| randrot_noise_77obj_dist_agent | percent_correct (%) | 88.74 | 88.74 | 0 |
|  | used_mlh (%) | 17.75 | 17.75 | 0 |
|  | match_steps | 120 | 120 | 0 |
|  | rotation_error (deg) | 33.03 | 33.03 | 0 |
|  | runtime (min) | 26 | 28 | 2 |
|  | episode_runtime (sec) | 75 | 81 | 6 |
|  | num_episodes | 231 | 231 | 0 |
| randrot_noise_77obj_surf_agent | percent_correct (%) | 99.57 | 99.57 | 0 |
|  | used_mlh (%) | 20.35 | 20.35 | 0 |
|  | match_steps | 109 | 109 | 0 |
|  | rotation_error (deg) | 23.73 | 23.73 | 0 |
|  | runtime (min) | 37 | 34 | -3 |
|  | episode_runtime (sec) | 121 | 110 | -11 |
|  | num_episodes | 231 | 231 | 0 |
| randrot_noise_77obj_5lms_dist_agent | percent_correct (%) | 96.1 | 96.1 | 0 |
|  | used_mlh (%) | 1.3 | 1.3 | 0 |
|  | match_steps | 68 | 68 | 0 |
|  | rotation_error (deg) | 57.04 | 57.04 | 0 |
|  | runtime (min) | 16 | 16 | 0 |
|  | episode_runtime (sec) | 144 | 140 | -4 |
|  | num_episodes | 77 | 77 | 0 |
| unsupervised_inference_distinctobj_dist_agent | percent_correct (%) | 97 | 97 | 0 |
|  | match_steps | 97 | 97 | 0 |
|  | runtime (min) | 12 | 12 | 0 |
|  | episode_runtime (sec) | 5 | 4 | -1 |
|  | num_episodes | 100 | 100 | 0 |
| unsupervised_inference_distinctobj_surf_agent | percent_correct (%) | 100 | 100 | 0 |
|  | match_steps | 98 | 98 | 0 |
|  | runtime (min) | 23 | 24 | 1 |
|  | episode_runtime (sec) | 11 | 12 | 1 |
|  | num_episodes | 100 | 100 | 0 |
| randrot_noise_sim_on_scan_monty_world | percent_correct (%) | 88.33 | 88.33 | 0 |
|  | used_mlh (%) | 90 | 90 | 0 |
|  | match_steps | 456 | 456 | 0 |
|  | runtime (min) | 22 | 24 | 2 |
|  | episode_runtime (sec) | 165 | 174 | 9 |
|  | num_episodes | 120 | 120 | 0 |
| world_image_on_scanned_model | percent_correct (%) | 68.75 | 68.75 | 0 |
|  | used_mlh (%) | 68.75 | 68.75 | 0 |
|  | match_steps | 403 | 403 | 0 |
|  | runtime (min) | 10 | 10 | 0 |
|  | episode_runtime (sec) | 12 | 12 | 0 |
|  | num_episodes | 48 | 48 | 0 |
| dark_world_image_on_scanned_model | percent_correct (%) | 29.17 | 29.17 | 0 |
|  | used_mlh (%) | 14.58 | 14.58 | 0 |
|  | match_steps | 234 | 234 | 0 |
|  | runtime (min) | 8 | 8 | 0 |
|  | episode_runtime (sec) | 9 | 9 | 0 |
|  | num_episodes | 48 | 48 | 0 |
| bright_world_image_on_scanned_model | percent_correct (%) | 37.5 | 37.5 | 0 |
|  | used_mlh (%) | 62.5 | 62.5 | 0 |
|  | match_steps | 400 | 400 | 0 |
|  | runtime (min) | 10 | 11 | 1 |
|  | episode_runtime (sec) | 11 | 12 | 1 |
|  | num_episodes | 48 | 48 | 0 |
| hand_intrusion_world_image_on_scanned_model | percent_correct (%) | 37.5 | 37.5 | 0 |
|  | used_mlh (%) | 27.08 | 27.08 | 0 |
|  | match_steps | 277 | 277 | 0 |
|  | runtime (min) | 10 | 9 | -1 |
|  | episode_runtime (sec) | 11 | 10 | -1 |
|  | num_episodes | 48 | 48 | 0 |
| multi_object_world_image_on_scanned_model | percent_correct (%) | 22.92 | 22.92 | 0 |
|  | used_mlh (%) | 2.08 | 2.08 | 0 |
|  | match_steps | 155 | 155 | 0 |
|  | runtime (min) | 5 | 5 | 0 |
|  | episode_runtime (sec) | 5 | 5 | 0 |
|  | num_episodes | 48 | 48 | 0 |
| infer_comp_lvl1_with_monolithic_models | correct_child_or_parent (%) | 89.29 | 89.29 | 0 |
|  | used_mlh (%) | 84.52 | 84.52 | 0 |
|  | match_steps | 415 | 415 | 0 |
|  | rotation_error (deg) | 56.28 | 56.28 | 0 |
|  | avg_prediction_error | 0.25 | 0.25 | 0 |
|  | runtime (min) | 34 | 36 | 2 |
|  | num_episodes | 84 | 84 | 0 |
| infer_comp_lvl1_with_comp_models | correct_child_or_parent (%) | 86.9 | 86.9 | 0 |
|  | used_mlh (%) | 23.81 | 23.81 | 0 |
|  | match_steps | 32 | 32 | 0 |
|  | rotation_error (deg) | 40.58 | 40.58 | 0 |
|  | avg_prediction_error | 0.31 | 0.31 | 0 |
|  | runtime (min) | 4 | 4 | 0 |
|  | num_episodes | 84 | 84 | 0 |
| infer_comp_lvl2_with_comp_models | correct_child_or_parent (%) | 84.29 | 84.29 | 0 |
|  | used_mlh (%) | 31.43 | 31.43 | 0 |
|  | match_steps | 38 | 38 | 0 |
|  | rotation_error (deg) | 44.59 | 44.59 | 0 |
|  | avg_prediction_error | 0.31 | 0.31 | 0 |
|  | runtime (min) | 11 | 11 | 0 |
|  | num_episodes | 210 | 210 | 0 |
| infer_comp_lvl3_with_comp_models | correct_child_or_parent (%) | 63.43 | 63.43 | 0 |
|  | used_mlh (%) | 46.57 | 46.57 | 0 |
|  | match_steps | 35 | 35 | 0 |
|  | rotation_error (deg) | 47.58 | 47.58 | 0 |
|  | avg_prediction_error | 0.31 | 0.31 | 0 |
|  | runtime (min) | 15 | 15 | 0 |
|  | num_episodes | 350 | 350 | 0 |