### PR TITLE
docs: validate future work metadata example

### DIFF
--- a/docs/contributing/documentation/future-work-widget-metadata.md
+++ b/docs/contributing/documentation/future-work-widget-metadata.md
@@ -14,7 +14,7 @@ rfc: https://github.com/thousandbrainsproject/tbp.monty/blob/main/rfcs/0015_futu
 estimated-scope: medium
 improved-metric: community-engagement
 output-type: documentation
-skills: github-actions, python, github-readme-sync-tool, S3, JS, HTML, CSS
+skills: github-actions, python, github-readme-sync-tool, s3, javascript, html, css
 contributor: codeallthethingz
 status: in-progress
 ---
@@ -48,7 +48,7 @@ Very roughly, how big of a chunk of work is this? [Edit future-work-estimated-sc
 !snippet[../../snippets/future-work-estimated-scope.md]
 
 > [!NOTE] Notes on Some of the Fields
-> **small** tasks in the future work table are usually still multi-day efforts. We only put reasonably large chunks of work into our future work documentation as even those marked as small need to be large enough to justify the effort of writing up a detailed future work page. For smaller items, check out our [GitHub issues](https://github.com/thousandbrainsproject/tbp.monty/issues) and other [ways to contribute](../../contributing/why-contribute.md). You can also have a look at the TODO comments throughout the Monty codebase or help up remove one of the many currently ignored ruff lint rules (listed in [pyproject.toml](../../../pyproject.toml)).
+> **small** tasks in the future work table are usually still multi-day efforts. We only put reasonably large chunks of work into our future work documentation as even those marked as small need to be large enough to justify the effort of writing up a detailed future work page. For smaller items, check out our [GitHub issues](https://github.com/thousandbrainsproject/tbp.monty/issues) and other [ways to contribute](../../contributing/why-contribute.md). You can also have a look at the TODO comments throughout the Monty codebase or help us remove one of the many currently ignored ruff lint rules (listed in [pyproject.toml](../../../pyproject.toml)).
 > 
 > **medium** tasks are usually multi-week efforts that require several pieces of output (e.g. several PRs, data analysis, write ups, iterative testing, ...)
 > 

--- a/tools/future_work_widget/tests/validator_test.py
+++ b/tools/future_work_widget/tests/validator_test.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 import tempfile
 import unittest
@@ -65,6 +66,60 @@ class TestLoadAllowedValues(unittest.TestCase):
 
 
 class TestFutureWorkRecord(unittest.TestCase):
+    @staticmethod
+    def _repo_root() -> Path:
+        return Path(__file__).resolve().parents[3]
+
+    @staticmethod
+    def _parse_frontmatter_example(markdown: str) -> dict[str, str]:
+        match = re.search(
+            r"```example\n---\n(?P<frontmatter>.*?)\n---\n```",
+            markdown,
+            re.DOTALL,
+        )
+        if match is None:
+            raise AssertionError("Expected a fenced example frontmatter block")
+
+        example = {}
+        for line in match.group("frontmatter").splitlines():
+            key, value = line.split(":", 1)
+            example[key.strip()] = value.strip()
+
+        return example
+
+    def test_documentation_example_matches_allowed_metadata_values(self):
+        repo_root = self._repo_root()
+        docs_page = (
+            repo_root / "docs/contributing/documentation/future-work-widget-metadata.md"
+        )
+        example = self._parse_frontmatter_example(docs_page.read_text(encoding="utf-8"))
+        example.update(
+            {
+                "path": "future-work/future-work-widget.md",
+                "path1": "future-work",
+                "path2": "future-work-widget",
+            }
+        )
+
+        allowed_values = load_allowed_values(repo_root / "docs/snippets")
+
+        validated = FutureWorkRecord.model_validate(
+            example, context={"allowed_values": allowed_values}
+        )
+
+        self.assertEqual(
+            validated.skills,
+            [
+                "github-actions",
+                "python",
+                "github-readme-sync-tool",
+                "s3",
+                "javascript",
+                "html",
+                "css",
+            ],
+        )
+
     def test_validation_success(self):
         record = {
             "path": "future-work/test-item.md",


### PR DESCRIPTION
## Summary

- Update the future-work widget metadata docs example so the `skills` values match the allowlisted tokens in `docs/snippets/future-work-skills.md`.
- Add a regression test that parses the docs example frontmatter and validates it with the same widget validator and snippet allowlists used for future-work pages.
- Fix a small typo in the same docs page.

## Why

The published example used `S3`, `JS`, `HTML`, and `CSS`, but the widget validator expects `s3`, `javascript`, `html`, and `css`. Contributors copying the example could create metadata that fails validation.

## Contributor Branch

This contribution is hosted from the contributor fork: https://github.com/PerpetualRoyalty/tbp.monty/tree/codex/future-work-metadata-example

## Validation

- `/private/tmp/tbp-monty-future-work-venv/bin/pytest -n 0 tools/future_work_widget`
- `/private/tmp/tbp-monty-future-work-venv/bin/ruff check tools/future_work_widget/tests/validator_test.py`
- `/private/tmp/tbp-monty-future-work-venv/bin/ruff format --check tools/future_work_widget/tests/validator_test.py`
- Clean archive docs pipeline: `tools.github_readme_sync.cli generate-index` followed by `tools.future_work_widget.cli`, result `success: true`, `future_work_items: 77`, `total_items: 168`
