### PR TITLE
refactor!: sensor_module.states is unused and removed

### DIFF
--- a/src/tbp/monty/frameworks/models/sensor_modules.py
+++ b/src/tbp/monty/frameworks/models/sensor_modules.py
@@ -611,7 +611,6 @@ class CameraSM(SensorModule):
         # Tests check sm.features, not sure if this should be exposed
         self.features = features
         self.processed_obs: list[dict[str, Any]] = []
-        self.states: list[SensorState] = []
         # TODO: give more descriptive & distinct names
         self.sensor_module_id = sensor_module_id
         self.save_raw_obs = save_raw_obs
@@ -621,7 +620,6 @@ class CameraSM(SensorModule):
         self._percept_filter.reset()
         self.is_exploring = False
         self.processed_obs = []
-        self.states = []
 
     def update_state(self, agent: AgentState):
         """Update information about the sensors location and rotation."""
@@ -671,7 +669,6 @@ class CameraSM(SensorModule):
 
         if not self.is_exploring:
             self.processed_obs.append(percept.__dict__)
-            self.states.append(self.state)
 
         return percept
 

--- a/src/tbp/monty/frameworks/models/two_d_sensor_module.py
+++ b/src/tbp/monty/frameworks/models/two_d_sensor_module.py
@@ -133,7 +133,6 @@ class TwoDSensorModule(SensorModule):
 
         self.features = features
         self.processed_obs = []
-        self.states = []
         self.sensor_module_id = sensor_module_id
         self.save_raw_obs = save_raw_obs
         self.edge_detector = edge_detector
@@ -149,7 +148,6 @@ class TwoDSensorModule(SensorModule):
         self._percept_filter.reset()
         self.is_exploring = False
         self.processed_obs = []
-        self.states = []
         self._previous_3d_location = None
         self._previous_2d_location = np.zeros(2)
         self._tangent_frame = None
@@ -224,7 +222,6 @@ class TwoDSensorModule(SensorModule):
 
         if not self.is_exploring:
             self.processed_obs.append(observed_state.__dict__)
-            self.states.append(self.state)
 
         return observed_state
 

--- a/tests/unit/frameworks/models/two_d_sensor_module_test.py
+++ b/tests/unit/frameworks/models/two_d_sensor_module_test.py
@@ -196,7 +196,6 @@ class TwoDSensorModuleInitTest(unittest.TestCase):
         msg = two_d_sm.step(ctx, obs, motor_only_step=False)
 
         assert two_d_sm.state is not None
-        assert two_d_sm.states[-1] is two_d_sm.state
 
         assert msg.sender_id == two_d_sm.sensor_module_id
         assert msg.sender_type == "SM"


### PR DESCRIPTION
When considering how to refactor sensor modules during the engineering meeting today, we noticed that the `.states` attribute of sensor modules is unused.

This pull request removes the unused attribute.