### PR TITLE
docs: consistent use of "orientation"

### DIFF
--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -61,7 +61,7 @@ An object's location and orientation (in a given reference frame). The location 
 
 # Reference Frame
 
-A specific coordinate system within which locations and rotations can be represented. For instance, a location may be represented relative to the body (body/ego-centric reference frame) or relative to some point in the world (world/allo-centric reference frame) or relative to an object's center (object-centric reference frame).
+A specific coordinate system within which locations and orientations can be represented. For instance, a location may be represented relative to the body (body/ego-centric reference frame) or relative to some point in the world (world/allo-centric reference frame) or relative to an object's center (object-centric reference frame).
 There is no requirement for a specific origin (for example grid cells in the brain don't represent an origin). The important thing is that locations are represented relative to each other in a consistent metric space with path integration properties.
 For more information, see [our documentation on reference frames in Monty (and transforms between them)](../how-monty-works/monty/reference-frame-transformations.md).
 


### PR DESCRIPTION
In the glossary entry for Reference Frame, use the terms "location" and "orientation" like they are used to define Pose.
