### PR TITLE
chore: version 0.35.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,7 +8,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.34.0"
+__version__ = "0.35.0"
 
 import sys
 


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since 0.34.0.

<img width="1036" height="962" alt="Screenshot 2026-05-14 at 15 36 16" src="https://github.com/user-attachments/assets/fdb2ff99-ff4d-4f3e-ba1b-6cf7a88b666c" />

## feat!: wxyz-friendly Rotation object (#937)

- Everywhere `scipy.spatial.transform.Rotation` was imported has been replaced with an import of `tbp.monty.geometry.Rotation` EXCEPT the new mujoco code.

## refactor!: delegate SM construction to Hydra (#975)

- `sensor_module_configs` configuration parameter renamed to `sensor_modules`
- `sensor_module_class` and `sensor_module_args` configuration replaced with `_target_` and the usual way of passing arguments to a `_target_`.

## refactor!: delegate LM construction to Hydra (#976)

- `learning_module_configs` configuration parameter renamed to `learning_modules`
- `learning_module_class` and `learning_module_args` configuration replaced with `_target_` and the usual way of passing arguments to a `_target_`.

## refactor!: sensor_module.states is unused and removed (#979)

- The `.states` attribute of sensor modules is unused. This pull request removes the unused attribute.

## refactor!: extract evidence sdr similarity measure code (#984)

- Evidence SDR similarity measure and associated code are deleted. The deleted code is now available at https://github.com/thousandbrainsproject/feat.evidence_sdr_matching

## refactor!: rename LearningModule.post_episode to update_ltm_from_stm (#983)

- Removed `post_episode` from Learning Modules.

## refactor!: remove unused memory_consolidation method (#981)

- Removed unused `LLMemory.memory_consolidation` method.

## refactor!: split fixme_update_ground_truth from update_ltm_from_stm (#985)

- Callers of `update_ltm_from_stm` will need to also call `fixme_update_ground_truth` until this code moved.