### PR TITLE
refactor!: no need for input_channel in FeatureEvidenceCalculator

### DIFF
--- a/src/tbp/monty/frameworks/models/evidence_matching/burst_sampling.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/burst_sampling.py
@@ -613,7 +613,6 @@ class BurstSamplingHypothesesUpdater:
                 channel_feature_weights=self.feature_weights[input_channel],
                 channel_query_features=features,
                 channel_tolerances=self.tolerances[input_channel],
-                input_channel=input_channel,
             )
             # Find the indices for the nodes with highest evidence scores. The sorting
             # is done in ascending order, so extract the indices from the end of

--- a/src/tbp/monty/frameworks/models/evidence_matching/feature_evidence/calculator.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/feature_evidence/calculator.py
@@ -22,7 +22,6 @@ class FeatureEvidenceCalculator(Protocol):
         channel_feature_weights: dict,
         channel_query_features: dict,
         channel_tolerances: dict,
-        input_channel: str,
     ) -> np.ndarray: ...
 
 
@@ -40,7 +39,6 @@ class DefaultFeatureEvidenceCalculator:
         channel_feature_weights: dict,
         channel_query_features: dict,
         channel_tolerances: dict,
-        input_channel: str,  # noqa: ARG003
     ) -> np.ndarray:
         """Calculate the feature evidence for all nodes stored in a graph.
 
@@ -62,8 +60,6 @@ class DefaultFeatureEvidenceCalculator:
                 against the stored features, keyed by feature name.
             channel_tolerances: Per-feature tolerance, the largest
                 difference that still produces non-zero evidence.
-            input_channel: The channel the observation came from, used to
-                select which features in the graph to compare against.
 
         Returns:
             The feature evidence for all nodes, shape `(n_nodes,)`.

--- a/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_displacer.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_displacer.py
@@ -313,7 +313,6 @@ class DefaultHypothesesDisplacer:
                 channel_feature_weights=self.feature_weights[input_channel],
                 channel_query_features=channel_features,
                 channel_tolerances=self.tolerances[input_channel],
-                input_channel=input_channel,
             )
             hypothesis_radius_feature_evidence = node_feature_evidence[nearest_node_ids]
             # Set feature evidence of nearest neighbors that are too far away to 0

--- a/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/hypotheses_updater.py
@@ -432,7 +432,6 @@ class DefaultHypothesesUpdater(HypothesesUpdater):
                 channel_feature_weights=self.feature_weights[input_channel],
                 channel_query_features=channel_features,
                 channel_tolerances=self.tolerances[input_channel],
-                input_channel=input_channel,
             )
             # Stack node_feature_evidence to match possible poses
             nwmf_stacked = []

--- a/tests/unit/frameworks/models/evidence_matching/feature_evidence/calculator_test.py
+++ b/tests/unit/frameworks/models/evidence_matching/feature_evidence/calculator_test.py
@@ -37,7 +37,6 @@ class DefaultFeatureEvidenceCalculatorTest(unittest.TestCase):
             channel_feature_weights=weights,
             channel_query_features=query,
             channel_tolerances=tolerances,
-            input_channel="patch_0",
         )
 
     @given(


### PR DESCRIPTION
With #984 merged, there is no longer a need for `input_channel` in the `FeatureEvidenceCalculator` protocol. This pull request removes it.