### PR TITLE
fix: extract pose vectors and SN iff on object

### DIFF
--- a/src/tbp/monty/frameworks/models/two_d_sensor_module.py
+++ b/src/tbp/monty/frameworks/models/two_d_sensor_module.py
@@ -191,13 +191,16 @@ class TwoDSensorModule(SensorModule):
 
         observed_state = self._observation_processor.process(observation)
 
-        curvature_pose_vectors = observed_state.get_pose_vectors().copy()
-        true_surface_normal = observed_state.get_surface_normal().copy()
-
         # Only edges define pose for 2D sensor; reset curvature-based flag.
         observed_state.morphological_features["pose_fully_defined"] = False
 
+        curvature_pose_vectors = None
+        true_surface_normal = None
         if observed_state.use_state and observed_state.get_on_object():
+            # pose_vectors are only present when the patch center is on the object.
+            curvature_pose_vectors = observed_state.get_pose_vectors().copy()
+            true_surface_normal = observed_state.get_surface_normal().copy()
+
             self._update_tangent_frame(true_surface_normal)
             if self._extract_edges:
                 observed_state = self._extract_2d_edge(

--- a/tests/unit/frameworks/models/two_d_sensor_module_test.py
+++ b/tests/unit/frameworks/models/two_d_sensor_module_test.py
@@ -175,6 +175,30 @@ class TwoDSensorModuleInitTest(unittest.TestCase):
         np.testing.assert_allclose(two_d_sm._previous_2d_location, [1.0, 2.0])
         np.testing.assert_allclose(two_d_sm._previous_3d_location, world_location)
 
+    def test_step_handles_off_object_percept_without_pose_vectors(self) -> None:
+        two_d_sm = make_2d_sm(edge_detector=Mock(return_value=make_no_edge()))
+        percept = Message(
+            location=np.array([1.0, 2.0, 3.0]),
+            morphological_features={"on_object": 0.0},
+            non_morphological_features={},
+            confidence=1.0,
+            use_state=False,
+            sender_id="test",
+            sender_type="SM",
+        )
+        two_d_sm._observation_processor.process = Mock(return_value=percept)
+
+        msg = two_d_sm.step(
+            ctx=RuntimeContext(rng=np.random.RandomState()),
+            observation=sentinel.raw_observation,
+            motor_only_step=False,
+        )
+
+        assert msg.use_state is False
+        assert "pose_vectors" not in msg.morphological_features
+        np.testing.assert_allclose(msg.displacement["displacement"], np.zeros(3))
+        assert two_d_sm._tangent_frame is None
+
     def test_like_how_monty_uses_two_d_sm(self) -> None:
         """Mimic how Monty might use SMs in aggregate_sensory_inputs().
 


### PR DESCRIPTION
If an observation is not `on_object`, it will not have pose and surface normal values to extract. I moved the extraction function calls to inside the `on_object` check, otherwise, we see the below error.

```zsh
Traceback (most recent call last):
  File "/home/ramy/.local/data/anaconda3/envs/tbp.monty/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/home/ramy/.local/data/anaconda3/envs/tbp.monty/lib/python3.8/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/run_parallel.py", line 379, in single_train
    exp.run()
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/experiments/monty_experiment.py", line 610, in run
    self.train()
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/experiments/pretraining_experiments.py", line 219, in train
    self.run_epoch()
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/experiments/monty_experiment.py", line 574, in run_epoch
    self.run_episode()
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/experiments/pretraining_experiments.py", line 103, in run_episode
    actions = self.model.step(ctx, observations, proprioceptive_state)
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/models/monty_base.py", line 152, in step
    self._exploratory_step(ctx, observations, proprioceptive_state)
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/models/abstract_monty_classes.py", line 107, in _exploratory_step
    self.aggregate_sensory_inputs(ctx, observations, proprioceptive_state)
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/models/monty_base.py", line 179, in aggregate_sensory_inputs
    sm_output = sensor_module.step(ctx, raw_obs, self.is_motor_only_step)
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/frameworks/models/two_d_sensor_module.py", line 194, in step
    curvature_pose_vectors = observed_state.get_pose_vectors().copy()
  File "/home/ramy/tbp/tbp.monty/src/tbp/monty/cmp.py", line 156, in get_pose_vectors
    return self.morphological_features["pose_vectors"]
KeyError: 'pose_vectors'
```

No benchmark runs needed, 2D SM is not currently used in benchmarks.