### PR TITLE
chore: version 0.36.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,7 +8,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.35.0"
+__version__ = "0.36.0"
 
 import sys
 


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since 0.35.0.

<img width="2332" height="1360" alt="image" src="https://github.com/user-attachments/assets/a53e2aac-9577-46ac-ac52-4c01581072e7" />

## refactor!: no need for input_channel in FeatureEvidenceCalculator (#989)
Removes `input_channel` from the `FeatureEvidenceCalculator` protocol.

## refactor!: FeatureEvidenceScorer encapsulation toward better DI (#990)
Signature of the `DefaultHypothesesDisplacer` constructor is changed to require `FeatureEvidenceScorer` and no longer requires `tolerances`, `use_features_for_matching`, `feature_evidence_calculator`, nor `feature_evidence_increment`.

## refactor!: remove pre_episode from LMs (#992)
Callers must replace calls to `pre_episode` with calls to `reset_stm` and `fixme_reset_ground_truth`.
The `reset` method is no longer part of the `LearningModule` public interface, but is often inherited from `GraphLM`.