### PR TITLE
fix: always emit edge_strength and coherence from 2D SM

### DIFF
--- a/src/tbp/monty/frameworks/models/two_d_sensor_module.py
+++ b/src/tbp/monty/frameworks/models/two_d_sensor_module.py
@@ -246,8 +246,9 @@ class TwoDSensorModule(SensorModule):
                 saved before edge detection may overwrite pose_vectors.
 
         Returns:
-            Message with edge-based pose vectors if edge detected,
-            otherwise returns the original state unchanged.
+            Message with edge-based pose vectors if an edge is detected.
+            When no edge is detected, pose vectors are left unchanged and
+            `edge_strength`/`coherence` (if listed in features) are set to 0.0.
 
         Raises:
             RuntimeError: If edge features were requested but no edge detector
@@ -260,8 +261,18 @@ class TwoDSensorModule(SensorModule):
             )
 
         edge = self.edge_detector(observation)
+        edge_detected = edge.has_edge and not (edge.strength and edge.is_geometric_edge)
 
-        if not edge.has_edge or (edge.strength and edge.is_geometric_edge):
+        if "edge_strength" in self.features:
+            state.non_morphological_features["edge_strength"] = (
+                edge.strength if edge_detected else 0.0
+            )
+        if "coherence" in self.features:
+            state.non_morphological_features["coherence"] = (
+                edge.coherence if edge_detected else 0.0
+            )
+
+        if not edge_detected:
             return state
 
         pose_2d = _angle_to_pose_2d(
@@ -273,12 +284,6 @@ class TwoDSensorModule(SensorModule):
 
         state.morphological_features["pose_vectors"] = pose_2d
         state.morphological_features["pose_fully_defined"] = True
-
-        if "edge_strength" in self.features:
-            state.non_morphological_features["edge_strength"] = edge.strength
-        if "coherence" in self.features:
-            state.non_morphological_features["coherence"] = edge.coherence
-
         return state
 
     def _update_tangent_frame(self, surface_normal_3d: np.ndarray) -> None:

--- a/tests/unit/frameworks/models/two_d_sensor_module_test.py
+++ b/tests/unit/frameworks/models/two_d_sensor_module_test.py
@@ -349,6 +349,8 @@ class TwoDSensorModuleEdgeTest(unittest.TestCase):
         np.testing.assert_allclose(
             msg.morphological_features["pose_vectors"], original_pose
         )
+        assert msg.non_morphological_features["edge_strength"] == 0.0
+        assert msg.non_morphological_features["coherence"] == 0.0
 
     def test_extract_2d_edge_ignores_geometric_edge(self):
         observation = make_raw_observation(
@@ -375,8 +377,9 @@ class TwoDSensorModuleEdgeTest(unittest.TestCase):
         np.testing.assert_allclose(
             msg.morphological_features["pose_vectors"], original_pose
         )
-        assert "edge_strength" not in msg.non_morphological_features
-        assert "coherence" not in msg.non_morphological_features
+
+        assert msg.non_morphological_features["edge_strength"] == 0.0
+        assert msg.non_morphological_features["coherence"] == 0.0
 
 
 class TwoDSensorModuleTangentFrameTest(unittest.TestCase):


### PR DESCRIPTION
When an edge is not detected, we don't attach `edge_strength` or `coherence` to the message sent to the LM. This causes issues with the buffer length of features and padding when using a `GridObjectModel` to store the models. Normally, the buffer will pad certain channels based on `on_objects` to make them equal in length, but it will not pad different feature lists within a channel. If we define `edge_strength` and `coherence` in the feature list of the SM, I think we should send them in every message.

This PR refactors the code a bit to send 0.0 for strength and coherence if we don't detect an edge. Please let me know if you see a problem with this approach.