### PR TITLE
chore: version 0.37.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,7 +8,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.36.1"
+__version__ = "0.37.0"
 
 import sys
 


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since 0.36.1.

<img width="2358" height="1180" alt="image" src="https://github.com/user-attachments/assets/822631ff-e3b6-4e0f-8bf2-51d47c08b67b" />

## feat!: VOCUS2 Salience Strategy (#954)
- Updated `SalienceStrategy` protocol with narrower types
- `SalienceStrategy` protocol now requires `ctx: RuntimeContext` as first parameter
- `SensorObservation` "rgba" modality now has the type `npt.NDArray[np.uint8]` (unsigned) instead of `npt.NDArray[np.int_]` (signed). This corresponds to the type of the actual data returned from the simulator.

## refactor!: introduce Snapshotable interface and Memento state dict (#996)
- `MontyExperiment.save_state_dict` is renamed to `MontyExperiment.save_state_dir`
- `MontyExperiment.load_state_dict` is renamed to `MontyExperiment.load_state_dir`