### PR TITLE
refactor: Explicitly set weights_only on torch.load calls

### DIFF
--- a/docs/how-to-use-monty/tutorials/multiple-learning-modules.md
+++ b/docs/how-to-use-monty/tutorials/multiple-learning-modules.md
@@ -204,7 +204,7 @@ from tbp.monty.frameworks.utils.plot_utils_dev import plot_graph
 project_dir = Path("~/tbp/results/monty/projects").expanduser()
 model_name = "dist_agent_5lm_2obj_train"
 model_path = project_dir / model_name / "pretrained" / "model.pt"
-state_dict = torch.load(model_path)
+state_dict = torch.load(model_path, weights_only=False)
 
 fig = plt.figure(figsize=(8, 3))
 for lm_id in range(5):

--- a/docs/how-to-use-monty/tutorials/unsupervised-continual-learning.md
+++ b/docs/how-to-use-monty/tutorials/unsupervised-continual-learning.md
@@ -157,7 +157,7 @@ from tbp.monty.frameworks.utils.plot_utils_dev import plot_graph
 
 def load_graph(exp_dir: Path, epoch: int, object_name: str) -> GraphObjectModel:
     model_path = exp_dir / str(epoch) / "model.pt"
-    state_dict = torch.load(model_path)
+    state_dict = torch.load(model_path, weights_only=False)
     return state_dict["lm_dict"][0]["graph_memory"][object_name]["patch"]
 
 

--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -9,24 +9,3 @@
 # https://opensource.org/licenses/MIT.
 
 __version__ = "0.37.0"
-
-import sys
-
-# Things break if we try to import some of these classes in the Conda version
-if sys.version_info >= (3, 10):
-    import torch
-    from torch_geometric.data.data import DataEdgeAttr, DataTensorAttr
-    from torch_geometric.data.storage import GlobalStorage
-
-    from tbp.monty.frameworks.models.object_model import GraphObjectModel
-
-    # PyTorch 2.6 changes the default value of `weights_only` in `torch.load` from False
-    # to True, as a result it now gives an error when we try to load things without
-    # specifying `weights_only=False`.
-    #
-    # Rather than change all the call sites, the error message suggests an alternative
-    # of allow-listing the expected global classes we use.
-    # See https://docs.pytorch.org/docs/stable/notes/serialization.html#weights-only-allowlist
-    torch.serialization.add_safe_globals(
-        [GraphObjectModel, DataEdgeAttr, DataTensorAttr, GlobalStorage]
-    )

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -185,7 +185,7 @@ class MontyExperiment:
         if model_path:
             if "model.pt" not in model_path.parts:
                 model_path = model_path / "model.pt"
-            state_dict = torch.load(model_path)
+            state_dict = torch.load(model_path, weights_only=False)
             model.load_state_dict(state_dict)
 
         return model
@@ -660,9 +660,9 @@ class MontyExperiment:
     def load_state_dir(self, load_dir):
         """Load state of previous experiment from the filesystem."""
         load_dir = Path(load_dir)
-        model_state_dict = torch.load(load_dir / "model.pt")
-        exp_state_dict = torch.load(load_dir / "exp_state_dict.pt")
-        config = torch.load(load_dir / "config.pt")
+        model_state_dict = torch.load(load_dir / "model.pt", weights_only=False)
+        exp_state_dict = torch.load(load_dir / "exp_state_dict.pt", weights_only=False)
+        config = torch.load(load_dir / "config.pt", weights_only=False)
         state_dict_keys = self.state_dict().keys()
 
         self.model.load_state_dict(model_state_dict)

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -163,7 +163,7 @@ class MontyGeneralizationExperiment(MontyObjectRecognitionExperiment):
         """Pre episode where we pass target object to the model for logging."""
         if "model.pt" not in self.model_path.parts:
             model_path = self.model_path / "model.pt"
-        state_dict = torch.load(model_path)
+        state_dict = torch.load(model_path, weights_only=False)
         print(f"loading models again from {model_path}")
         self.model.load_state_dict(state_dict)
         super().pre_episode()

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -198,7 +198,7 @@ class MontyForGraphMatching(MontyBase):
     def load_state_dict_from_parallel(self, parallel_dirs, save=False):
         lm_dict = {}
         for pdir in parallel_dirs:
-            state_dict = torch.load(pdir / "model.pt")
+            state_dict = torch.load(pdir / "model.pt", weights_only=False)
             for lm in state_dict["lm_dict"]:
                 if lm not in lm_dict:
                     lm_dict[lm] = dict(

--- a/src/tbp/monty/frameworks/utils/logging_utils.py
+++ b/src/tbp/monty/frameworks/utils/logging_utils.py
@@ -80,7 +80,7 @@ def load_models_from_dir(exp_path, pretrained_dict=None):
 
     if pretrained_dict is not None:
         lm_models["pretrained"] = {}
-        state_dict = torch.load(Path(pretrained_dict) / "model.pt")
+        state_dict = torch.load(Path(pretrained_dict) / "model.pt", weights_only=False)
         for lm_id in list(state_dict["lm_dict"].keys()):
             pretrained_models = state_dict["lm_dict"][lm_id]["graph_memory"]
             lm_models["pretrained"][lm_id] = pretrained_models
@@ -88,7 +88,7 @@ def load_models_from_dir(exp_path, pretrained_dict=None):
     for child in Path(exp_path).iterdir():
         folder = child.name
         if folder.isnumeric():
-            state_dict = torch.load(child / "model.pt")
+            state_dict = torch.load(child / "model.pt", weights_only=False)
             for lm_id in list(state_dict["lm_dict"].keys()):
                 epoch_models = state_dict["lm_dict"][lm_id]["graph_memory"]
                 if folder not in lm_models:

--- a/tests/integration/frameworks/run_parallel_test.py
+++ b/tests/integration/frameworks/run_parallel_test.py
@@ -78,9 +78,12 @@ class RunParallelTest(unittest.TestCase):
             self.output_dir
             / self.supervised_pre_training_cfg.experiment.config.logging.run_name
             / "pretrained"
-            / "model.pt"
+            / "model.pt",
+            weights_only=False,
         )
-        serial_model = torch.load(self.output_dir / "pretrained" / "model.pt")
+        serial_model = torch.load(
+            self.output_dir / "pretrained" / "model.pt", weights_only=False
+        )
 
         # Same objects
         self.assertEqual(

--- a/tests/integration/reproducibility/supervised_training_test.py
+++ b/tests/integration/reproducibility/supervised_training_test.py
@@ -58,6 +58,6 @@ class SupervisedTrainingTest(unittest.TestCase):
                 / "model.pt"
             )
 
-        serial_model = torch.load(serial_model_path)
-        parallel_model = torch.load(parallel_model_path)
+        serial_model = torch.load(serial_model_path, weights_only=False)
+        parallel_model = torch.load(parallel_model_path, weights_only=False)
         assert_trained_models_equal(serial_model, parallel_model)


### PR DESCRIPTION
In PyTorch 2.6, the default value for the `weights_only` argument in `torch.load` was changed to True.

This breaks our uses of it, as we are storing more than just weights and primitive Python objects. Originally I added the code block in `src/tbp/monty/__init__.py` to allow-list the modules we're specifically loading, but as I started work on the test migration for MuJoCo, it started wanting me to add internal modules from NumPy to the list.

Since this seems to be getting out of hand, I decided that changing the call sites was the simpler solution.

Technically, this introduces the possibility of RCE if we load untrusted data, but given that this isn't a live service, and we're generally loading data we've saved with `torch.save`, it should be safe.

This should have no effect on the Conda environment and the Habitat version of things, as we're just explicitly setting what was already the default.