### PR TITLE
refactor!: split Runtime and Experiment aspects of `SensorModule`

### DIFF
--- a/src/tbp/monty/experiment/sensor_module.py
+++ b/src/tbp/monty/experiment/sensor_module.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+from typing import Protocol
+
+__all__ = [
+    "ExperimentSensorModule",
+]
+
+
+class ExperimentSensorModule(Protocol):
+    """Experiment interface to a Sensor Module."""
+
+    def reset(self) -> None:
+        """Reset the internal state of this Sensor Module."""
+        pass
+        ...

--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -467,7 +467,7 @@ class RuntimeSensorModule(Protocol):
         """Update the proprioceptive state for this Sensor Module.
 
         Args:
-            agent: The proprioceptive state of the Agent.
+            agent: The proprioceptive state of this sensor module's Agent.
         """
         ...
 
@@ -485,7 +485,7 @@ class RuntimeSensorModule(Protocol):
             motor_only_step: Whether the current step is a motor-only step.
 
         Returns:
-            Percept with features and morphological features.
+            An optional percept with features and morphological features.
         """
         ...
 
@@ -493,7 +493,7 @@ class RuntimeSensorModule(Protocol):
         """Return the goals proposed by this Sensor Module.
 
         Returns:
-            A collection of proposed Goals.
+            A sequence of proposed Goals.
         """
         ...
 

--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -18,6 +18,7 @@ import numpy.typing as npt
 from tbp.monty.cmp import Goal, Message
 from tbp.monty.context import RuntimeContext
 from tbp.monty.experiment.learning_module import ExperimentLearningModule
+from tbp.monty.experiment.sensor_module import ExperimentSensorModule
 from tbp.monty.frameworks.actions.actions import Action
 from tbp.monty.frameworks.agents import AgentID
 from tbp.monty.frameworks.experiments.mode import ExperimentMode
@@ -459,13 +460,51 @@ class GoalGenerator(metaclass=abc.ABCMeta):
         pass
 
 
-class SensorModule(metaclass=abc.ABCMeta):
+class RuntimeSensorModule(Protocol):
+    """Monty runtime interface to a Sensor Module."""
+
+    def update_state(self, agent: AgentState) -> None:
+        """Update the proprioceptive state for this Sensor Module.
+
+        Args:
+            agent: The proprioceptive state of the Agent.
+        """
+        ...
+
+    def step(
+        self,
+        ctx: RuntimeContext,
+        observation: SensorObservation,
+        motor_only_step: bool = False,
+    ) -> Message | None:
+        """Execute a time-step for the Sensor Module.
+
+        Args:
+            ctx: The runtime context.
+            observation: Sensor observation.
+            motor_only_step: Whether the current step is a motor-only step.
+
+        Returns:
+            Percept with features and morphological features.
+        """
+        ...
+
+    def propose_goals(self) -> Sequence[Goal]:
+        """Return the goals proposed by this Sensor Module.
+
+        Returns:
+            A collection of proposed Goals.
+        """
+        ...
+
+
+class SensorModule(RuntimeSensorModule, ExperimentSensorModule, metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def state_dict(self) -> Memento:
         pass
 
     @abc.abstractmethod
-    def update_state(self, agent: AgentState):
+    def update_state(self, agent: AgentState) -> None:
         pass
 
     @abc.abstractmethod
@@ -474,21 +513,12 @@ class SensorModule(metaclass=abc.ABCMeta):
         ctx: RuntimeContext,
         observation: SensorObservation,
         motor_only_step: bool = False,
-    ):
-        """Called on each step.
-
-        Args:
-            ctx: The runtime context.
-            observation: Sensor observation.
-            motor_only_step: Whether the current step is a motor-only step.
-        """
-        pass
-
-    @abc.abstractmethod
-    def pre_episode(self) -> None:
-        """This method is called before each episode."""
+    ) -> Message | None:
         pass
 
     def propose_goals(self) -> list[Goal]:
-        """Return the goals proposed by this Sensor Module."""
         return []
+
+    @abc.abstractmethod
+    def reset(self) -> None:
+        pass

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -75,7 +75,7 @@ class MontyForGraphMatching(MontyBase):
             lm.fixme_reset_ground_truth(primary_target)
 
         for sm in self.sensor_modules:
-            sm.pre_episode()
+            sm.reset()
 
         self.motor_system.pre_episode()
         self._goals = []

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -21,6 +21,7 @@ from tbp.monty.frameworks.models.abstract_monty_classes import (
     Monty,
     Observations,
     RuntimeContext,
+    SensorModule,
 )
 from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.frameworks.models.motor_system_state import ProprioceptiveState
@@ -36,7 +37,7 @@ class MontyBase(Monty):
 
     def __init__(
         self,
-        sensor_modules,
+        sensor_modules: Sequence[SensorModule],
         learning_modules: Sequence[LearningModule],
         motor_system: MotorSystem,
         sm_to_agent_dict,
@@ -47,7 +48,7 @@ class MontyBase(Monty):
         min_train_steps,
         num_exploratory_steps,
         max_total_steps,
-    ):
+    ) -> None:
         """Initialize the base class.
 
         Args:
@@ -379,6 +380,7 @@ class MontyBase(Monty):
         # for sm in self.sensor_modules: sm.set_experiment_mode() unused & removed
 
     def pre_episode(self):
+        # TODO: move most (all?) of this logic to Experiment
         self._is_done = False
         self.reset_episode_steps()
         self.switch_to_matching_step()
@@ -386,7 +388,7 @@ class MontyBase(Monty):
             lm.reset_stm()
 
         for sm in self.sensor_modules:
-            sm.pre_episode()
+            sm.reset()
 
         self.motor_system.pre_episode()
         self._goals = []
@@ -473,14 +475,14 @@ class MontyBase(Monty):
         return agent_obs[sensor_module_id]
 
     @property
-    def is_motor_only_step(self):
+    def is_motor_only_step(self) -> bool:
         return self.motor_system.motor_only_step
 
     @property
-    def is_done(self):
+    def is_done(self) -> bool:
         return self._is_done
 
-    def set_done(self):
+    def set_done(self) -> None:
         self._is_done = True
 
     @property

--- a/src/tbp/monty/frameworks/models/salience/sensor_module.py
+++ b/src/tbp/monty/frameworks/models/salience/sensor_module.py
@@ -65,7 +65,7 @@ class SalienceSM(SensorModule):
     def state_dict(self) -> Memento:
         return self._snapshot_telemetry.state_dict()
 
-    def update_state(self, agent: AgentState):
+    def update_state(self, agent: AgentState) -> None:
         """Update information about the sensor's location and rotation."""
         sensor = agent.sensors[SensorID(self.sensor_module_id)]
         self.state = SensorState(
@@ -163,8 +163,7 @@ class SalienceSM(SensorModule):
 
         return (weighted_salience - min_) / scale
 
-    def pre_episode(self) -> None:
-        """This method is called before each episode."""
+    def reset(self) -> None:
         self._goals.clear()
         self._return_inhibitor.reset()
         self._snapshot_telemetry.reset()

--- a/src/tbp/monty/frameworks/models/sensor_modules.py
+++ b/src/tbp/monty/frameworks/models/sensor_modules.py
@@ -653,7 +653,7 @@ class CameraSM(SensorModule):
                 observation, self.state.rotation, self.state.position
             )
 
-        percept: Message = self._observation_processor.process(observation)
+        percept = self._observation_processor.process(observation)
 
         if percept.use_state:
             percept = self._message_noise(percept, rng=ctx.rng)

--- a/src/tbp/monty/frameworks/models/sensor_modules.py
+++ b/src/tbp/monty/frameworks/models/sensor_modules.py
@@ -394,7 +394,7 @@ class Probe(SensorModule):
     observations and does not emit a Cortical Message.
     """
 
-    def __init__(self, sensor_module_id: str, save_raw_obs: bool):
+    def __init__(self, sensor_module_id: str, save_raw_obs: bool) -> None:
         """Initialize the probe.
 
         Args:
@@ -414,8 +414,7 @@ class Probe(SensorModule):
     def state_dict(self) -> Memento:
         return self._snapshot_telemetry.state_dict()
 
-    def update_state(self, agent: AgentState):
-        """Update information about the sensors location and rotation."""
+    def update_state(self, agent: AgentState) -> None:
         sensor = agent.sensors[SensorID(self.sensor_module_id)]
         self.state = SensorState(
             position=agent.position
@@ -428,16 +427,15 @@ class Probe(SensorModule):
         ctx: RuntimeContext,  # noqa: ARG002
         observation: SensorObservation,
         motor_only_step: bool = False,  # noqa: ARG002
-    ) -> Message | None:
+    ) -> None:
         if self.save_raw_obs and not self.is_exploring:
             self._snapshot_telemetry.raw_observation(
                 observation, self.state.rotation, self.state.position
             )
 
-        return None
+        return None  # noqa: PLR1711, RET501
 
-    def pre_episode(self) -> None:
-        """Reset buffer and is_exploring flag."""
+    def reset(self) -> None:
         self._snapshot_telemetry.reset()
         self.is_exploring = False
 
@@ -614,14 +612,13 @@ class CameraSM(SensorModule):
         self.sensor_module_id = sensor_module_id
         self.save_raw_obs = save_raw_obs
 
-    def pre_episode(self) -> None:
+    def reset(self) -> None:
         self._snapshot_telemetry.reset()
         self._percept_filter.reset()
         self.is_exploring = False
         self.processed_obs = []
 
-    def update_state(self, agent: AgentState):
-        """Update information about the sensors location and rotation."""
+    def update_state(self, agent: AgentState) -> None:
         sensor = agent.sensors[SensorID(self.sensor_module_id)]
         self.state = SensorState(
             position=agent.position
@@ -639,7 +636,7 @@ class CameraSM(SensorModule):
         ctx: RuntimeContext,
         observation: SensorObservation,
         motor_only_step: bool = False,
-    ) -> Message | None:
+    ) -> Message:
         """Turn raw observations into dict of features at location.
 
         Args:
@@ -656,7 +653,7 @@ class CameraSM(SensorModule):
                 observation, self.state.rotation, self.state.position
             )
 
-        percept = self._observation_processor.process(observation)
+        percept: Message = self._observation_processor.process(observation)
 
         if percept.use_state:
             percept = self._message_noise(percept, rng=ctx.rng)

--- a/src/tbp/monty/frameworks/models/two_d_sensor_module.py
+++ b/src/tbp/monty/frameworks/models/two_d_sensor_module.py
@@ -189,7 +189,7 @@ class TwoDSensorModule(SensorModule):
                 observation, self.state.rotation, self.state.position
             )
 
-        observed_state: Message = self._observation_processor.process(observation)
+        observed_state = self._observation_processor.process(observation)
 
         # Only edges define pose for 2D sensor; reset curvature-based flag.
         observed_state.morphological_features["pose_fully_defined"] = False

--- a/src/tbp/monty/frameworks/models/two_d_sensor_module.py
+++ b/src/tbp/monty/frameworks/models/two_d_sensor_module.py
@@ -86,7 +86,7 @@ class TwoDSensorModule(SensorModule):
         edge_detector: EdgeDetector | None = None,
         noise_params: dict[str, Any] | None = None,
         delta_thresholds: dict[str, Any] | None = None,
-    ):
+    ) -> None:
         """Initialize 2D Sensor Module.
 
         Args:
@@ -144,7 +144,7 @@ class TwoDSensorModule(SensorModule):
         self._previous_2d_location: np.ndarray = np.zeros(2)
         self._tangent_frame: TangentFrame | None = None
 
-    def pre_episode(self) -> None:
+    def reset(self) -> None:
         self._snapshot_telemetry.reset()
         self._percept_filter.reset()
         self.is_exploring = False
@@ -153,8 +153,7 @@ class TwoDSensorModule(SensorModule):
         self._previous_2d_location = np.zeros(2)
         self._tangent_frame = None
 
-    def update_state(self, agent: AgentState):
-        """Update information about the sensor's location and rotation."""
+    def update_state(self, agent: AgentState) -> None:
         sensor = agent.sensors[SensorID(self.sensor_module_id)]
         self.state = SensorState(
             position=agent.position
@@ -190,7 +189,7 @@ class TwoDSensorModule(SensorModule):
                 observation, self.state.rotation, self.state.position
             )
 
-        observed_state = self._observation_processor.process(observation)
+        observed_state: Message = self._observation_processor.process(observation)
 
         # Only edges define pose for 2D sensor; reset curvature-based flag.
         observed_state.morphological_features["pose_fully_defined"] = False

--- a/tests/unit/frameworks/models/fakes/sensor_modules.py
+++ b/tests/unit/frameworks/models/fakes/sensor_modules.py
@@ -39,9 +39,6 @@ class FakeSensorModule(SensorModule):
     def update_state(self, agent: AgentState) -> None:
         pass
 
-    # def set_experiment_mode(self, mode: ExperimentMode):
-    #     pass
-
     def step(
         self,
         ctx: RuntimeContext,  # noqa: ARG002

--- a/tests/unit/frameworks/models/fakes/sensor_modules.py
+++ b/tests/unit/frameworks/models/fakes/sensor_modules.py
@@ -13,7 +13,6 @@ import numpy as np
 
 from tbp.monty.cmp import Message
 from tbp.monty.context import RuntimeContext
-from tbp.monty.frameworks.experiments.mode import ExperimentMode
 from tbp.monty.frameworks.models.abstract_monty_classes import (
     SensorModule,
     SensorObservation,
@@ -34,24 +33,21 @@ class FakeSensorModule(SensorModule):
     def state_dict(self) -> Memento:
         return {}
 
-    def update_state(self, agent: AgentState):
+    def reset(self) -> None:
         pass
 
-    def pre_episode(self) -> None:
+    def update_state(self, agent: AgentState) -> None:
         pass
 
-    def post_episode(self):
-        pass
-
-    def set_experiment_mode(self, mode: ExperimentMode):
-        pass
+    # def set_experiment_mode(self, mode: ExperimentMode):
+    #     pass
 
     def step(
         self,
         ctx: RuntimeContext,  # noqa: ARG002
         observation: SensorObservation,
         motor_only_step: bool = False,  # noqa: ARG002
-    ):
+    ) -> Message:
         """Returns a dummy/placeholder message."""
         return Message(
             location=np.zeros(3),


### PR DESCRIPTION
The methods of `SensorModule` are segregated into "Methods that define the algorithm" and "Methods that interact with the experiment". This PR extracts a `RuntimeSensorModule` Protocol for the former, and an `ExperimentSensorModule` Protocol for the latter.

This segregation is in preparation for moving Experiment-related logic from the Sensor Module into the Experiment.

## Breaking Changes

- `SensorModule.pre_episode()` is renamed to `ExperimentSensorModule.reset()`
