### PR TITLE
chore: ignore ruff checks RET501 and PLR1711

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,6 +221,8 @@ ignore = [
     # TBP-specific, deliberately ignored rules
     "N818", # N818: error-suffix-on-exception-name
     "COM812", # COM812: Trailing comma missing
+    "RET501", # RET501: Do not explicitly `return None` in function if it is the only possible return value
+    "PLR1711", # PLR1711: Useless `return` statement at end of function
     # End of deliberately ignored rules
     # Original inherited flake8 ignores
     "D1", # D1XX: Missing Docstrings

--- a/src/tbp/monty/frameworks/models/sensor_modules.py
+++ b/src/tbp/monty/frameworks/models/sensor_modules.py
@@ -433,7 +433,7 @@ class Probe(SensorModule):
                 observation, self.state.rotation, self.state.position
             )
 
-        return None  # noqa: PLR1711, RET501
+        return None
 
     def reset(self) -> None:
         self._snapshot_telemetry.reset()


### PR DESCRIPTION
Add the following `ruff` checks to the Monty-specific ignore section of `pyproject.toml`:
- **RET501**: Do not explicitly `return None` in function if it is the only possible return value
- **PLR1711**: Useless `return` statement at end of function

Also, remove the previous `# noqa:` directive for these checks.

More details about these checks can be found at:
- https://docs.astral.sh/ruff/rules/unnecessary-return-none/
- https://docs.astral.sh/ruff/rules/useless-return/
