### PR TITLE
chore: version 0.38.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.37.0"
+__version__ = "0.38.0"


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since 0.37.0.

<img width="1034" height="943" alt="Screenshot 2026-06-11 at 09 14 06" src="https://github.com/user-attachments/assets/acbde527-7098-49db-8e79-db19e3c533dd" />

## refactor!: remove ambiguity from Resolution2D (#1007)

- The type of Resolution2D has change from `tuple[int, int]` to a `TypedDict` with `width` and `height` keys. This should only affect code and experiments using the MuJoCo simulator.

## refactor!: learning modules explicitly accept percepts (#1009)

- `LearningModule.matching_step` now requires `percepts: Sequence[Message]`
- `LearningModule.exploratory_step` now requires `percepts: Sequence[Message]`

## feat!: implement MuJoCo SurfaceAgent (#1012)

- The `pitch` method on `Embodiment` has changed meaning from pitching the sensor body to pitching the agent itself. A separate `pitch_sensor` method has been added to pitch the sensor body.

## refactor!: split Runtime and Experiment aspects of SensorModule (#1015)

- `SensorModule.pre_episode()` is renamed to `ExperimentSensorModule.reset()`