### PR TITLE
test: create MuJoCo version of run_test.py

### DIFF
--- a/src/tbp/monty/conf/environment/test_mujoco_ycb_agent.yaml
+++ b/src/tbp/monty/conf/environment/test_mujoco_ycb_agent.yaml
@@ -1,0 +1,25 @@
+# @package experiment.config.environment
+
+env_init_args:
+  data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
+  agents:
+    - _target_: tbp.monty.simulators.mujoco.agents.NoopAgent
+      _partial_: true
+      agent_id: agent_id_0
+      sensor_configs:
+        sensor_id_0:
+          position:
+            - 0.0
+            - 1.5
+            - 0.0
+          rotation:
+            - 1.0
+            - 0.0
+            - 0.0
+            - 0.0
+          resolution:
+            width: 320
+            height: 240
+          zoom: 1.0
+  raise_actuate_missing: false
+env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}

--- a/src/tbp/monty/conf/experiment/test/run_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/run_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: base_exp1000_e3_t3_tot2500
+  - /monty/motor_system_config: base
+  - /monty/learning_module: fake_1lm
+  - /monty/sensor_module: fake
+  - /monty/connectivity: test_1lm_1sm
+  - /environment: test_mujoco_ycb_agent
+  - /env_interface: test_train_eval
+  - /env_interface/transform: none
+  - /logging: test_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.monty_experiment.MontyExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 10
+    max_eval_steps: 5
+    max_total_steps: 6000
+    n_train_epochs: 2
+    n_eval_epochs: 1
+    model_name_or_path: ""
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/tests/mujoco/integration/frameworks/run_test.py
+++ b/tests/mujoco/integration/frameworks/run_test.py
@@ -1,0 +1,83 @@
+# Copyright 2025-2026 Thousand Brains Project
+# Copyright 2022-2024 Numenta Inc.
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import hydra
+import numpy as np
+from omegaconf import OmegaConf
+
+from tbp.monty.frameworks.run import main
+from tests import HYDRA_ROOT
+
+DATASET_LEN = 1000
+TRAIN_EPOCHS = 2
+MAX_TRAIN_STEPS = 10
+MAX_EVAL_STEPS = 5
+EVAL_EPOCHS = 1
+FAKE_OBS = np.random.rand(DATASET_LEN, 64, 64, 1)
+EXPECTED_LOG = []
+
+# Train steps
+EXPECTED_LOG += ["pre_train"]
+EXPECTED_LOG += [
+    "pre_epoch",
+    "pre_episode",
+    "post_episode",
+    "post_epoch",
+] * TRAIN_EPOCHS
+EXPECTED_LOG += ["post_train"]
+
+# Eval steps
+EXPECTED_LOG += ["pre_eval"]
+EXPECTED_LOG += [
+    "pre_epoch",
+    "pre_episode",
+    "post_episode",
+    "post_epoch",
+] * EVAL_EPOCHS
+EXPECTED_LOG += ["post_eval"]
+
+
+class MontyRunTest(unittest.TestCase):
+    """Test for the `main` function of `run.py`.
+
+    This tests that the logic in the `main` function drives an experiment through
+    the expected steps of the training and evaluation process.
+    """
+
+    def setUp(self):
+        self.output_dir = tempfile.mkdtemp()
+
+        with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
+            self.cfg = hydra.compose(
+                config_name="experiment",
+                overrides=[
+                    "experiment=test/run_mujoco",
+                    f"experiment.config.logging.output_dir={self.output_dir}",
+                ],
+            )
+
+    def tearDown(self):
+        shutil.rmtree(self.output_dir)
+
+    def test_main(self):
+        main(self.cfg)
+
+        output_dir = Path(self.cfg.experiment.config.logging.output_dir)
+
+        with (output_dir / "fake_log.json").open("r") as f:
+            exp_log = json.load(f)
+
+        self.assertListEqual(exp_log, EXPECTED_LOG)

--- a/tests/mujoco/integration/frameworks/run_test.py
+++ b/tests/mujoco/integration/frameworks/run_test.py
@@ -16,7 +16,6 @@ from pathlib import Path
 
 import hydra
 import numpy as np
-from omegaconf import OmegaConf
 
 from tbp.monty.frameworks.run import main
 from tests import HYDRA_ROOT


### PR DESCRIPTION
This PR is part of a larger effort to migrate integration tests to use MuJoCo instead of Habitat.

The Habitat version of this test mocks out the internals of Habitat, which is easier to do because it's self-contained in their internal simulator object.

MuJoCo doesn't have an equivalent internal simulator object, but instead we interact with it via several APIs. This makes mocking it all more complicated. Mocking our `MuJoCoSimulator` itself runs into issues because we're pickling the experiment configuration and `Mock`s aren't picklable.

In local testing, it seems like actually running the MuJoCo simulator instead of mocking it is faster than the mocked Habitat version. Roughly 3.5 seconds on average vs 5.5 seconds on average. The difference could be attributed to Rosetta translation of the x86 Conda environment on MacOS, vs the native aarch64 version that MuJoCo uses.

Using the simulator directly keeps the test setup code simpler and easier to follow than mocking it all out would. Also, this is an integration test, so running the full simulator is probably a better test, despite this test only tracking whether certain methods were called in a certain order.

Mocking MontyExperiment would be another option, but that's the code under test, so it doesn't seem appropriate to take that approach.