### PR TITLE
refactor!: change Resolution2D and SensorConfig to dataclasses

### DIFF
--- a/src/tbp/monty/frameworks/sensors.py
+++ b/src/tbp/monty/frameworks/sensors.py
@@ -6,27 +6,30 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
-from typing import NewType, TypedDict
+from dataclasses import dataclass
+from typing import NewType
 
 __all__ = ["Resolution2D", "SensorConfig", "SensorID"]
 
-from tbp.monty.math import QuaternionWXYZ, VectorXYZ
+from tbp.monty.math import IDENTITY_QUATERNION, ZERO_VECTOR, QuaternionWXYZ, VectorXYZ
 
 SensorID = NewType("SensorID", str)
 """Unique identifier for a sensor."""
 
 
-class Resolution2D(TypedDict):
+@dataclass
+class Resolution2D:
     """Pixel resolution of a sensor."""
 
     width: int
     height: int
 
 
-class SensorConfig(TypedDict):
+@dataclass
+class SensorConfig:
     """A sensor configuration, mapping to our configs in Hydra."""
 
-    position: VectorXYZ
-    rotation: QuaternionWXYZ
     resolution: Resolution2D
-    zoom: float
+    position: VectorXYZ = ZERO_VECTOR
+    rotation: QuaternionWXYZ = IDENTITY_QUATERNION
+    zoom: float = 1.0

--- a/src/tbp/monty/simulators/mujoco/agents.py
+++ b/src/tbp/monty/simulators/mujoco/agents.py
@@ -129,10 +129,10 @@ class Embodiment(Agent):
         for sensor_id, sensor_cfg in self._sensor_configs.items():
             sensor_body.add_camera(
                 name=f"{self.id}.{sensor_id}",
-                pos=sensor_cfg["position"],
-                quat=sensor_cfg["rotation"],
+                pos=sensor_cfg.position,
+                quat=sensor_cfg.rotation,
                 # Camera resolution isn't used in MuJoCo, so we're not setting it.
-                fovy=DEFAULT_CAMERA_FOVY / sensor_cfg["zoom"],
+                fovy=DEFAULT_CAMERA_FOVY / sensor_cfg.zoom,
             )
 
     @property
@@ -177,7 +177,7 @@ class Embodiment(Agent):
     def observations(self) -> AgentObservations:
         obs = AgentObservations()
         for sensor_id, sensor_cfg in self._sensor_configs.items():
-            renderer = self.sim.renderer_for_res(sensor_cfg["resolution"])
+            renderer = self.sim.renderer_for_res(sensor_cfg.resolution)
             renderer.update_scene(self.sim.data, camera=f"{self.id}.{sensor_id}")
             rgba_data = renderer.render()
 
@@ -212,9 +212,7 @@ class Embodiment(Agent):
             # configured position of the sensor (rel. agent) to compute positions.
             # This constraint can be removed by computing the sensor's position
             # relative agent from their world coordinates.
-            sensor_pos_rel_agent = sensor_body_rot_rel_agent.apply(
-                sensor_cfg["position"]
-            )
+            sensor_pos_rel_agent = sensor_body_rot_rel_agent.apply(sensor_cfg.position)
             sensor_states[sensor_id] = SensorState(
                 position=cast("VectorXYZ", tuple(sensor_pos_rel_agent)),
                 rotation=sensor_body_rot_quat,

--- a/src/tbp/monty/simulators/mujoco/simulator.py
+++ b/src/tbp/monty/simulators/mujoco/simulator.py
@@ -36,7 +36,7 @@ from tbp.monty.frameworks.environments.environment import (
 )
 from tbp.monty.frameworks.models.abstract_monty_classes import Observations
 from tbp.monty.frameworks.models.motor_system_state import ProprioceptiveState
-from tbp.monty.frameworks.sensors import Resolution2D
+from tbp.monty.frameworks.sensors import Resolution2D, SensorConfig, SensorID
 from tbp.monty.geometry import Rotation
 from tbp.monty.math import IDENTITY_QUATERNION, ZERO_VECTOR, QuaternionWXYZ, VectorXYZ
 from tbp.monty.simulators.mujoco.agents import Agent
@@ -73,6 +73,8 @@ HABITAT_PRIMITIVE_OBJECTS = {
     "cubeSolid": mjtGeom.mjGEOM_BOX,
 }
 
+# Default rendering resolution in the event that there are no sensor
+# configurations, e.g. in tests.
 DEFAULT_RESOLUTION = Resolution2D(width=64, height=64)
 
 
@@ -187,8 +189,8 @@ class MuJoCoSimulator(SimulatedObjectEnvironment):
         if self._agents:
             render_resolution = self._max_sensor_resolution()
         g = self.spec.visual.global_
-        g.offheight = render_resolution["height"]
-        g.offwidth = render_resolution["width"]
+        g.offheight = render_resolution.height
+        g.offwidth = render_resolution.width
 
     def _configure_lights(self) -> None:
         """Configure the lights as needed.
@@ -226,10 +228,10 @@ class MuJoCoSimulator(SimulatedObjectEnvironment):
         Returns:
             a renderer of the specified resolution
         """
-        resolution_key = (resolution["height"], resolution["width"])
+        resolution_key = (resolution.height, resolution.width)
         if resolution_key not in self._renderers:
             self._renderers[resolution_key] = Renderer(
-                height=resolution["height"], width=resolution["width"], model=self.model
+                height=resolution.height, width=resolution.width, model=self.model
             )
         return self._renderers[resolution_key]
 
@@ -254,14 +256,14 @@ class MuJoCoSimulator(SimulatedObjectEnvironment):
         max_width = max_height = 0
         # Introspect the agent partials to determine what the original sensor
         # configs were, so we can determine the maximum resolution needed.
-        sensor_configs = [
+        agent_sensor_cfgs: list[dict[SensorID, SensorConfig]] = [
             p.keywords["sensor_configs"]
             for p in cast("list[partial[Agent]]", self._agent_partials)
         ]
-        for sensor_cfg in sensor_configs:
-            for sensor in sensor_cfg.values():
-                max_height = max(max_height, sensor["resolution"]["height"])
-                max_width = max(max_width, sensor["resolution"]["width"])
+        for sensor_cfgs in agent_sensor_cfgs:
+            for sensor_cfg in sensor_cfgs.values():
+                max_height = max(max_height, sensor_cfg.resolution.height)
+                max_width = max(max_width, sensor_cfg.resolution.width)
         return Resolution2D(height=max_height, width=max_width)
 
     def remove_all_objects(self) -> None:


### PR DESCRIPTION
While migrating tests for MuJoCo, I've run into a few instances where the Habitat version of a config relies on default values for some of the sensor configuration.

Rather than make it explicit every time, I'm changing SensorConfig and Resolution2D into dataclasses. This allows us to set defaults, and also improves the way we interact with these objects in code.

I think I was under the impression that Hydra would need extra details to use dataclasses, like specifying a `_target_` but that's not the case.

> [!warning] 
> **Breaking Changes**
> - The type of `SensorConfig` changed from a TypedDict to a dataclass.
> - The type of `Resolution2D` changed from a TypedDict to a dataclass.