### PR TITLE
test: create MuJoCo version of base_config_test.py

### DIFF
--- a/src/tbp/monty/conf/environment/test_mujoco.yaml
+++ b/src/tbp/monty/conf/environment/test_mujoco.yaml
@@ -7,6 +7,7 @@ env_init_args:
       agent_id: agent_id_0
       sensor_configs:
         sensor_id_0:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
           resolution:
             width: 320
             height: 240

--- a/src/tbp/monty/conf/environment/test_mujoco.yaml
+++ b/src/tbp/monty/conf/environment/test_mujoco.yaml
@@ -1,0 +1,14 @@
+# @package experiment.config.environment
+
+env_init_args:
+  agents:
+    - _target_: tbp.monty.simulators.mujoco.agents.NoopAgent
+      _partial_: true
+      agent_id: agent_id_0
+      sensor_configs:
+        sensor_id_0:
+          resolution:
+            width: 320
+            height: 240
+  raise_actuate_missing: false
+env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}

--- a/src/tbp/monty/conf/experiment/test/base_config/base_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/base_config/base_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: base_exp1000_e3_t3_tot2500
+  - /monty/motor_system_config: base
+  - /monty/learning_module: fake_1lm
+  - /monty/sensor_module: fake
+  - /monty/connectivity: test_1lm_1sm
+  - /environment: test_mujoco
+  - /env_interface: test_train_3obj_default_eval_3obj_default
+  - /env_interface/transform: none
+  - /logging: detailed_debug_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.monty_experiment.MontyExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 50
+    max_eval_steps: 50
+    max_total_steps: 400
+    n_train_epochs: 1
+    n_eval_epochs: 1
+    model_name_or_path: ""
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/evidence_lm/base_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/evidence_lm/base_mujoco.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: displacement_1lm
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_dist_agent
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/positioning_procedures_train: getgoodview_viewfinder_patch
+  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_debug_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ""
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/simulators/mujoco/simulator.py
+++ b/src/tbp/monty/simulators/mujoco/simulator.py
@@ -71,6 +71,10 @@ PRIMITIVE_OBJECTS = {
 HABITAT_PRIMITIVE_OBJECTS = {
     "capsule3DSolid": mjtGeom.mjGEOM_CAPSULE,
     "cubeSolid": mjtGeom.mjGEOM_BOX,
+    "cylinderSolid": mjtGeom.mjGEOM_CYLINDER,
+    # We're substituting a sphere for a cone because MuJoCo lacks a
+    # cone primitive object as an option.
+    "coneSolid": mjtGeom.mjGEOM_SPHERE,
 }
 
 # Default rendering resolution in the event that there are no sensor

--- a/tests/mujoco/integration/frameworks/experiments/__init__.py
+++ b/tests/mujoco/integration/frameworks/experiments/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.

--- a/tests/mujoco/integration/frameworks/experiments/base_config_test.py
+++ b/tests/mujoco/integration/frameworks/experiments/base_config_test.py
@@ -23,8 +23,7 @@ from tests import HYDRA_ROOT
 
 
 class BaseConfigTest(unittest.TestCase):
-    def setUp(self):
-        """Code that gets executed before every test."""
+    def setUp(self) -> None:
         self.output_dir = tempfile.mkdtemp()
 
         with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
@@ -36,21 +35,15 @@ class BaseConfigTest(unittest.TestCase):
                 ],
             )
 
-    def tearDown(self):
-        """Code that gets executed after every test."""
+    def tearDown(self) -> None:
         shutil.rmtree(self.output_dir)
 
-    def test_can_set_up(self):
-        """Canary for setup_experiment.
-
-        This could be part of the setUp method, but it's easier to debug if
-        something breaks the setup_experiment method if there's a separate test for it.
-        """
+    def test_can_set_up(self) -> None:
         exp = hydra.utils.instantiate(self.base_cfg.experiment)
         with exp:
             pass
 
-    def test_can_run_episode(self):
+    def test_can_run_episode(self) -> None:
         exp = hydra.utils.instantiate(self.base_cfg.experiment)
         with exp:
             exp.experiment_mode = ExperimentMode.TRAIN
@@ -58,22 +51,21 @@ class BaseConfigTest(unittest.TestCase):
             exp.env_interface = exp.train_env_interface
             exp.run_episode()
 
-    def test_can_run_train_epoch(self):
+    def test_can_run_train_epoch(self) -> None:
         exp = hydra.utils.instantiate(self.base_cfg.experiment)
         with exp:
             exp.experiment_mode = ExperimentMode.TRAIN
             exp.model.set_experiment_mode(exp.experiment_mode)
             exp.run_epoch()
 
-    def test_can_run_eval_epoch(self):
+    def test_can_run_eval_epoch(self) -> None:
         exp = hydra.utils.instantiate(self.base_cfg.experiment)
         with exp:
             exp.experiment_mode = ExperimentMode.EVAL
             exp.model.set_experiment_mode(exp.experiment_mode)
             exp.run_epoch()
 
-    def test_observation_unpacking(self):
-        """Make sure this test uses very small n_actions_per_epoch for speed."""
+    def test_observation_unpacking(self) -> None:
         exp = hydra.utils.instantiate(self.base_cfg.experiment)
         with exp:
             monty_module_sids = {s.sensor_module_id for s in exp.model.sensor_modules}
@@ -114,20 +106,19 @@ class BaseConfigTest(unittest.TestCase):
                     "sensor_module must receive depth",
                 )
 
-    def test_can_save_and_load(self):
-        # Make sure deepcopy works (config is serializable)
-        config_1 = OmegaConf.to_object(self.base_cfg)
+    def test_can_save_and_load(self) -> None:
+        config_1: Mapping = OmegaConf.to_object(self.base_cfg)  # type: ignore[assignment,type-arg]
 
         exp = hydra.utils.instantiate(config_1["experiment"])
         with exp:
-            # change something about exp.state that will be saved via save_state_dir
+            # Change something about exp.state that will be saved via save_state_dir.
             new_attr = False
             exp.model.learning_modules[0].test_attr_2 = new_attr
 
             exp.save_state_dir()
             prev_model = exp.model
 
-        config_2: Mapping = OmegaConf.to_object(  # ignore: type[assignment]
+        config_2: Mapping = OmegaConf.to_object(  # type: ignore[assignment,type-arg]
             self.base_cfg
         )
         config_2["experiment"]["config"]["model_name_or_path"] = exp.output_dir
@@ -157,6 +148,9 @@ class BaseConfigTest(unittest.TestCase):
 
     def test_logging_debug_level(self) -> None:
         """Check that logs go to a file, we can load them, and they have basic info."""
+        # TODO: This seems to test the behaviour of the Python `logging` library, which
+        #   we should just assume works as advertised. Change this test to introspect
+        #   the experiment to see if the loggers got configured correctly instead.
         exp = hydra.utils.instantiate(self.base_cfg.experiment)
         with exp:
             # Add some stuff to the logs, verify it shows up
@@ -175,7 +169,10 @@ class BaseConfigTest(unittest.TestCase):
 
     def test_logging_info_level(self) -> None:
         """Check that if we set logging level to info, debug logs do not show up."""
-        base_config: Mapping = OmegaConf.to_object(self.base_cfg)
+        # TODO: This seems to test the behaviour of the Python `logging` library, which
+        #   we should just assume works as advertised. Change this test to introspect
+        #   the experiment to see if the loggers got configured correctly instead.
+        base_config: Mapping = OmegaConf.to_object(self.base_cfg)  # type: ignore[assignment,type-arg]
         log_cfg = base_config["experiment"]["config"]["logging"]
         log_cfg["python_log_level"] = logging.INFO
 

--- a/tests/mujoco/integration/frameworks/experiments/base_config_test.py
+++ b/tests/mujoco/integration/frameworks/experiments/base_config_test.py
@@ -1,0 +1,196 @@
+# Copyright 2025-2026 Thousand Brains Project
+# Copyright 2022-2024 Numenta Inc.
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import logging
+import shutil
+import tempfile
+import unittest
+from typing import Mapping
+
+import hydra
+from omegaconf import OmegaConf
+
+from tbp.monty.context import RuntimeContext
+from tbp.monty.frameworks.experiments.mode import ExperimentMode
+from tests import HYDRA_ROOT
+
+
+class BaseConfigTest(unittest.TestCase):
+    def setUp(self):
+        """Code that gets executed before every test."""
+        self.output_dir = tempfile.mkdtemp()
+
+        with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
+            self.base_cfg = hydra.compose(
+                config_name="experiment",
+                overrides=[
+                    "experiment=test/base_config/base_mujoco",
+                    f"experiment.config.logging.output_dir={self.output_dir}",
+                ],
+            )
+
+    def tearDown(self):
+        """Code that gets executed after every test."""
+        shutil.rmtree(self.output_dir)
+
+    def test_can_set_up(self):
+        """Canary for setup_experiment.
+
+        This could be part of the setUp method, but it's easier to debug if
+        something breaks the setup_experiment method if there's a separate test for it.
+        """
+        exp = hydra.utils.instantiate(self.base_cfg.experiment)
+        with exp:
+            pass
+
+    def test_can_run_episode(self):
+        exp = hydra.utils.instantiate(self.base_cfg.experiment)
+        with exp:
+            exp.experiment_mode = ExperimentMode.TRAIN
+            exp.model.set_experiment_mode(exp.experiment_mode)
+            exp.env_interface = exp.train_env_interface
+            exp.run_episode()
+
+    def test_can_run_train_epoch(self):
+        exp = hydra.utils.instantiate(self.base_cfg.experiment)
+        with exp:
+            exp.experiment_mode = ExperimentMode.TRAIN
+            exp.model.set_experiment_mode(exp.experiment_mode)
+            exp.run_epoch()
+
+    def test_can_run_eval_epoch(self):
+        exp = hydra.utils.instantiate(self.base_cfg.experiment)
+        with exp:
+            exp.experiment_mode = ExperimentMode.EVAL
+            exp.model.set_experiment_mode(exp.experiment_mode)
+            exp.run_epoch()
+
+    def test_observation_unpacking(self):
+        """Make sure this test uses very small n_actions_per_epoch for speed."""
+        exp = hydra.utils.instantiate(self.base_cfg.experiment)
+        with exp:
+            monty_module_sids = {s.sensor_module_id for s in exp.model.sensor_modules}
+
+            # Handle the training loop manually for this interim test
+            max_count = 5
+            count = 0
+            ctx = RuntimeContext(rng=exp.rng)
+            while True:
+                observations, _ = exp.train_env_interface.step([])
+                agent_keys = set(observations.keys())
+                sensor_keys = []
+                for agent in agent_keys:
+                    sensor_keys.extend(list(observations[agent].keys()))
+
+                sensor_key_set = set(sensor_keys)
+                self.assertCountEqual(
+                    sensor_key_set, monty_module_sids, "sensor module ids must match"
+                )
+
+                if count >= max_count:
+                    break
+
+                count += 1
+
+            # Verify we can skip the loop and just run a single
+            for s in exp.model.sensor_modules:
+                s_obs = exp.model.get_observations(observations, s.sensor_module_id)
+                feature = s.step(ctx, s_obs)
+                self.assertIn(
+                    "rgba",
+                    feature.non_morphological_features,
+                    "sensor_module must receive rgba",
+                )
+                self.assertIn(
+                    "depth",
+                    feature.non_morphological_features,
+                    "sensor_module must receive depth",
+                )
+
+    def test_can_save_and_load(self):
+        # Make sure deepcopy works (config is serializable)
+        config_1 = OmegaConf.to_object(self.base_cfg)
+
+        exp = hydra.utils.instantiate(config_1["experiment"])
+        with exp:
+            # change something about exp.state that will be saved via save_state_dir
+            new_attr = False
+            exp.model.learning_modules[0].test_attr_2 = new_attr
+
+            exp.save_state_dir()
+            prev_model = exp.model
+
+        config_2: Mapping = OmegaConf.to_object(  # ignore: type[assignment]
+            self.base_cfg
+        )
+        config_2["experiment"]["config"]["model_name_or_path"] = exp.output_dir
+
+        exp_2 = hydra.utils.instantiate(config_2["experiment"])
+        with exp_2:
+            # Test 1: untouched attributes are saved and loaded correctly
+            prev_attr_1_value = prev_model.learning_modules[0].test_attr_1
+            new_attr_1_value = exp_2.model.learning_modules[0].test_attr_1
+            self.assertEqual(prev_attr_1_value, new_attr_1_value, "attrs do not match")
+
+            # Test 2: the attribute we changed was saved as such
+            new_lm = exp_2.model.learning_modules[0]
+            self.assertEqual(new_lm.test_attr_2, new_attr, "attrs did not match")
+
+            # Use explicit load_state_dir function instead of setup_experiment
+            exp_2.load_state_dir(exp.output_dir)
+
+            # Test 1: untouched attributes are saved and loaded correctly
+            prev_attr_1_value = prev_model.learning_modules[0].test_attr_1
+            new_attr_1_value = exp_2.model.learning_modules[0].test_attr_1
+            self.assertEqual(prev_attr_1_value, new_attr_1_value, "attrs do not match")
+
+            # Test 2: the attribute we changed was saved as such
+            new_lm = exp_2.model.learning_modules[0]
+            self.assertEqual(new_lm.test_attr_2, new_attr, "attrs did not match")
+
+    def test_logging_debug_level(self) -> None:
+        """Check that logs go to a file, we can load them, and they have basic info."""
+        exp = hydra.utils.instantiate(self.base_cfg.experiment)
+        with exp:
+            # Add some stuff to the logs, verify it shows up
+            info_message = "INFO is in the log"
+            warning_message = "WARNING is in the log"
+
+            logger = logging.getLogger("tbp.monty")
+            logger.info(info_message)
+            logger.warning(warning_message)
+
+            with (exp.output_dir / "log.txt").open() as f:
+                log = f.read()
+
+            self.assertTrue(info_message in log)
+            self.assertTrue(warning_message in log)
+
+    def test_logging_info_level(self) -> None:
+        """Check that if we set logging level to info, debug logs do not show up."""
+        base_config: Mapping = OmegaConf.to_object(self.base_cfg)
+        log_cfg = base_config["experiment"]["config"]["logging"]
+        log_cfg["python_log_level"] = logging.INFO
+
+        exp = hydra.utils.instantiate(base_config["experiment"])
+        with exp:
+            # Add some stuff to the logs, verify it shows up
+            debug_message = "DEBUG is in the log"
+            warning_message = "WARNING is in the log"
+
+            logger = logging.getLogger("tbp.monty")
+            logger.debug(debug_message)
+            logger.warning(warning_message)
+
+            with (exp.output_dir / "log.txt").open() as f:
+                log = f.read()
+
+            self.assertTrue(debug_message not in log)
+            self.assertTrue(warning_message in log)

--- a/tests/mujoco/integration/frameworks/experiments/detailed_logging_config_test.py
+++ b/tests/mujoco/integration/frameworks/experiments/detailed_logging_config_test.py
@@ -1,0 +1,63 @@
+# Copyright 2025-2026 Thousand Brains Project
+# Copyright 2022-2024 Numenta Inc.
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+import shutil
+import tempfile
+import unittest
+
+import hydra
+
+from tbp.monty.frameworks.experiments.mode import ExperimentMode
+from tests import HYDRA_ROOT
+
+
+class DetailedEvidenceLmLoggingConfigTest(unittest.TestCase):
+    def setUp(self):
+        self.output_dir = tempfile.mkdtemp()
+
+        with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
+            self.cfg = hydra.compose(
+                config_name="experiment",
+                overrides=[
+                    "experiment=test/evidence_lm/base_mujoco",
+                    "logging=detailed_info_evidence_eval_runs",
+                    f"++experiment.config.logging.output_dir={self.output_dir}",
+                ],
+            )
+
+    def tearDown(self):
+        shutil.rmtree(self.output_dir)
+
+    def test_can_set_up(self):
+        """Canary for setup_experiment.
+
+        This could be part of the setUp method, but it's easier to debug if
+        something breaks the setup_experiment method if there's a separate test for it.
+        """
+        exp = hydra.utils.instantiate(self.cfg.experiment)
+        with exp:
+            pass
+
+    def test_logging_detailed_evidence_lm_config_creates_json(self) -> None:
+        """Test for the detailed evidence LM logging config.
+
+        This ensures the config can be composed, the experiment can be instantiated,
+        and that running an episode produces detailed logging json file.
+        """
+        exp = hydra.utils.instantiate(self.cfg.experiment)
+        with exp:
+            exp.model.set_experiment_mode(ExperimentMode.EVAL)
+            exp.run_epoch()
+
+        # Detailed logging handler should create a detailed_run_stats.json file
+        self.assertTrue(
+            (exp.output_dir / "detailed_run_stats.json").exists(),
+            "Expected detailed_run_stats.json file to be created",
+        )

--- a/tests/mujoco/integration/frameworks/experiments/detailed_logging_config_test.py
+++ b/tests/mujoco/integration/frameworks/experiments/detailed_logging_config_test.py
@@ -22,7 +22,7 @@ class DetailedEvidenceLmLoggingConfigTest(unittest.TestCase):
     # TODO: This test seems to primarily test our DetailedJSONHandler, and we should
     #   do that directly instead of testing to see if the Python `logging` library
     #   did what it is supposed to do.
-    def setUp(self):
+    def setUp(self) -> None:
         self.output_dir = tempfile.mkdtemp()
 
         with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
@@ -35,10 +35,10 @@ class DetailedEvidenceLmLoggingConfigTest(unittest.TestCase):
                 ],
             )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.output_dir)
 
-    def test_can_set_up(self):
+    def test_can_set_up(self) -> None:
         exp = hydra.utils.instantiate(self.cfg.experiment)
         with exp:
             pass

--- a/tests/mujoco/integration/frameworks/experiments/detailed_logging_config_test.py
+++ b/tests/mujoco/integration/frameworks/experiments/detailed_logging_config_test.py
@@ -19,6 +19,9 @@ from tests import HYDRA_ROOT
 
 
 class DetailedEvidenceLmLoggingConfigTest(unittest.TestCase):
+    # TODO: This test seems to primarily test our DetailedJSONHandler, and we should
+    #   do that directly instead of testing to see if the Python `logging` library
+    #   did what it is supposed to do.
     def setUp(self):
         self.output_dir = tempfile.mkdtemp()
 
@@ -36,11 +39,6 @@ class DetailedEvidenceLmLoggingConfigTest(unittest.TestCase):
         shutil.rmtree(self.output_dir)
 
     def test_can_set_up(self):
-        """Canary for setup_experiment.
-
-        This could be part of the setUp method, but it's easier to debug if
-        something breaks the setup_experiment method if there's a separate test for it.
-        """
         exp = hydra.utils.instantiate(self.cfg.experiment)
         with exp:
             pass


### PR DESCRIPTION
This PR is part of a larger effort to migrate integration tests to use MuJoCo instead of Habitat.