### PR TITLE
rfc: add wandb logging for unsupervised learning

### DIFF
--- a/rfcs/0000_add_more_wandb_logging_for_unsupervised_learning.md
+++ b/rfcs/0000_add_more_wandb_logging_for_unsupervised_learning.md
@@ -1,0 +1,60 @@
+- Start Date: 2026-06-13
+- RFC PR: (leave this empty, it will be filled in after RFC is merged)
+
+# RFC: Improve WandB Logging for Unsupervised Learning
+
+## Summary
+
+This RFC proposes improving the visibility of unsupervised continual learning experiments by exposing additional experiment statistics through Weights & Biases (WandB).
+
+The goal is to make it easier to monitor learning progress, memory growth, matching behavior, and graph formation during training and evaluation without changing the underlying learning algorithms.
+
+## Motivation
+
+The current roadmap contains the item:
+
+> Add More Wandb Logging for Unsupervised Learning
+
+The Monty framework already computes and stores a variety of useful statistics related to object matching, graph memory, and learning progress. However, not all of these statistics appear to be readily available through WandB dashboards.
+
+Improved WandB logging would help contributors and researchers:
+
+* Monitor unsupervised learning runs more effectively.
+* Compare experiments more easily.
+* Debug unexpected learning behavior.
+* Better understand graph-memory growth over time.
+
+## Proposed Approach
+
+Initially focus on exposing existing metrics rather than introducing new experiment logic.
+
+Candidate metrics include:
+
+* Graph-memory statistics (e.g. graph/object relationships).
+* Matching statistics.
+* Possible match counts.
+* Episode-level learning statistics.
+* Additional learning-module statistics already available in experiment outputs.
+
+The exact set of metrics can be refined based on maintainer feedback.
+
+## Non-Goals
+
+This RFC does not propose:
+
+* Changes to Monty's learning algorithms.
+* Changes to matching logic.
+* Changes to graph construction.
+* New evaluation procedures.
+
+The focus is strictly on experiment instrumentation and observability.
+
+## Open Questions
+
+1. Which unsupervised-learning metrics are currently considered most important by maintainers?
+2. Are there existing WandB dashboards or conventions that new metrics should follow?
+3. Should the initial implementation focus on parity with existing CSV outputs, or should it introduce additional WandB-specific visualizations?
+
+## Expected Outcome
+
+Researchers and contributors will have improved visibility into unsupervised learning behavior through WandB with minimal impact on the existing codebase.


### PR DESCRIPTION
## Summary

This RFC proposes improving WandB logging for unsupervised learning experiments.

The goal is to expose additional experiment statistics that are already available within the framework, making it easier to monitor learning progress, graph-memory growth, and matching behavior during training and evaluation.

## Motivation

The roadmap currently includes the item:

> Add More Wandb Logging for Unsupervised Learning

While exploring the codebase and documentation, I noticed that a number of useful statistics are already generated by the logging infrastructure and experiment outputs. This RFC proposes making more of these metrics available through WandB without changing the underlying learning algorithms.

## Scope

This RFC is focused on experiment instrumentation and observability.

It does not propose changes to:

* learning algorithms
* matching logic
* graph construction
* evaluation procedures

## Feedback Requested

I would appreciate maintainer guidance on:

* whether this roadmap item should proceed through the RFC process or a direct PR,
* which metrics would be most valuable to expose in WandB,
* any existing dashboard conventions or preferred approaches.
