### PR TITLE
refactor!: create MuJoCo version of graph_building_test.py

### DIFF
--- a/src/tbp/monty/conf/experiment/test/graph_building/load_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_building/load_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: test_displacement_1lm_tol00001
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_dist_agent
+  - /env_interface: test_train_2obj_predefined_eval_2obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ""
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_building/load_mujoco_for_feat_eval.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_building/load_mujoco_for_feat_eval.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: test_feature_1lm_mmd001
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_dist_agent
+  - /env_interface: test_eval_2obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ""
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_building/load_mujoco_for_feat_train.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_building/load_mujoco_for_feat_train.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: test_feature_1lm_mmd001
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_dist_agent
+  - /env_interface: test_train_2obj_predefined_r2
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ""
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_building/load_mujoco_for_ppf.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_building/load_mujoco_for_ppf.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: test_displacement_1lm_ppf
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_dist_agent
+  - /env_interface: test_train_2obj_predefined_eval_2obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ""
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_building/sptm_feat.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_building/sptm_feat.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp10_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: test_feature_1lm_mmdnone
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_dist_agent
+  - /env_interface: test_train_2obj_predefined_r2
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: silent_warning_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.pretraining_experiments.MontySupervisedObjectPretrainingExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 2
+    n_eval_epochs: 3
+    model_name_or_path: ""
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: all
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_building/supervised_pre_training_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_building/supervised_pre_training_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp10_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: displacement_1lm
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_dist_agent
+  - /env_interface: test_train_2obj_predefined_r2
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: silent_warning_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.pretraining_experiments.MontySupervisedObjectPretrainingExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 2
+    n_eval_epochs: 3
+    model_name_or_path: ""
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: all
+    logging:
+      run_name: ""

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -591,7 +591,7 @@ class MontyExperiment:
             self.eval_epochs += 1
             self.eval_env_interface.post_epoch()
 
-    def run(self):
+    def run(self) -> None:
         """Run the experiment."""
         if self.do_train:
             self.train()
@@ -609,7 +609,7 @@ class MontyExperiment:
             self.run_epoch()
         self.logger_handler.post_train(self.logger_args)
 
-    def evaluate(self):
+    def evaluate(self) -> None:
         """Run n_eval_epochs."""
         logger.info(f"running {self.n_eval_epochs} eval epochs")
         self.experiment_mode = ExperimentMode.EVAL

--- a/src/tbp/monty/frameworks/utils/graph_matching_utils.py
+++ b/src/tbp/monty/frameworks/utils/graph_matching_utils.py
@@ -22,7 +22,7 @@ from tbp.monty.geometry import Rotation
 logger = logging.getLogger(__name__)
 
 
-def get_correct_k_n(k_n, num_datapoints):
+def get_correct_k_n(k_n: int, num_datapoints: int) -> int | None:
     """Determine k_n given the number of datapoints.
 
     The k_n specified in the hyperparameter may not be possible to achieve with the

--- a/src/tbp/monty/simulators/mujoco/agents.py
+++ b/src/tbp/monty/simulators/mujoco/agents.py
@@ -179,7 +179,14 @@ class Embodiment(Agent):
         for sensor_id, sensor_cfg in self._sensor_configs.items():
             renderer = self.sim.renderer_for_res(sensor_cfg.resolution)
             renderer.update_scene(self.sim.data, camera=f"{self.id}.{sensor_id}")
-            rgba_data = renderer.render()
+            # MuJoCo only renders RGB image data. Monty currently expects RGBA, so
+            # we need to add an alpha channel. We're setting it to a fully opaque
+            # value, since a camera should always return opaque pixel values for
+            # every location.
+            rgb_data = renderer.render()
+            rgba_data = np.dstack(
+                [rgb_data, np.full(rgb_data.shape[:2], 255, dtype=rgb_data.dtype)]
+            )
 
             renderer.enable_depth_rendering()
             depth_data = renderer.render()

--- a/tests/mujoco/integration/frameworks/experiments/__init__.py
+++ b/tests/mujoco/integration/frameworks/experiments/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.

--- a/tests/mujoco/integration/frameworks/experiments/graph_building_test.py
+++ b/tests/mujoco/integration/frameworks/experiments/graph_building_test.py
@@ -1,0 +1,257 @@
+# Copyright 2025-2026 Thousand Brains Project
+# Copyright 2022-2024 Numenta Inc.
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import hydra
+from omegaconf import DictConfig
+
+from tbp.monty.frameworks.experiments.monty_experiment import MontyExperiment
+from tbp.monty.frameworks.experiments.pretraining_experiments import (
+    MontySupervisedObjectPretrainingExperiment,
+)
+from tbp.monty.frameworks.models.object_model import GraphObjectModel
+from tbp.monty.frameworks.utils.graph_matching_utils import get_correct_k_n
+from tests import HYDRA_ROOT
+
+
+class GraphBuildingTest(unittest.TestCase):
+    """Tests for graph memory building functionality.
+
+    These tests run rudimentary tests to confirm that our graph memory building
+    works as it should. We're also testing whether we can successfully train a
+    model and use it in subsequent evaluation experiments.
+    """
+
+    def setUp(self) -> None:
+        self.save_path = tempfile.mkdtemp()
+        self.mesh_save_path = tempfile.mkdtemp()
+        self.model_load_path = Path(self.save_path) / "pretrained"
+        self.habitat_learned_rotations = [[0.0, 0.0, 0.0], [0.0, 45.0, 0.0]]
+
+        def training_config(test_name: str) -> DictConfig:
+            return hydra.compose(
+                config_name="experiment",
+                overrides=[
+                    f"experiment=test/graph_building/{test_name}",
+                    f"experiment.config.logging.output_dir={self.save_path}",
+                ],
+            )
+
+        def loading_config(test_name: str) -> DictConfig:
+            return hydra.compose(
+                config_name="experiment",
+                overrides=[
+                    f"experiment=test/graph_building/{test_name}",
+                    f"experiment.config.logging.output_dir={self.save_path}",
+                    f"experiment.config.model_name_or_path={self.model_load_path}",
+                ],
+            )
+
+        with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
+            self.supervised_pre_training_cfg = training_config(
+                "supervised_pre_training_mujoco"
+            )
+            self.sptm_feat_cfg = training_config("sptm_feat")
+            self.load_cfg = loading_config("load_mujoco")
+            self.load_for_ppf_cfg = loading_config("load_mujoco_for_ppf")
+            self.load_for_feat_eval_cfg = loading_config("load_mujoco_for_feat_eval")
+            self.load_for_feat_train_cfg = loading_config("load_mujoco_for_feat_train")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.save_path)
+        shutil.rmtree(self.mesh_save_path)
+
+    def check_graph_formatting(
+        self, graph: GraphObjectModel, features_to_check: list[str]
+    ) -> None:
+        # Makes sure graph contains right feature at location information.
+        self.assertIsNot(
+            graph.pos,
+            None,
+            "graph contains no location information",
+        )
+        self.assertIsNot(
+            graph.x,
+            None,
+            "graph contains no feature information",
+        )
+        self.assertIsNot(
+            graph.feature_mapping,
+            None,
+            "graph contains no feature_mapping dict",
+        )
+        for feature in features_to_check:
+            self.assertIn(
+                feature,
+                graph.feature_ids_in_graph,
+                f"{feature} not stored in graph",
+            )
+        self.assertIn(
+            "principal_curvatures",
+            graph.feature_ids_in_graph,
+            "curvature not stored in graph",
+        )
+        self.assertIn(
+            "node_ids",
+            graph.feature_ids_in_graph,
+            "node ids not stored in graph",
+        )
+
+    def build_and_save_supervised_graph(
+        self,
+    ) -> MontySupervisedObjectPretrainingExperiment:
+        """Builds and saves a supervised graph.
+
+        Returns:
+            The experiment.
+        """
+        exp: MontySupervisedObjectPretrainingExperiment = hydra.utils.instantiate(
+            self.supervised_pre_training_cfg.experiment
+        )
+        with exp:
+            exp.run()
+        return exp
+
+    def build_and_save_supervised_graph_feat(
+        self,
+    ) -> MontySupervisedObjectPretrainingExperiment:
+        """Builds and saves a supervised graph with feature matching.
+
+        Returns:
+            The experiment.
+        """
+        exp: MontySupervisedObjectPretrainingExperiment = hydra.utils.instantiate(
+            self.sptm_feat_cfg.experiment
+        )
+        with exp:
+            exp.run()
+        return exp
+
+    def test_get_correct_k_n(self) -> None:
+        # enough data points sampled, just add 1 to remove self connection
+        self.assertEqual(get_correct_k_n(5, 10), 6)
+        # not enough points sampled, set k_n to num points - 1
+        self.assertEqual(get_correct_k_n(5, 3), 2)
+        # not enough points to make edges
+        self.assertEqual(get_correct_k_n(5, 2), None)
+
+    def test_can_build_graph_supervised(self) -> None:
+        exp = self.build_and_save_supervised_graph()
+
+        cfg_object_names = list(
+            self.supervised_pre_training_cfg.experiment.config.train_env_interface_args.object_names
+        )
+        self.assertListEqual(
+            cfg_object_names,
+            exp.model.learning_modules[0].get_all_known_object_ids(),
+            "Object ids of learned objects and graphs in memory.",
+        )
+        for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
+            graph = exp.model.learning_modules[0].get_graph(
+                graph_id, input_channel="first"
+            )
+            # Make sure that all features that are extracted by the SM are stored in
+            # the graph.
+            self.check_graph_formatting(
+                graph,
+                features_to_check=exp.model.sensor_modules[0].features,
+            )
+            self.assertIsNot(
+                graph.edge_index,
+                None,
+                "graph contains no edges",
+            )
+            self.assertEqual(
+                graph.edge_attr.shape[1],
+                3,
+                "Edge attributes don't store 3d displacements",
+            )
+
+    def test_can_load_disp_graph(self) -> None:
+        self.build_and_save_supervised_graph()
+        exp: MontyExperiment = hydra.utils.instantiate(self.load_cfg.experiment)
+        with exp:
+            for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
+                graph = exp.model.learning_modules[0].get_graph(
+                    graph_id, input_channel="first"
+                )
+                self.check_graph_formatting(
+                    graph,
+                    features_to_check=exp.model.sensor_modules[0].features,
+                )
+            exp.evaluate()
+
+    def test_can_load_disp_graph_for_ppf_matching(self) -> None:
+        self.build_and_save_supervised_graph()
+        exp: MontyExperiment = hydra.utils.instantiate(self.load_for_ppf_cfg.experiment)
+        with exp:
+            for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
+                graph = exp.model.learning_modules[0].get_graph(
+                    graph_id, input_channel="first"
+                )
+                self.check_graph_formatting(
+                    graph,
+                    features_to_check=exp.model.sensor_modules[0].features,
+                )
+                self.assertEqual(
+                    graph.edge_attr.shape[1],
+                    4,
+                    "Edge attributes don't store 4d PPF (should be added when loading)",
+                )
+            exp.evaluate()
+
+    def test_can_load_disp_graph_for_feature_matching(self) -> None:
+        self.build_and_save_supervised_graph()
+        exp: MontyExperiment = hydra.utils.instantiate(
+            self.load_for_feat_eval_cfg.experiment
+        )
+        with exp:
+            for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
+                graph = exp.model.learning_modules[0].get_graph(
+                    graph_id, input_channel="first"
+                )
+                self.check_graph_formatting(
+                    graph,
+                    features_to_check=exp.model.sensor_modules[0].features,
+                )
+                self.assertEqual(
+                    graph.edge_attr.shape[1],
+                    3,
+                    "Edge attributes don't store 3d displacements",
+                )
+            exp.run()
+
+    def test_can_extend_and_save_feat_graph(self) -> None:
+        self.build_and_save_supervised_graph_feat()
+        exp: MontyExperiment = hydra.utils.instantiate(
+            self.load_for_feat_train_cfg.experiment
+        )
+        with exp:
+            for graph_id in exp.model.learning_modules[0].get_all_known_object_ids():
+                graph = exp.model.learning_modules[0].get_graph(
+                    graph_id, input_channel="first"
+                )
+                self.check_graph_formatting(
+                    graph,
+                    features_to_check=exp.model.sensor_modules[0].features,
+                )
+                # TODO: not sure if we want this check. Right now it doesn't but I
+                # also don't see a reason why it couldn't in the future.
+                self.assertIs(
+                    graph.edge_attr,
+                    None,
+                    "feature at location graph should not contain edges.",
+                )
+            exp.run()

--- a/tests/unit/simulators/mujoco/noop_agent_test.py
+++ b/tests/unit/simulators/mujoco/noop_agent_test.py
@@ -86,7 +86,7 @@ class NoopAgentTest(unittest.TestCase):
             # be sensitive to rendering differences, but we want to get a rough idea
             # that we got back observational data.
             assert depth.shape == (64, 64)
-            assert rgba.shape == (64, 64, 3)
+            assert rgba.shape == (64, 64, 4)
             # assert that the min depth is the near surface of the cube
             assert np.allclose(depth.min(), 4.0)
             # assert that the max depth is beyond the back of the cube
@@ -132,5 +132,5 @@ class NoopAgentTest(unittest.TestCase):
             patch_rgba = obs[SensorID("patch")]["rgba"]
             view_finder_rgba = obs[SensorID("view_finder")]["rgba"]
 
-            assert patch_rgba.shape == (64, 64, 3)
-            assert view_finder_rgba.shape == (256, 256, 3)
+            assert patch_rgba.shape == (64, 64, 4)
+            assert view_finder_rgba.shape == (256, 256, 4)


### PR DESCRIPTION
This PR is part of a larger effort to migrate integration tests to use MuJoCo instead of Habitat.

In the new configuration files, the only field that has changed is `/environment` in the defaults list entries. There was some additional type-hinting added to functions called directly from the new test module, due to MyPy's `no-untyped-call` rule. MyPy still returns errors for the test module because we're accessing methods on subclasses of `LearningModule` that don't exist on `LearningModule` itself. Same goes for `SensorModule`.

> [!warning]
> **Breaking Changes**
> - `MuJoCoSimulator` incorrectly returned RGB data for the "rgba" modality. It now returns data with an alpha component set to 255 (full opaque) since that's the only alpha value a camera can capture. The shape of the data has changed from `(height, width, 3)` to `(height, width, 4)`.