### PR TITLE
fix: gate LM messages based on terminal state

### DIFF
--- a/benchmarks/logos_on_objects.csv
+++ b/benchmarks/logos_on_objects.csv
@@ -1,5 +1,5 @@
 Experiment,Correct Child or Parent (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Avg Prediction Error|align right,Run Time (mins)|align right,Num Episodes|hidden
-infer_comp_lvl1_with_monolithic_models,89.29,84.52,415,56.28,0.25,36,84
-infer_comp_lvl1_with_comp_models,86.90,23.81,32,40.58,0.31,4,84
-infer_comp_lvl2_with_comp_models,84.29,31.43,38,44.59,0.31,11,210
-infer_comp_lvl3_with_comp_models,63.43,46.57,35,47.58,0.31,16,350
+infer_comp_lvl1_with_monolithic_models,89.29,84.52,415,56.28,0.25,33,84
+infer_comp_lvl1_with_comp_models,86.90,29.76,34,58.33,0.29,5,84
+infer_comp_lvl2_with_comp_models,86.67,32.38,40,42.34,0.29,13,210
+infer_comp_lvl3_with_comp_models,72.00,42.57,34,49.35,0.30,19,350

--- a/benchmarks/montymeetsworld.csv
+++ b/benchmarks/montymeetsworld.csv
@@ -1,7 +1,7 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-randrot_noise_sim_on_scan_monty_world,90.00,85.00,444,24,176,120
+randrot_noise_sim_on_scan_monty_world,90.00,85.00,444,25,164,120
 world_image_on_scanned_model,66.67,62.50,374,10,11,48
-dark_world_image_on_scanned_model,29.17,18.75,242,7,7,48
+dark_world_image_on_scanned_model,29.17,18.75,242,8,9,48
 bright_world_image_on_scanned_model,37.50,64.58,413,11,12,48
 hand_intrusion_world_image_on_scanned_model,43.75,18.75,272,9,10,48
-multi_object_world_image_on_scanned_model,25.00,2.08,158,5,6,48
+multi_object_world_image_on_scanned_model,25.00,2.08,158,6,6,48

--- a/benchmarks/ycb_10objs.csv
+++ b/benchmarks/ycb_10objs.csv
@@ -1,13 +1,13 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-base_config_10distinctobj_dist_agent,100.00,0.00,28,10.29,2,5,140
-base_config_10distinctobj_surf_agent,100.00,0.00,28,3.64,3,11,140
-randrot_noise_10distinctobj_dist_agent,99.00,2.00,39,15.85,2,8,100
-randrot_noise_10distinctobj_dist_on_distm,100.00,0.00,29,9.82,2,7,100
-randrot_noise_10distinctobj_surf_agent,100.00,0.00,30,12.85,4,27,100
-randrot_10distinctobj_surf_agent,100.00,0.00,28,5.22,2,11,100
-randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,36,54.19,3,22,100
-base_10simobj_surf_agent,98.57,2.14,49,2.39,4,20,140
-randrot_noise_10simobj_dist_agent,97.00,26.00,177,20.0,5,33,100
-randrot_noise_10simobj_surf_agent,98.00,27.00,166,16.89,17,136,100
+base_config_10distinctobj_dist_agent,100.00,0.00,28,10.29,3,5,140
+base_config_10distinctobj_surf_agent,100.00,0.00,28,3.64,4,12,140
+randrot_noise_10distinctobj_dist_agent,99.00,2.00,39,15.85,2,7,100
+randrot_noise_10distinctobj_dist_on_distm,100.00,0.00,29,9.82,2,6,100
+randrot_noise_10distinctobj_surf_agent,100.00,0.00,30,12.85,5,22,100
+randrot_10distinctobj_surf_agent,100.00,0.00,28,5.22,3,13,100
+randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,39,53.20,4,19,100
+base_10simobj_surf_agent,98.57,2.14,49,2.39,6,19,140
+randrot_noise_10simobj_dist_agent,97.00,26.00,177,20.0,6,31,100
+randrot_noise_10simobj_surf_agent,98.00,27.00,166,16.89,19,133,100
 randomrot_rawnoise_10distinctobj_surf_agent,68.00,68.00,14,92.93,5,7,100
-base_10multi_distinctobj_dist_agent,48.57,1.43,32,37.74,37,2,140
+base_10multi_distinctobj_dist_agent,48.57,1.43,32,37.74,36,2,140

--- a/benchmarks/ycb_77objs.csv
+++ b/benchmarks/ycb_77objs.csv
@@ -1,6 +1,6 @@
 Experiment,Correct (%)|align right,Used MLH (%)|align right,Num Match Steps|align right,Rotation Error (degrees)|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-base_77obj_dist_agent,98.27,8.66,75,13.68,11,27,231
-base_77obj_surf_agent,100.00,4.76,43,2.27,12,28,231
-randrot_noise_77obj_dist_agent,96.97,16.88,123,24.63,19,58,231
-randrot_noise_77obj_surf_agent,99.57,15.58,93,21.91,30,93,231
-randrot_noise_77obj_5lms_dist_agent,90.91,0.0,33,50.26,9,96,77
+base_77obj_dist_agent,98.27,8.66,75,13.68,12,24,231
+base_77obj_surf_agent,100.00,4.76,43,2.27,12,24,231
+randrot_noise_77obj_dist_agent,96.97,16.88,123,24.63,22,57,231
+randrot_noise_77obj_surf_agent,99.57,15.58,93,21.91,36,97,231
+randrot_noise_77obj_5lms_dist_agent,92.21,0.0,38,47.40,10,96,77

--- a/benchmarks/ycb_unsupervised_inference.csv
+++ b/benchmarks/ycb_unsupervised_inference.csv
@@ -1,3 +1,3 @@
 Experiment,Correct (%)|align right,Num Match Steps|align right,Run Time (mins)|align right,Episode Run Time (s)|align right,Num Episodes|hidden
-unsupervised_inference_distinctobj_dist_agent,98.00,98,10,5,100
-unsupervised_inference_distinctobj_surf_agent,100.00,98,21,10,100
+unsupervised_inference_distinctobj_dist_agent,98.00,98,12,5,100
+unsupervised_inference_distinctobj_surf_agent,100.00,98,23,12,100

--- a/src/tbp/monty/conf/experiment/test/hierarchy/two_lms_semisupervised.yaml
+++ b/src/tbp/monty/conf/experiment/test/hierarchy/two_lms_semisupervised.yaml
@@ -30,4 +30,3 @@ experiment:
     monty_config:
       monty_args:
         num_exploratory_steps: 0
-        min_train_steps: 200

--- a/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
+++ b/src/tbp/monty/frameworks/models/evidence_matching/learning_module.py
@@ -478,8 +478,7 @@ class EvidenceGraphLM(GraphLM):
         output therefore has the same format to keep the messaging protocol
         consistent and make it easy to stack multiple LMs on top of each other.
 
-        If the evidence for mlh is < object_evidence_threshold,
-        interesting_features == False
+        If the LM has not reached a "match" terminal state, use_state == False.
         """
         mlh = self.get_current_mlh()
         pose_features = self._object_pose_to_features(mlh["rotation"].inv())
@@ -488,11 +487,9 @@ class EvidenceGraphLM(GraphLM):
         #       1) The last input it received was on_object (+getting SM input
         #           check will make sure that we are also currently on object)
         #           NOTE: May want to relax this check but still need a motor input
-        #       2) Its most likely hypothesis has an evidence >
-        #           object_evidence_threshold
+        #       2) It has reached a "match" terminal state
         use_state = bool(
-            self.buffer.get_currently_on_object()
-            and mlh["evidence"] > self.object_evidence_threshold
+            self.buffer.get_currently_on_object() and self.terminal_state == "match"
         )
         # TODO H: is this a good way to scale evidence to [0, 1]?
         confidence = (

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -730,12 +730,16 @@ class GraphLM(LearningModule):
             object_id = possible_matches[0]
             pose = self.get_unique_pose_if_available(object_id)
             if pose is None:  # No pose determined yet
+                if self.terminal_state == "match":
+                    self.set_individual_ts(None)
                 logger.info(f"Pose for {self.learning_module_id} not narrowed down yet")
             else:
                 self.set_individual_ts("match")
                 logger.info(f"{self.learning_module_id} recognized object {object_id}")
         # > 1 possible match
         else:
+            if self.terminal_state == "match":
+                self.set_individual_ts(None)
             logger.info(f"{self.learning_module_id} did not recognize an object yet.")
         return self.terminal_state
 


### PR DESCRIPTION
We currently gate the LM message based on `mlh["evidence"] > object_evidence_threshold`. Which ends up adding points to the HL-LM graph before the LL-LM is confident in its hypothesis. This PR makes two changes:
1. Gate the output message of an LM by `terminal_state=="match"`
2. Have the LM switch back to `terminal_state=None` if the `match` terminal conditions are no longer met.

# Benchmark Runs

Runs are tagged with `PR#1032` on wandb.

### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 10.29 | 10.29 | 0 | ⬜ |
| runtime (min) | 2 | 3 | 1 | ❌ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 3.64 | 3.64 | 0 | ⬜ |
| runtime (min) | 3 | 4 | 1 | ❌ |
| episode_runtime (sec) | 11 | 12 | 1 | ❌ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99 | 99 | 0 | ⬜ |
| used_mlh (%) | 2 | 2 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 15.85 | 15.85 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 8 | 7 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 9.82 | 9.82 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 6 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 30 | 30 | 0 | ⬜ |
| rotation_error (deg) | 12.85 | 12.85 | 0 | ⬜ |
| runtime (min) | 4 | 5 | 1 | ❌ |
| episode_runtime (sec) | 27 | 22 | -5 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 5.22 | 5.22 | 0 | ⬜ |
| runtime (min) | 2 | 3 | 1 | ❌ |
| episode_runtime (sec) | 11 | 13 | 2 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 36 | 39 | 3 | ❌ |
| rotation_error (deg) | 54.19 | 53.2 | -0.99 | ✅ |
| runtime (min) | 3 | 4 | 1 | ❌ |
| episode_runtime (sec) | 22 | 19 | -3 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.57 | 98.57 | 0 | ⬜ |
| used_mlh (%) | 2.14 | 2.14 | 0 | ⬜ |
| match_steps | 49 | 49 | 0 | ⬜ |
| rotation_error (deg) | 2.39 | 2.39 | 0 | ⬜ |
| runtime (min) | 4 | 6 | 2 | ❌ |
| episode_runtime (sec) | 20 | 19 | -1 | ✅ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| used_mlh (%) | 26 | 26 | 0 | ⬜ |
| match_steps | 177 | 177 | 0 | ⬜ |
| rotation_error (deg) | 20 | 20.04 | 0.04 | ❌ |
| runtime (min) | 5 | 6 | 1 | ❌ |
| episode_runtime (sec) | 33 | 31 | -2 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| used_mlh (%) | 27 | 27 | 0 | ⬜ |
| match_steps | 166 | 166 | 0 | ⬜ |
| rotation_error (deg) | 16.89 | 16.89 | 0 | ⬜ |
| runtime (min) | 17 | 19 | 2 | ❌ |
| episode_runtime (sec) | 136 | 133 | -3 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 68 | 68 | 0 | ⬜ |
| used_mlh (%) | 68 | 68 | 0 | ⬜ |
| match_steps | 14 | 14 | 0 | ⬜ |
| rotation_error (deg) | 92.93 | 92.93 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 7 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10multi_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 48.57 | 48.57 | 0 | ⬜ |
| used_mlh (%) | 1.43 | 1.43 | 0 | ⬜ |
| match_steps | 32 | 32 | 0 | ⬜ |
| rotation_error (deg) | 37.74 | 37.74 | 0 | ⬜ |
| runtime (min) | 37 | 36 | -1 | ✅ |
| episode_runtime (sec) | 2 | 2 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.27 | 98.27 | 0 | ⬜ |
| used_mlh (%) | 8.66 | 8.66 | 0 | ⬜ |
| match_steps | 75 | 75 | 0 | ⬜ |
| rotation_error (deg) | 13.68 | 13.68 | 0 | ⬜ |
| runtime (min) | 11 | 12 | 1 | ❌ |
| episode_runtime (sec) | 27 | 24 | -3 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 4.76 | 4.76 | 0 | ⬜ |
| match_steps | 43 | 43 | 0 | ⬜ |
| rotation_error (deg) | 2.27 | 2.27 | 0 | ⬜ |
| runtime (min) | 12 | 12 | 0 | ⬜ |
| episode_runtime (sec) | 28 | 24 | -4 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96.97 | 96.97 | 0 | ⬜ |
| used_mlh (%) | 16.88 | 16.88 | 0 | ⬜ |
| match_steps | 123 | 123 | 0 | ⬜ |
| rotation_error (deg) | 24.63 | 24.63 | 0 | ⬜ |
| runtime (min) | 19 | 22 | 3 | ❌ |
| episode_runtime (sec) | 58 | 57 | -1 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99.57 | 99.57 | 0 | ⬜ |
| used_mlh (%) | 15.58 | 15.58 | 0 | ⬜ |
| match_steps | 93 | 93 | 0 | ⬜ |
| rotation_error (deg) | 21.91 | 21.91 | 0 | ⬜ |
| runtime (min) | 30 | 36 | 6 | ❌ |
| episode_runtime (sec) | 93 | 97 | 4 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 90.91 | 92.21 | 1.3 | ✅ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 33 | 38 | 5 | ❌ |
| rotation_error (deg) | 50.26 | 47.4 | -2.86 | ✅ |
| runtime (min) | 9 | 10 | 1 | ❌ |
| episode_runtime (sec) | 96 | 96 | 0 | ⬜ |
| num_episodes | 77 | 77 | 0 | ⬜ |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 10 | 12 | 2 | ❌ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 21 | 23 | 2 | ❌ |
| episode_runtime (sec) | 10 | 12 | 2 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 90 | 90 | 0 | ⬜ |
| used_mlh (%) | 85 | 85 | 0 | ⬜ |
| match_steps | 444 | 444 | 0 | ⬜ |
| runtime (min) | 24 | 25 | 1 | ❌ |
| episode_runtime (sec) | 176 | 164 | -12 | ✅ |
| num_episodes | 120 | 120 | 0 | ⬜ |

### world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 66.67 | 66.67 | 0 | ⬜ |
| used_mlh (%) | 62.5 | 62.5 | 0 | ⬜ |
| match_steps | 374 | 374 | 0 | ⬜ |
| runtime (min) | 10 | 10 | 0 | ⬜ |
| episode_runtime (sec) | 11 | 11 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### dark_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 29.17 | 29.17 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 242 | 242 | 0 | ⬜ |
| runtime (min) | 7 | 8 | 1 | ❌ |
| episode_runtime (sec) | 7 | 9 | 2 | ❌ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### bright_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 37.5 | 37.5 | 0 | ⬜ |
| used_mlh (%) | 64.58 | 64.58 | 0 | ⬜ |
| match_steps | 413 | 413 | 0 | ⬜ |
| runtime (min) | 11 | 11 | 0 | ⬜ |
| episode_runtime (sec) | 12 | 12 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### hand_intrusion_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 43.75 | 43.75 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 272 | 272 | 0 | ⬜ |
| runtime (min) | 9 | 9 | 0 | ⬜ |
| episode_runtime (sec) | 10 | 10 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### multi_object_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 25 | 25 | 0 | ⬜ |
| used_mlh (%) | 2.08 | 2.08 | 0 | ⬜ |
| match_steps | 158 | 158 | 0 | ⬜ |
| runtime (min) | 5 | 6 | 1 | ❌ |
| episode_runtime (sec) | 6 | 6 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### infer_comp_lvl1_with_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 89.29 | 89.29 | 0 | ⬜ |
| used_mlh (%) | 84.52 | 84.52 | 0 | ⬜ |
| match_steps | 415 | 415 | 0 | ⬜ |
| rotation_error (deg) | 56.28 | 56.28 | 0 | ⬜ |
| avg_prediction_error | 0.25 | 0.25 | 0 | ⬜ |
| runtime (min) | 36 | 33 | -3 | ✅ |
| num_episodes | 84 | 84 | 0 | ⬜ |

### infer_comp_lvl1_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 86.9 | 86.9 | 0 | ⬜ |
| used_mlh (%) | 23.81 | 29.76 | 5.95 | ❌ |
| match_steps | 32 | 34 | 2 | ❌ |
| rotation_error (deg) | 40.58 | 58.33 | 17.75 | ❌ |
| avg_prediction_error | 0.31 | 0.29 | -0.02 | ✅ |
| runtime (min) | 4 | 5 | 1 | ❌ |
| num_episodes | 84 | 84 | 0 | ⬜ |

### infer_comp_lvl2_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 84.29 | 86.67 | 2.38 | ✅ |
| used_mlh (%) | 31.43 | 32.38 | 0.95 | ❌ |
| match_steps | 38 | 40 | 2 | ❌ |
| rotation_error (deg) | 44.59 | 42.34 | -2.25 | ✅ |
| avg_prediction_error | 0.31 | 0.29 | -0.02 | ✅ |
| runtime (min) | 11 | 13 | 2 | ❌ |
| num_episodes | 210 | 210 | 0 | ⬜ |

### infer_comp_lvl3_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 63.43 | 72 | 8.57 | ✅ |
| used_mlh (%) | 46.57 | 42.57 | -4 | ✅ |
| match_steps | 35 | 34 | -1 | ✅ |
| rotation_error (deg) | 47.58 | 49.35 | 1.77 | ❌ |
| avg_prediction_error | 0.31 | 0.3 | -0.01 | ✅ |
| runtime (min) | 16 | 19 | 3 | ❌ |
| num_episodes | 350 | 350 | 0 | ⬜ |
