### PR TITLE
refactor!: create MuJoCo version of graph_learning_test.py

### DIFF
--- a/src/tbp/monty/conf/environment/mujoco_ycb_dist_agent.yaml
+++ b/src/tbp/monty/conf/environment/mujoco_ycb_dist_agent.yaml
@@ -38,6 +38,6 @@ env_init_args:
       position:
         - 0.0
         - 1.5
-        - 0.5
+        - 0.2
   raise_actuate_missing: False
 env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}

--- a/src/tbp/monty/conf/environment/test_mujoco_dist_agent_sensors5.yaml
+++ b/src/tbp/monty/conf/environment/test_mujoco_dist_agent_sensors5.yaml
@@ -1,0 +1,73 @@
+# @package experiment.config.environment
+
+env_init_args:
+  agents:
+    - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+      _partial_: true
+      agent_id: agent_id_0
+      sensor_configs:
+        patch_0:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          position:
+            - 0.0
+            - 0.0
+            - 0.0
+          zoom: 10.0
+        patch_1:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          position:
+            - 0.0
+            - 0.01
+            - 0.0
+          zoom: 10.0
+        patch_2:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          position:
+            - 0.0
+            - -0.01
+            - 0.0
+          zoom: 10.0
+        patch_3:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          position:
+            - 0.01
+            - 0.0
+            - 0.0
+          zoom: 10.0
+        patch_4:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          position:
+            - -0.01
+            - 0.0
+            - 0.0
+          zoom: 10.0
+        view_finder:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          position:
+            - 0.0
+            - 0.0
+            - 0.0
+          zoom: 1.0
+      position:
+        - 0.0
+        - 1.5
+        - 0.2
+env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}

--- a/src/tbp/monty/conf/environment/test_mujoco_surf_transforms.yaml
+++ b/src/tbp/monty/conf/environment/test_mujoco_surf_transforms.yaml
@@ -1,0 +1,28 @@
+# @package experiment.config.environment
+
+env_init_args:
+  agents:
+    - _target_: tbp.monty.simulators.mujoco.agents.SurfaceAgent
+      _partial_: true
+      agent_id: agent_id_0
+      sensor_configs:
+        patch:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          zoom: 10.0
+        view_finder:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          position:
+            - 0.0
+            - 0.0
+            - 0.03
+      position:
+        - 0.0
+        - 1.5
+        - 0.1
+env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}

--- a/src/tbp/monty/conf/experiment/test/graph_learning/base_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/base_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: displacement_1lm
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/disp_pred_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/disp_pred_mujoco.yaml
@@ -1,0 +1,35 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: displacement_1lm
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    monty_config:
+      learning_modules:
+        learning_module_0:
+          tolerance:
+            - 0.0001
+            - 0.0001
+            - 0.0001
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/feature_pred_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/feature_pred_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: test_feature_1lm_mmd001_tol_p_pcl11
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/feature_pred_off_object_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/feature_pred_off_object_mujoco.yaml
@@ -1,0 +1,31 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: test_predefined_off_object
+  - /monty/learning_module: test_feature_1lm_mmd001_tol_p_pc55_pv402020
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_1obj_predefined_r1_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 50
+    max_eval_steps: 50
+    max_total_steps: 200
+    n_train_epochs: 2
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    monty_config:
+      monty_args:
+        min_train_steps: 12
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/feature_pred_off_object_train_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/feature_pred_off_object_train_mujoco.yaml
@@ -1,0 +1,31 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: test_predefined_off_object
+  - /monty/learning_module: test_feature_1lm_mmd001_tol_p_pc55_pv402020
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_1obj_predefined_r1
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 50
+    max_eval_steps: 50
+    max_total_steps: 200
+    n_train_epochs: 2
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    monty_config:
+      monty_args:
+        min_train_steps: 12
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/feature_pred_time_out_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/feature_pred_time_out_mujoco.yaml
@@ -1,0 +1,34 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp30_e3_t3_tot2500
+  - /monty/motor_system_config: test_predefined
+  - /monty/learning_module: test_feature_1lm_mmd0001_tol_pcl_pv180_rse1000
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    train_env_interface_args:
+      object_init_sampler:
+        rotations:
+          - - 0.0
+            - 0.0
+            - 0.0
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/feature_uniform_initial_poses_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/feature_uniform_initial_poses_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp30_e3_t3_tot2500
+  - /monty/motor_system_config: test_predefined
+  - /monty/learning_module: test_feature_1lm_mmd001_tol_p_hsv_pcl_ippu
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/five_lm_feature_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/five_lm_feature_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp10_e3_t3_tot2500
+  - /monty/motor_system_config: test_predefined
+  - /monty/learning_module: test_feature_5lm_mmd001_tol_p_hsv_pcl
+  - /monty/sensor_module: 5sm_camera
+  - /monty/connectivity: 5lm_5sm
+  - /environment: test_mujoco_dist_agent_sensors5
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor6
+  - /logging: detailed_debug_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 3
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/five_lm_ppf_displacement_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/five_lm_ppf_displacement_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp10_e3_t3_tot2500
+  - /monty/motor_system_config: test_predefined
+  - /monty/learning_module: test_displacement_5lm_ppf
+  - /monty/sensor_module: 5sm_camera
+  - /monty/connectivity: 5lm_5sm
+  - /environment: test_mujoco_dist_agent_sensors5
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor6
+  - /logging: detailed_debug_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 3
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/fixed_actions_disp_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/fixed_actions_disp_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp10_e3_t3_tot2500
+  - /monty/motor_system_config: test_predefined
+  - /monty/learning_module: test_displacement_1lm_tol00001
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/fixed_actions_feat_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/fixed_actions_feat_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: test_predefined
+  - /monty/learning_module: test_feature_1lm_mmd0001_tol_full
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/fixed_actions_ppf_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/fixed_actions_ppf_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: test_predefined
+  - /monty/learning_module: test_displacement_1lm_ppf_tol00001_rel
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/ppf_pred_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/ppf_pred_mujoco.yaml
@@ -1,0 +1,32 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: test_displacement_1lm_ppf
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    monty_config:
+      learning_modules:
+        learning_module_0:
+          use_relative_len: true
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/graph_learning/surface_agent_eval_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/graph_learning/surface_agent_eval_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: surface
+  - /monty/learning_module: displacement_1lm
+  - /monty/sensor_module: camera_surf
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_surf_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0_clip
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/frameworks/models/feature_location_matching.py
+++ b/src/tbp/monty/frameworks/models/feature_location_matching.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import numpy as np
 import torch
@@ -44,15 +45,18 @@ class FeatureGraphLM(GraphLM):
 
     def __init__(
         self,
-        max_match_distance,
-        tolerances,
-        path_similarity_threshold=0.1,
-        pose_similarity_threshold=0.35,
-        required_symmetry_evidence=5,
-        graph_delta_thresholds=None,
-        initial_possible_poses="informed",
-        umbilical_num_poses=8,
-    ):
+        max_match_distance: float,
+        # TODO: Create a specific type for `tolerances`.
+        tolerances: dict[str, dict[str, Any]],
+        path_similarity_threshold: float = 0.1,
+        pose_similarity_threshold: float = 0.35,
+        required_symmetry_evidence: int = 5,
+        # TODO: Create a specific type for `graph_delta_thresholds`.
+        #  Is this the same type as `tolerances`?
+        graph_delta_thresholds: dict[str, dict[str, Any]] | None = None,
+        initial_possible_poses: str = "informed",
+        umbilical_num_poses: int = 8,
+    ) -> None:
         """Initialize Learning Module.
 
         Args:

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -585,7 +585,11 @@ class GraphLM(LearningModule):
         self.detected_pose = [None for _ in range(7)]
         self.detected_rotation_r = None
 
-    def fixme_reset_ground_truth(self, primary_target=None) -> None:
+    def fixme_reset_ground_truth(
+        self,
+        # TODO: Create a specific type for `primary_target`.
+        primary_target: dict[str, Any] | None = None,
+    ) -> None:
         """Set target object var and reset others from last episode.
 
         Args:
@@ -641,13 +645,13 @@ class GraphLM(LearningModule):
         self.buffer.append(buffer_data)
         self.buffer.append_input_percepts(percepts)
 
-    def update_ltm_from_stm(self):
+    def update_ltm_from_stm(self) -> None:
         """If training, update memory from buffer."""
         if self.mode is ExperimentMode.TRAIN and len(self.buffer) > 0:
             logger.info(f"\n---Updating memory of {self.learning_module_id}---")
             self._update_memory()
 
-    def fixme_update_ground_truth(self):
+    def fixme_update_ground_truth(self) -> None:
         """If training, update ground truth."""
         if self.mode is ExperimentMode.TRAIN and len(self.buffer) > 0:
             self._update_target_graph_mapping(self.detected_object, self.primary_target)
@@ -762,7 +766,7 @@ class GraphLM(LearningModule):
             graph_id = None
         self.detected_object = graph_id
 
-    def get_possible_matches(self):
+    def get_possible_matches(self) -> list[str]:
         """Get list of current possible objects.
 
         TODO: Maybe make this private -> check terminal condition
@@ -772,7 +776,7 @@ class GraphLM(LearningModule):
         """
         return list(self.possible_matches.keys())
 
-    def get_possible_paths(self):
+    def get_possible_paths(self) -> dict[str, Any]:
         """Return possible paths for each object.
 
         This is used for logging/plotting
@@ -781,6 +785,7 @@ class GraphLM(LearningModule):
         Returns:
             Possible paths for each object.
         """
+        # TODO: Create a specific type for the return value.
         return self.possible_paths.copy()
 
     def get_possible_locations(self):
@@ -799,7 +804,7 @@ class GraphLM(LearningModule):
                 possible_locations[obj] = np.array([])
         return possible_locations
 
-    def get_possible_poses(self, as_euler=True):
+    def get_possible_poses(self, as_euler: bool = True) -> dict[str, Any]:
         """Return possible poses for each object (for logging).
 
         Possible poses are narrowed down
@@ -825,6 +830,7 @@ class GraphLM(LearningModule):
                 all_poses[obj] = euler_poses
         else:
             all_poses = poses
+        # TODO: Use a more specific type for the return value.
         return all_poses
 
     def get_object_scale(self, _object_id):
@@ -835,12 +841,14 @@ class GraphLM(LearningModule):
         """
         return 1
 
-    def get_all_known_object_ids(self):
+    def get_all_known_object_ids(self) -> list[str]:
         """Get the IDs of all object models stored in memory.
 
         Returns:
             IDs of all object models stored in memory.
         """
+        # TODO: Create a more specific return type. Maybe object ids should be
+        #  a new type like SensorID?
         return self.graph_memory.get_memory_ids()
 
     def get_graph(self, model_id, input_channel=None):

--- a/src/tbp/monty/simulators/mujoco/agents.py
+++ b/src/tbp/monty/simulators/mujoco/agents.py
@@ -66,8 +66,8 @@ def zoom_fovy(base_fovh: float, resolution: Resolution2D, zoom: float) -> float:
     """
     resolution_ratio = resolution.height / resolution.width
     base_fovh_radians = np.deg2rad(base_fovh)
-    zoom_fovy_radians = 2 * np.arctan(
-        resolution_ratio * np.tan(base_fovh_radians / 2.0) / zoom
+    zoom_fovy_radians = 2 * np.arctan2(
+        resolution_ratio * np.tan(base_fovh_radians / 2.0), zoom
     )
     return np.rad2deg(zoom_fovy_radians)
 

--- a/src/tbp/monty/simulators/mujoco/agents.py
+++ b/src/tbp/monty/simulators/mujoco/agents.py
@@ -35,7 +35,7 @@ from tbp.monty.frameworks.models.abstract_monty_classes import (
     SensorObservation,
 )
 from tbp.monty.frameworks.models.motor_system_state import AgentState, SensorState
-from tbp.monty.frameworks.sensors import SensorConfig, SensorID
+from tbp.monty.frameworks.sensors import Resolution2D, SensorConfig, SensorID
 from tbp.monty.geometry import Rotation
 from tbp.monty.math import IDENTITY_QUATERNION, ZERO_VECTOR, QuaternionWXYZ, VectorXYZ
 
@@ -45,9 +45,31 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# The default field of view value for zoom 1.0
-# Note: this value is the half-FOV rather than the full FOV
-DEFAULT_CAMERA_FOVY: float = 45.0
+# The default horizontal field of view value for zoom 1.0
+# This value needs to stay in sync with the value in the `DepthTo3DLocations` transform.
+# TODO: Make this configurable
+DEFAULT_CAMERA_FOVH: float = 90.0
+
+
+def zoom_fovy(base_fovh: float, resolution: Resolution2D, zoom: float) -> float:
+    """Calculate the vertical field of view for a given zoom level and resolution.
+
+    This helper function takes the base horizontal field of view along with the
+    resolution and requested zoom level and returns the correct vertical field of
+    view angle for that zoom level.
+
+    MuJoCo only allows us to set the vertical field of view for a camera, and
+    DepthTo2DLocations uses horizontal field of view.
+
+    Returns:
+        zoomed vertical field of view angle in degrees.
+    """
+    resolution_ratio = resolution.height / resolution.width
+    base_fovh_radians = np.deg2rad(base_fovh)
+    zoom_fovy_radians = 2 * np.arctan(
+        resolution_ratio * np.tan(base_fovh_radians / 2.0) / zoom
+    )
+    return np.rad2deg(zoom_fovy_radians)
 
 
 class Axis(IntEnum):
@@ -132,7 +154,11 @@ class Embodiment(Agent):
                 pos=sensor_cfg.position,
                 quat=sensor_cfg.rotation,
                 # Camera resolution isn't used in MuJoCo, so we're not setting it.
-                fovy=DEFAULT_CAMERA_FOVY / sensor_cfg.zoom,
+                fovy=zoom_fovy(
+                    base_fovh=DEFAULT_CAMERA_FOVH,
+                    resolution=sensor_cfg.resolution,
+                    zoom=sensor_cfg.zoom,
+                ),
             )
 
     @property

--- a/src/tbp/monty/simulators/mujoco/agents.py
+++ b/src/tbp/monty/simulators/mujoco/agents.py
@@ -59,7 +59,7 @@ def zoom_fovy(base_fovh: float, resolution: Resolution2D, zoom: float) -> float:
     view angle for that zoom level.
 
     MuJoCo only allows us to set the vertical field of view for a camera, and
-    DepthTo2DLocations uses horizontal field of view.
+    DepthTo3DLocations uses horizontal field of view.
 
     Returns:
         zoomed vertical field of view angle in degrees.

--- a/src/tbp/monty/simulators/mujoco/simulator.py
+++ b/src/tbp/monty/simulators/mujoco/simulator.py
@@ -47,7 +47,7 @@ from tbp.monty.simulators.mujoco.objects import (
 
 # Scaling factor to make MuJoCo primitives roughly the same size
 # as their Habitat counterparts. This was determined by trial and error.
-HABITAT_SCALING_FACTOR = (0.05, 0.05, 0.05)
+HABITAT_SCALING_FACTOR = (0.1, 0.1, 0.1)
 
 if TYPE_CHECKING:
     from functools import partial

--- a/tests/mujoco/integration/frameworks/models/__init__.py
+++ b/tests/mujoco/integration/frameworks/models/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.

--- a/tests/mujoco/integration/frameworks/models/graph_learning_test.py
+++ b/tests/mujoco/integration/frameworks/models/graph_learning_test.py
@@ -26,6 +26,7 @@ from tbp.monty.cmp import Message
 from tbp.monty.context import RuntimeContext
 from tbp.monty.frameworks.actions.actions import Action
 from tbp.monty.frameworks.experiments.mode import ExperimentMode
+from tbp.monty.frameworks.models.abstract_monty_classes import Monty
 from tbp.monty.frameworks.models.feature_location_matching import FeatureGraphLM
 from tbp.monty.frameworks.models.graph_matching import GraphLM
 from tbp.monty.frameworks.utils.logging_utils import (
@@ -943,7 +944,7 @@ class GraphLearningTest(BaseGraphTest):
             objects = [self.fake_obs_learn, self.fake_obs_house_3d]
             trained_modules = self.get_5lm_gm_with_fake_objects(objects)
             exp.experiment_mode = ExperimentMode.EVAL
-            monty = exp.model
+            monty: Monty = exp.model
             monty.set_experiment_mode(exp.experiment_mode)
             monty.learning_modules = [tm.learning_module for tm in trained_modules]
 
@@ -956,10 +957,11 @@ class GraphLearningTest(BaseGraphTest):
             for episode_num in range(tm.num_episodes):
                 exp.pre_episode()
                 # Normally the experiment `pre_episode` method would call the model
-                # `pre_episode` method, but it expects to feed data from an environment
+                # `reset` method, but it expects to feed data from an environment
                 # interface to the model. We aren't using that, so we call it again
                 # with the correct target value.
-                monty.pre_episode(self.placeholder_target)
+                monty.reset()
+                monty.fixme_set_ground_truth(self.placeholder_target)
                 for step in range(tm.num_observations(episode_num)):
                     # Manually run through the internal Monty steps since we aren't
                     # using the data from the environment interface and are instead

--- a/tests/mujoco/integration/frameworks/models/graph_learning_test.py
+++ b/tests/mujoco/integration/frameworks/models/graph_learning_test.py
@@ -1,0 +1,986 @@
+# Copyright 2025-2026 Thousand Brains Project
+# Copyright 2022-2024 Numenta Inc.
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+import copy
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import hydra
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from omegaconf import DictConfig
+
+from tbp.monty.cmp import Message
+from tbp.monty.context import RuntimeContext
+from tbp.monty.frameworks.actions.actions import Action
+from tbp.monty.frameworks.experiments.mode import ExperimentMode
+from tbp.monty.frameworks.models.feature_location_matching import FeatureGraphLM
+from tbp.monty.frameworks.models.graph_matching import GraphLM
+from tbp.monty.frameworks.utils.logging_utils import (
+    load_stats,
+)
+from tests import HYDRA_ROOT
+from tests.unit.resources.unit_test_utils import BaseGraphTest
+
+
+@dataclass
+class EpisodeObservations:
+    """An episode of observations for a single named object."""
+
+    name: str
+    observations: list[Any]
+
+    def __len__(self) -> int:
+        return len(self.observations)
+
+
+@dataclass
+class TrainedGraphLM:
+    """Class to bundle up a GraphLM and the object observations it was trained on.
+
+    Used by the tests below to bundle the trained GraphLMs with the object observations
+    it was trained on. See `GraphLearningTest::get_5lm_gm_with_fake_objects` for
+    more details.
+    """
+
+    learning_module: GraphLM
+    episodes: list[EpisodeObservations]
+
+    @property
+    def mode(self) -> ExperimentMode | None:
+        """Helper property to make setting and reading the LM mode easier."""
+        return self.learning_module.mode
+
+    @mode.setter
+    def mode(self, mode: ExperimentMode | None) -> None:
+        self.learning_module.mode = mode
+
+    def num_observations(self, episode_num: int) -> int:
+        """Number of observations in the specified episode.
+
+        Returns:
+            The number of observations in the episode.
+        """
+        return len(self.episodes[episode_num].observations)
+
+    @property
+    def num_episodes(self) -> int:
+        """Number of episodes/objects this LM was trained on."""
+        return len(self.episodes)
+
+    def reset_stm(self) -> None:
+        """Reset short-term memory buffer."""
+        self.learning_module.reset_stm()
+
+    # TODO: fix primary_target's type
+    def fixme_reset_ground_truth(self, primary_target: dict[str, Any]) -> None:
+        """Reset internal state based on ground truth."""
+        self.learning_module.fixme_reset_ground_truth(primary_target)
+
+
+class GraphLearningTest(BaseGraphTest):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.output_dir = Path(tempfile.mkdtemp())
+        self.compositional_save_path = tempfile.mkdtemp()
+
+        def hydra_config(
+            test_name: str,
+        ) -> DictConfig:
+            """Return a Hydra configuration from the specified test name.
+
+            Args:
+                test_name: the name of the test config to load
+            """
+            overrides = [
+                f"experiment=test/graph_learning/{test_name}",
+                f"experiment.config.logging.output_dir={self.output_dir}",
+            ]
+            return hydra.compose(config_name="experiment", overrides=overrides)
+
+        with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
+            self.base_cfg = hydra_config("base_mujoco")
+            self.surface_agent_eval_cfg = hydra_config("surface_agent_eval_mujoco")
+            self.ppf_pred_cfg = hydra_config("ppf_pred_mujoco")
+            self.disp_pred_cfg = hydra_config("disp_pred_mujoco")
+            self.feature_pred_cfg = hydra_config("feature_pred_mujoco")
+            self.fixed_actions_disp_cfg = hydra_config("fixed_actions_disp_mujoco")
+            self.fixed_actions_ppf_cfg = hydra_config("fixed_actions_ppf_mujoco")
+            self.fixed_actions_feat_cfg = hydra_config("fixed_actions_feat_mujoco")
+            self.feature_pred_time_out_cfg = hydra_config(
+                "feature_pred_time_out_mujoco"
+            )
+            self.feature_pred_off_object_cfg = hydra_config(
+                "feature_pred_off_object_mujoco"
+            )
+            self.feature_pred_off_object_train_cfg = hydra_config(
+                "feature_pred_off_object_train_mujoco"
+            )
+            self.feature_uniform_initial_poses_cfg = hydra_config(
+                "feature_uniform_initial_poses_mujoco"
+            )
+            self.five_lm_ppf_displacement_cfg = hydra_config(
+                "five_lm_ppf_displacement_mujoco"
+            )
+            self.five_lm_feature_cfg = hydra_config("five_lm_feature_mujoco")
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.output_dir)
+
+    def test_can_initialize(self) -> None:
+        """Canary to confirm we can initialize an experiment."""
+        exp = hydra.utils.instantiate(self.base_cfg.experiment)
+        with exp:
+            pass
+
+    def test_can_run_train_episode(self) -> None:
+        exp = hydra.utils.instantiate(self.base_cfg.experiment)
+        with exp:
+            exp.experiment_mode = ExperimentMode.TRAIN
+            exp.model.set_experiment_mode(exp.experiment_mode)
+            exp.pre_epoch()
+            exp.run_episode()
+
+    def test_right_data_in_buffer(self) -> None:
+        exp = hydra.utils.instantiate(self.base_cfg.experiment)
+        with exp:
+            exp.experiment_mode = ExperimentMode.TRAIN
+            exp.model.set_experiment_mode(exp.experiment_mode)
+            exp.pre_epoch()
+            exp.pre_episode()
+            step = 0
+            ctx = RuntimeContext(rng=exp.rng)
+            actions: list[Action] = []
+            while True:
+                observations, proprioceptive_state = exp.env_interface.step(actions)
+                actions = exp.model.step(ctx, observations, proprioceptive_state)
+                self.assertEqual(
+                    step + 1,
+                    len(exp.model.learning_modules[0].buffer),
+                    "buffer does not contain the right amount of elements.",
+                )
+                self.assertEqual(
+                    step + 1,
+                    len(
+                        exp.model.learning_modules[
+                            0
+                        ].buffer.get_all_locations_on_object(input_channel="first")
+                    ),
+                    "buffer does not contain the right amount of locations.",
+                )
+                if step == 0:
+                    self.assertListEqual(
+                        list(exp.model.learning_modules[0].buffer.nth_displacement(0)),
+                        [0, 0, 0],
+                        "displacement at step 0 should be 0.",
+                    )
+                self.assertEqual(
+                    step + 1,
+                    len(
+                        exp.model.learning_modules[0].buffer.displacements[
+                            "displacement"
+                        ]
+                    ),
+                    "buffer does not contain the right amount of displacements.",
+                )
+                self.assertSetEqual(
+                    set(exp.model.sensor_modules[0].features),
+                    set(exp.model.learning_modules[0].buffer[-1]["patch"].keys()),
+                    "buffer doesn't contain all features required for matching.",
+                )
+                if step == 3:
+                    break
+
+                step += 1
+
+    def test_can_run_eval_episode(self) -> None:
+        exp = hydra.utils.instantiate(self.base_cfg.experiment)
+        with exp:
+            exp.experiment_mode = ExperimentMode.EVAL
+            exp.model.set_experiment_mode(exp.experiment_mode)
+            exp.pre_epoch()
+            exp.run_episode()
+
+    def test_can_run_eval_episode_with_surface_agent(self) -> None:
+        exp = hydra.utils.instantiate(self.surface_agent_eval_cfg.experiment)
+        with exp:
+            exp.experiment_mode = ExperimentMode.EVAL
+            exp.model.set_experiment_mode(exp.experiment_mode)
+            exp.pre_epoch()
+            exp.run_episode()
+
+    def test_can_run_ppf_experiment(self) -> None:
+        exp = hydra.utils.instantiate(self.ppf_pred_cfg.experiment)
+        with exp:
+            exp.run()
+
+    def test_can_run_disp_experiment(self) -> None:
+        exp = hydra.utils.instantiate(self.disp_pred_cfg.experiment)
+        with exp:
+            exp.run()
+
+    def test_can_run_feature_experiment(self) -> None:
+        exp = hydra.utils.instantiate(self.feature_pred_cfg.experiment)
+        with exp:
+            exp.run()
+
+    def test_fixed_actions_disp(self) -> None:
+        """Runs three test episodes on capsule3DSolid and cubeSolid.
+
+        1. capsule, rotation = 0,0,0 -> no models in memory yet -> store new model
+        2. cube, rotation = 0,0,0 -> no models in memory yet -> store new model
+        3. capsule, rotation = 0,45,0 -> displacements cant recognize rotated model
+             -> store new rotated model of object
+        4. cube, rotation = 0,45,0 -> same as 3 for cube
+        5. capsule, rotation = 0,0,0 -> recognize first model stored in memory
+        6. cube, rotation = 0,0,0 -> recognize first model stored in memory
+
+        To make sure we recognize the first model in step three we use a fixed
+        action policy that executed the same action sequence in every episode.
+
+        Followed by three eval episodes on capsule3DSolid (same rotation sequence so
+        the first and third episode should recognize the capsule).
+        """
+        exp = hydra.utils.instantiate(self.fixed_actions_disp_cfg.experiment)
+        with exp:
+            exp.run()
+
+        output_dir = Path(exp.output_dir)
+        train_stats = pd.read_csv(output_dir / "train_stats.csv")
+        self.check_train_results(train_stats)
+
+        eval_stats = pd.read_csv(output_dir / "eval_stats.csv")
+        self.check_eval_results(eval_stats)
+
+    def test_fixed_actions_ppf(self) -> None:
+        """Like test_fixed_actions_disp but using point pair features for matching."""
+        exp = hydra.utils.instantiate(self.fixed_actions_ppf_cfg.experiment)
+        with exp:
+            exp.run()
+
+        output_dir = Path(exp.output_dir)
+        train_stats = pd.read_csv(output_dir / "train_stats.csv")
+        self.check_train_results(train_stats)
+
+        eval_stats = pd.read_csv(output_dir / "eval_stats.csv")
+        self.check_eval_results(eval_stats)
+
+    def test_fixed_actions_feat(self) -> None:
+        """Like test_fixed_actions_disp but using point pair features for matching."""
+        exp = hydra.utils.instantiate(self.fixed_actions_feat_cfg.experiment)
+        with exp:
+            exp.run()
+
+        output_dir = Path(exp.output_dir)
+        train_stats = pd.read_csv(output_dir / "train_stats.csv")
+        self.check_train_results(train_stats)
+
+        eval_stats = pd.read_csv(output_dir / "eval_stats.csv")
+        self.check_eval_results(eval_stats)
+
+    def test_save_and_load(self) -> None:
+        # Move this to graph_building_test.py?
+        exp = hydra.utils.instantiate(self.fixed_actions_ppf_cfg.experiment)
+        with exp:
+            exp.run()
+
+        # We are training for 3 epochs by default, load most recent indexing from 0
+        cfg2 = copy.deepcopy(self.fixed_actions_ppf_cfg)
+        cfg2.experiment.config.model_name_or_path = str(
+            Path(exp.output_dir) / "2",  # latest checkpoint
+        )
+        exp2 = hydra.utils.instantiate(cfg2.experiment)
+        with exp2:
+            graph_memory_1 = exp.model.learning_modules[
+                0
+            ].graph_memory.get_all_models_in_memory()
+            graph_memory_2 = exp2.model.learning_modules[
+                0
+            ].graph_memory.get_all_models_in_memory()
+
+            # Loop over each graph model and check they have the exact same data
+            for obj_name in graph_memory_1:
+                for input_channel in graph_memory_1[obj_name]:
+                    graph_1 = graph_memory_1[obj_name][input_channel]
+                    graph_2 = graph_memory_2[obj_name][input_channel]
+                    self.check_graphs_equal(graph_1, graph_2)
+
+    def test_time_out(self) -> None:
+        """Test time_out and pose_time_out detection and logging.
+
+        # TODO: This test is a little shaky and should be improved.
+
+        Episodes 0 and 1: Should detect no_match and build models for 2 objects
+        Episode 2: Lowered max_steps and raised mmd -> detect pose_time_out
+        (Episode 3: object is too similar with tolerances, will also detect time_out)
+        Episodes 4 and 5: Increased curvature tolerance -> detect time_out
+        """
+        exp = hydra.utils.instantiate(self.feature_pred_time_out_cfg.experiment)
+        with exp:
+            exp.experiment_mode = ExperimentMode.TRAIN
+            exp.model.set_experiment_mode(exp.experiment_mode)
+            for e in range(6):
+                if e % 2 == 0:
+                    exp.pre_epoch()
+                if e == 2:
+                    # Set max steps low & raise mmd to get pose time outs
+                    exp.max_train_steps = 3
+                    exp.model.learning_modules[0].max_match_distance = 0.1
+                if e == 4:
+                    # set curvature threshold high to get time outs
+                    exp.model.learning_modules[0].tolerances["patch"][
+                        "principal_curvatures_log"
+                    ] = [10, 10]
+                exp.run_episode()
+                if e % 2 == 1:
+                    exp.post_epoch()
+
+        output_dir = Path(exp.output_dir)
+        train_stats = pd.read_csv(output_dir / "train_stats.csv")
+        self.assertEqual(
+            train_stats["primary_performance"][2],
+            "pose_time_out",
+            "pose time out not recognized/logged correctly",
+        )
+        # possible locations are str in .csv with one line per pose
+        # unique rotations may already be one but we don't know
+        # where we are yet.
+        self.assertGreater(
+            train_stats["possible_object_locations"][2].count("\n"),
+            0,  # If there are two possible locations, there will be 1 newline
+            "pose time out episode should have more than one possible pose.",
+        )
+        for episode in [4, 5]:
+            self.assertEqual(
+                train_stats["primary_performance"][episode],
+                "time_out",
+                "time out not recognized/logged correctly",
+            )
+            self.assertEqual(
+                train_stats["primary_performance"][episode],
+                "time_out",
+                "time out not recognized/logged correctly",
+            )
+            self.assertGreater(
+                train_stats["num_possible_matches"][episode],
+                1,
+                "time out episode should have more than one possible match.",
+            )
+            # possible objects are comma separated string
+            self.assertGreater(
+                train_stats["result"][episode].count(","),
+                0,  # If there are two objects, there should be 1 comma
+                "time out episode should log more than one possible match.",
+            )
+
+    def test_confused_logging(self) -> None:
+        # When the algorithm evolves, this scenario may not lead to confusion
+        # anymore. Setting min_steps would also avoid this, probably.
+        exp = hydra.utils.instantiate(self.fixed_actions_feat_cfg.experiment)
+        with exp:
+            exp.experiment_mode = ExperimentMode.TRAIN
+            exp.model.set_experiment_mode(exp.experiment_mode)
+            exp.pre_epoch()
+            # Overwrite target with a false name to test confused logging.
+            for e in range(4):
+                exp.pre_episode()
+                exp.model.primary_target = str(e)
+                for lm in exp.model.learning_modules:
+                    lm.primary_target = str(e)
+                last_step = exp.run_episode_steps()
+                exp.post_episode(last_step)
+            exp.post_epoch()
+
+        output_dir = Path(exp.output_dir)
+        train_stats = pd.read_csv(output_dir / "train_stats.csv")
+        for i in [0, 1]:
+            self.assertEqual(
+                train_stats["primary_performance"][i],
+                "no_match",
+                f"episode {i} should be no_match.",
+            )
+            self.assertEqual(
+                train_stats["TFNP"][i],
+                "unknown_object_not_matched_(TN)",
+                f"episode {i} should detect a true negative.",
+            )
+        for i in [2, 3]:
+            self.assertEqual(
+                train_stats["primary_performance"][i],
+                "confused",
+                f"episode {i} should log confused performance.",
+            )
+            self.assertEqual(
+                train_stats["TFNP"][i],
+                "unknown_object_in_possible_matches_(FP)",
+                f"episode {i} should detect a false positive.",
+            )
+            self.assertNotEqual(
+                train_stats["primary_target_object"][i],
+                train_stats["result"][i],
+                "confused object id should not be the same as target.",
+            )
+            self.assertNotEqual(
+                train_stats["primary_target_object"][i],
+                train_stats["possible_match_sources"][i],
+                "confused object id should not be in possible_match_sources.",
+            )
+
+    def test_moving_off_object(self) -> None:
+        # Tests additional elements of logging, in particular in relation
+        # to logging of observations when off the object
+
+        exp = hydra.utils.instantiate(self.feature_pred_off_object_train_cfg.experiment)
+        with exp:
+            # First episode will be used to learn object (no_match is triggered before
+            # min_steps is reached and the sensor moves off the object). In the second
+            # episode the sensor moves off the sphere on episode steps 6+
+            # Eventually, we circle round and come back to the object; recognition
+            # does not take place before then because when off the object, matching
+            # steps are no longer incremented, while it is an unfamiliar part of
+            # the object that we return to
+            exp.run()
+            self.assertEqual(
+                len(
+                    exp.model.learning_modules[0].buffer.get_all_locations_on_object(
+                        input_channel="patch"
+                    )
+                ),
+                len(
+                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                        "patch"
+                    ]["pose_vectors"]
+                ),
+                "Did not retrieve same amount of feature and locations on object.",
+            )
+            self.assertEqual(
+                sum(
+                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                        "patch"
+                    ]["on_object"]
+                ),
+                len(
+                    exp.model.learning_modules[0].buffer.get_all_features_on_object()[
+                        "patch"
+                    ]["on_object"]
+                ),
+                "not all retrieved features were collected on the object.",
+            )
+            # Since we don't add observations to the buffer that are off the object
+            # there should only be 8 observations stored for the 12 matching steps
+            # and all of them should be on the object.
+            num_matching_steps = len(
+                exp.model.learning_modules[0].buffer.stats["possible_matches"]
+            )
+            self.assertEqual(
+                num_matching_steps,
+                sum(
+                    exp.model.learning_modules[0].buffer.features["patch"]["on_object"][
+                        :num_matching_steps
+                    ]
+                ),
+                "Number of match steps does not match with stored observations "
+                "on object",
+            )
+
+    def test_detailed_logging(self) -> None:
+        exp = hydra.utils.instantiate(self.feature_pred_off_object_cfg.experiment)
+        with exp:
+            exp.run()
+
+        # TODO: improve load_stats with a structured return type
+        train_stats, eval_stats, detailed_stats, lm_models = load_stats(
+            exp.output_dir,
+            load_train=True,
+            load_eval=True,
+            load_detailed=True,
+        )
+        for episode in lm_models:
+            self.assertEqual(
+                list(lm_models[episode]["LM_0"].keys()),
+                ["new_object0"],
+                "should have only learned and saved one object during training.",
+            )
+        for row in range(train_stats.shape[0]):
+            self.assertEqual(
+                train_stats.loc[row]["primary_target_object"],
+                detailed_stats[str(row)]["LM_0"]["target"]["object"],
+                "targets in train_stats and detailed stats don't match.",
+            )
+
+        for row in range(eval_stats.shape[0]):
+            detailed_id = train_stats.shape[0] + row - 1
+            self.assertEqual(
+                eval_stats.loc[row]["primary_target_object"],
+                detailed_stats[str(detailed_id)]["LM_0"]["target"]["object"],
+                "targets in eval_stats and detailed stats don't match.",
+            )
+        self.assertEqual(
+            len(detailed_stats["1"]["SM_0"]["processed_observations"]),
+            200,
+            "sensor module observations should contain all observations,"
+            "even those off the object.",
+        )
+        self.assertEqual(
+            len(detailed_stats["1"]["LM_0"]["possible_matches"]),
+            train_stats.loc[1]["monty_matching_steps"],
+            "matching steps in detailed stats don't match with those in train stats.",
+        )
+        self.assertEqual(
+            sum(np.array(detailed_stats["1"]["LM_0"]["patch"]["on_object"])),
+            len(detailed_stats["1"]["LM_0"]["patch"]["on_object"]),
+            "learning module observations should only contain observations"
+            "that were on the object.",
+        )
+        # Could add more tests but not sure how important.
+
+    def test_uniform_initial_poses(self) -> None:
+        """Test same scenario as test_fixed_actions_feat with uniform poses."""
+        exp = hydra.utils.instantiate(self.feature_uniform_initial_poses_cfg.experiment)
+        with exp:
+            exp.run()
+
+        output_dir = Path(exp.output_dir)
+        train_stats = pd.read_csv(output_dir / "train_stats.csv")
+        self.check_train_results(train_stats)
+
+        eval_stats = pd.read_csv(output_dir / "eval_stats.csv")
+        self.check_eval_results(eval_stats)
+
+    def gm_learn_object(
+        self,
+        graph_lm: FeatureGraphLM,
+        obj_name: str,
+        observations: Sequence[Message],
+        offset: npt.NDArray[np.float64] | None = None,
+    ) -> list[Message]:
+        if offset is None:
+            offset = np.zeros(3)
+
+        graph_lm.mode = ExperimentMode.TRAIN
+        graph_lm.reset_stm()
+        graph_lm.fixme_reset_ground_truth(primary_target=self.placeholder_target)
+
+        offset_obs = []
+        for observation in observations:
+            obs_to_learn = copy.deepcopy(observation)
+            obs_to_learn.location += offset
+            offset_obs.append(obs_to_learn)
+            graph_lm.exploratory_step(self.ctx, [obs_to_learn])
+
+        graph_lm.detected_object = obj_name
+        graph_lm.detected_rotation_r = None
+        graph_lm.buffer.stats["detected_location_rel_body"] = (
+            graph_lm.buffer.get_current_location(input_channel="first")
+        )
+
+        graph_lm.update_ltm_from_stm()
+        graph_lm.fixme_update_ground_truth()
+        return offset_obs
+
+    def get_gm_with_fake_object(self) -> FeatureGraphLM:
+        graph_lm = FeatureGraphLM(
+            max_match_distance=0.005,
+            tolerances={
+                "patch": {
+                    "hsv": [0.1, 1, 1],
+                    "principal_curvatures_log": [1, 1],
+                }
+            },
+        )
+
+        self.gm_learn_object(
+            graph_lm, obj_name="new_object0", observations=self.fake_obs_learn
+        )
+
+        self.assertEqual(
+            len(graph_lm.get_all_known_object_ids()),
+            1,
+            "Should have stored exactly one object in memory.",
+        )
+        self.assertEqual(
+            graph_lm.get_all_known_object_ids()[0],
+            "new_object0",
+            "Learned object ID should be new_object0.",
+        )
+        return graph_lm
+
+    def get_5lm_gm_with_fake_objects(
+        self, objects: list[list[Message]]
+    ) -> list[TrainedGraphLM]:
+        graph_lms = []
+        for lm in range(5):
+            graph_lm = FeatureGraphLM(
+                max_match_distance=0.005,
+                tolerances={
+                    "patch": {
+                        "hsv": [0.1, 1, 1],
+                        "principal_curvatures_log": [1, 1],
+                    }
+                },
+            )
+            object_obs = []
+            for i, obj in enumerate(objects):
+                obj_name = f"new_object{i}"
+                offset_obs = self.gm_learn_object(
+                    graph_lm,
+                    obj_name=obj_name,
+                    observations=obj,
+                    offset=self.lm_offsets[lm],
+                )
+                object_obs.append(EpisodeObservations(obj_name, offset_obs))
+            graph_lms.append(TrainedGraphLM(graph_lm, object_obs))
+
+        return graph_lms
+
+    def test_same_sequence_recognition(self) -> None:
+        """Test that the object is recognized with same action sequence."""
+        fake_obs_test = copy.deepcopy(self.fake_obs_learn)
+
+        graph_lm = self.get_gm_with_fake_object()
+
+        graph_lm.mode = ExperimentMode.EVAL
+        # Don't need to give target object since we are not logging performance
+        graph_lm.reset_stm()
+        graph_lm.fixme_reset_ground_truth(primary_target=self.placeholder_target)
+        for observation in fake_obs_test:
+            graph_lm.matching_step(self.ctx, [observation])
+            self.assertEqual(
+                len(graph_lm.get_possible_matches()),
+                1,
+                "Should have exactly one possible match.",
+            )
+            self.assertEqual(
+                graph_lm.get_possible_matches()[0],
+                "new_object0",
+                "Should match to new_object0.",
+            )
+        self.assertEqual(
+            len(graph_lm.get_possible_paths()["new_object0"]),
+            1,
+            "Should recognize unique location",
+        )
+        self.assertEqual(
+            len(graph_lm.get_possible_poses()["new_object0"][0]),
+            1,
+            "Should recognize unique rotation",
+        )
+        self.assertListEqual(
+            list(graph_lm.get_possible_poses()["new_object0"][0][0]),
+            [0, 0, 0],
+            "Should recognize rotation 0, 0, 0.",
+        )
+
+    def test_reverse_sequence_recognition(self) -> None:
+        """Test that object is recognized irrespective of sampling order."""
+        fake_obs_test = copy.deepcopy(self.fake_obs_learn)
+        fake_obs_test.reverse()
+
+        graph_lm = self.get_gm_with_fake_object()
+
+        graph_lm.mode = ExperimentMode.EVAL
+        graph_lm.reset_stm()
+        graph_lm.fixme_reset_ground_truth(primary_target=self.placeholder_target)
+        for observation in fake_obs_test:
+            graph_lm.matching_step(self.ctx, [observation])
+            print(graph_lm.get_possible_matches())
+            self.assertEqual(
+                len(graph_lm.get_possible_matches()),
+                1,
+                "Should have exactly one possible match.",
+            )
+            self.assertEqual(
+                graph_lm.get_possible_matches()[0],
+                "new_object0",
+                "Should match to new_object0.",
+            )
+        self.assertEqual(
+            len(graph_lm.get_possible_paths()["new_object0"]),
+            1,
+            "Should recognize unique location",
+        )
+        self.assertEqual(
+            len(graph_lm.get_possible_poses()["new_object0"][0]),
+            1,
+            "Should recognize unique rotation",
+        )
+        self.assertListEqual(
+            list(graph_lm.get_possible_poses()["new_object0"][0][0]),
+            [0, 0, 0],
+            "Should recognize rotation 0, 0, 0.",
+        )
+
+    def test_offset_sequence_recognition(self) -> None:
+        """Test that the object is recognized irrespective of its location rel body."""
+        fake_obs_test = copy.deepcopy(self.fake_obs_learn)
+
+        graph_lm = self.get_gm_with_fake_object()
+
+        graph_lm.mode = ExperimentMode.EVAL
+        graph_lm.reset_stm()
+        graph_lm.fixme_reset_ground_truth(primary_target=self.placeholder_target)
+        for observation in fake_obs_test:
+            observation.location = observation.location + np.ones(3)
+            graph_lm.matching_step(self.ctx, [observation])
+            print(graph_lm.get_possible_matches())
+            self.assertEqual(
+                len(graph_lm.get_possible_matches()),
+                1,
+                "Should have exactly one possible match.",
+            )
+            self.assertEqual(
+                graph_lm.get_possible_matches()[0],
+                "new_object0",
+                "Should match to new_object0.",
+            )
+        self.assertEqual(
+            len(graph_lm.get_possible_paths()["new_object0"]),
+            1,
+            "Should recognize unique location",
+        )
+        self.assertEqual(
+            len(graph_lm.get_possible_poses()["new_object0"][0]),
+            1,
+            "Should recognize unique rotation",
+        )
+        self.assertListEqual(
+            list(graph_lm.get_possible_poses()["new_object0"][0][0]),
+            [0, 0, 0],
+            "Should recognize rotation 0, 0, 0.",
+        )
+
+    def test_new_sampling_recognition(self) -> None:
+        """Test object recognition with slightly perturbed observations.
+
+        Test that the object is recognized if observations don't exactly fit
+        the model.
+        """
+        fake_obs_test = copy.deepcopy(self.fake_obs_learn)
+        fake_obs_test[0].location = fake_obs_test[0].location + np.ones(3) * 0.001
+
+        graph_lm = self.get_gm_with_fake_object()
+
+        graph_lm.mode = ExperimentMode.EVAL
+        graph_lm.reset_stm()
+        graph_lm.fixme_reset_ground_truth(primary_target=self.placeholder_target)
+        for observation in fake_obs_test:
+            graph_lm.matching_step(self.ctx, [observation])
+            self.assertEqual(
+                len(graph_lm.get_possible_matches()),
+                1,
+                "Should have exactly one possible match.",
+            )
+            self.assertEqual(
+                graph_lm.get_possible_matches()[0],
+                "new_object0",
+                "Should match to new_object0.",
+            )
+        self.assertEqual(
+            len(graph_lm.get_possible_paths()["new_object0"]),
+            1,
+            "Should recognize unique location",
+        )
+        self.assertEqual(
+            len(graph_lm.get_possible_poses()["new_object0"][0]),
+            1,
+            "Should recognize unique rotation",
+        )
+        self.assertListEqual(
+            list(graph_lm.get_possible_poses()["new_object0"][0][0]),
+            [0, 0, 0],
+            "Should recognize rotation 0, 0, 0.",
+        )
+
+    def test_different_locations_not_recognized(self) -> None:
+        """Test that the object is not recognized if locations don't match."""
+        fake_obs_test = copy.deepcopy(self.fake_obs_learn)
+        fake_obs_test[0].location = fake_obs_test[0].location + np.ones(3) * 5
+
+        graph_lm = self.get_gm_with_fake_object()
+
+        graph_lm.mode = ExperimentMode.EVAL
+        graph_lm.reset_stm()
+        graph_lm.fixme_reset_ground_truth(primary_target=self.placeholder_target)
+        for i, observation in enumerate(fake_obs_test):
+            graph_lm.matching_step(self.ctx, [observation])
+            if i == 0:
+                self.assertEqual(
+                    len(graph_lm.get_possible_matches()),
+                    1,
+                    "Should have one match at the first step.",
+                )
+            else:
+                self.assertEqual(
+                    len(graph_lm.get_possible_matches()),
+                    0,
+                    "Should have no possible matches.",
+                )
+
+    def test_different_features_not_recognized(self) -> None:
+        """Test that the object is not recognized if features don't match."""
+        fake_obs_test = copy.deepcopy(self.fake_obs_learn)
+        fake_obs_test[0].non_morphological_features["hsv"] = [0.5, 1, 1]
+
+        graph_lm = self.get_gm_with_fake_object()
+
+        graph_lm.mode = ExperimentMode.EVAL
+        graph_lm.reset_stm()
+        graph_lm.fixme_reset_ground_truth(primary_target=self.placeholder_target)
+        for observation in fake_obs_test:
+            graph_lm.matching_step(self.ctx, [observation])
+            self.assertEqual(
+                len(graph_lm.get_possible_matches()),
+                0,
+                "Should have no possible matches.",
+            )
+
+    def test_different_pose_features_not_recognized(self) -> None:
+        """Test that the object is not recognized if pose features don't match."""
+        fake_obs_test = copy.deepcopy(self.fake_obs_learn)
+        fake_obs_test[0].morphological_features["pose_vectors"] = np.array(
+            [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        )
+
+        graph_lm = self.get_gm_with_fake_object()
+
+        graph_lm.mode = ExperimentMode.EVAL
+        graph_lm.reset_stm()
+        graph_lm.fixme_reset_ground_truth(primary_target=self.placeholder_target)
+        for step, observation in enumerate(fake_obs_test):
+            graph_lm.matching_step(self.ctx, [observation])
+            if step == 0:
+                self.assertEqual(
+                    len(graph_lm.get_possible_matches()),
+                    1,
+                    "Should have one possible match at first step.",
+                )
+            else:
+                self.assertEqual(
+                    len(graph_lm.get_possible_matches()),
+                    0,
+                    "Should have no possible matches.",
+                )
+
+    def test_moving_off_object_and_back(self) -> None:
+        """Test that the object is still recognized after moving off the object.
+
+        TODO: since the monty class checks use_state in combine_inputs it doesn't make
+        much sense to test this here anymore with an isolated LM.
+        """
+        fake_obs_test = copy.deepcopy(self.fake_obs_learn)
+        fake_obs_test[1].location = [1, 2, 1]
+        fake_obs_test[1].morphological_features["on_object"] = 0
+        fake_obs_test[1].use_state = False
+
+        graph_lm = self.get_gm_with_fake_object()
+
+        graph_lm.mode = ExperimentMode.EVAL
+        graph_lm.reset_stm()
+        graph_lm.fixme_reset_ground_truth(primary_target=self.placeholder_target)
+        for observation in fake_obs_test:
+            if not observation.use_state:
+                pass
+            else:
+                graph_lm.matching_step(self.ctx, [observation])
+                self.assertEqual(
+                    len(graph_lm.get_possible_matches()),
+                    1,
+                    "Should have exactly one possible match.",
+                )
+                self.assertEqual(
+                    graph_lm.get_possible_matches()[0],
+                    "new_object0",
+                    "Should match to new_object0.",
+                )
+        self.assertEqual(
+            len(graph_lm.get_possible_paths()["new_object0"]),
+            1,
+            "Should recognize unique location",
+        )
+        self.assertEqual(
+            len(graph_lm.get_possible_poses()["new_object0"][0]),
+            1,
+            "Should recognize unique rotation",
+        )
+        self.assertListEqual(
+            list(graph_lm.get_possible_poses()["new_object0"][0][0]),
+            [0, 0, 0],
+            "Should recognize rotation 0, 0, 0.",
+        )
+
+    def test_5lm_displacement_experiment(self) -> None:
+        """Test 5 displacement LMs voting with two evaluation settings."""
+        exp = hydra.utils.instantiate(self.five_lm_ppf_displacement_cfg.experiment)
+        with exp:
+            exp.run()
+
+        output_dir = Path(exp.output_dir)
+        train_stats = pd.read_csv(output_dir / "train_stats.csv")
+        self.check_multilm_train_results(train_stats, num_lms=5, min_done=3)
+
+        eval_stats = pd.read_csv(output_dir / "eval_stats.csv")
+        self.check_multilm_eval_results(
+            eval_stats, num_lms=5, min_done=3, num_episodes=1
+        )
+
+    def test_5lm_feature_experiment(self) -> None:
+        """Test 5 feature LMs voting with two evaluation settings."""
+        exp = hydra.utils.instantiate(self.five_lm_feature_cfg.experiment)
+        with exp:
+            objects = [self.fake_obs_learn, self.fake_obs_house_3d]
+            trained_modules = self.get_5lm_gm_with_fake_objects(objects)
+            exp.experiment_mode = ExperimentMode.EVAL
+            monty = exp.model
+            monty.set_experiment_mode(exp.experiment_mode)
+            monty.learning_modules = [tm.learning_module for tm in trained_modules]
+
+            for tm in trained_modules:
+                tm.mode = ExperimentMode.EVAL
+
+            exp.pre_epoch()
+            ctx = RuntimeContext(rng=exp.rng)
+
+            for episode_num in range(tm.num_episodes):
+                exp.pre_episode()
+                # Normally the experiment `pre_episode` method would call the model
+                # `pre_episode` method, but it expects to feed data from an environment
+                # interface to the model. We aren't using that, so we call it again
+                # with the correct target value.
+                monty.pre_episode(self.placeholder_target)
+                for step in range(tm.num_observations(episode_num)):
+                    # Manually run through the internal Monty steps since we aren't
+                    # using the data from the environment interface and are instead
+                    # providing faked observations.
+                    monty.sensor_module_outputs = [
+                        lm.episodes[episode_num].observations[step]
+                        for lm in trained_modules
+                    ]
+                    monty._step_learning_modules(ctx)
+                    monty._vote()
+                    monty._pass_goals()
+                    monty._set_step_type_and_check_if_done()
+                    monty._post_step()
+                exp.post_episode(tm.num_observations(episode_num))
+            exp.post_epoch()
+
+        output_dir = Path(exp.output_dir)
+        eval_stats = pd.read_csv(output_dir / "eval_stats.csv")
+        # Just testing 1 episode here. Somehow the second rotation doesn't get
+        # recognized. Probably just some parameter setting due to flaws in old
+        # LM but didn't want to dig too deep into that for now.
+        self.check_multilm_eval_results(
+            eval_stats, num_lms=5, min_done=3, num_episodes=1
+        )

--- a/tests/mujoco/integration/frameworks/models/graph_learning_test.py
+++ b/tests/mujoco/integration/frameworks/models/graph_learning_test.py
@@ -530,7 +530,7 @@ class GraphLearningTest(BaseGraphTest):
             )
         self.assertEqual(
             len(detailed_stats["1"]["SM_0"]["processed_observations"]),
-            200,
+            73,
             "sensor module observations should contain all observations,"
             "even those off the object.",
         )

--- a/tests/unit/resources/unit_test_utils.py
+++ b/tests/unit/resources/unit_test_utils.py
@@ -7,11 +7,14 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
+from __future__ import annotations
 
 import copy
 from unittest import TestCase
 
 import numpy as np
+from pandas import DataFrame
+from torch_geometric.data import Data
 
 from tbp.monty.cmp import Message
 from tbp.monty.conf.make_environment import (
@@ -22,7 +25,7 @@ from tbp.monty.geometry import Rotation
 
 
 class BaseGraphTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         print("setting up")
         fake_sender_id = "patch"
 
@@ -181,7 +184,7 @@ class BaseGraphTest(TestCase):
                 np_array = np.append(np_array, r)
         return np_array
 
-    def check_train_results(self, train_stats, num_lms=1):
+    def check_train_results(self, train_stats: DataFrame, num_lms: int = 1) -> None:
         for lm_id in range(num_lms):
             self.assertEqual(
                 train_stats["result"][0 * num_lms + lm_id],
@@ -274,7 +277,7 @@ class BaseGraphTest(TestCase):
                 "Rotation of cubeSolid not detected correctly.",
             )
 
-    def check_graphs_equal(self, g1, g2):
+    def check_graphs_equal(self, g1: Data, g2: Data) -> None:
         """Used for checking saving and loading.
 
         `g1` and `g2` are torch_geometric.data.data.Data objects. Check if all
@@ -308,7 +311,7 @@ class BaseGraphTest(TestCase):
         num_norm_same = (g1.norm == g2.norm).sum()
         self.assertEqual(num_norm_same, g1.norm.size(0) * g1.norm.size(1))
 
-    def check_eval_results(self, eval_stats, num_lms=1):
+    def check_eval_results(self, eval_stats: DataFrame, num_lms: int = 1) -> None:
         for lm_id in range(num_lms):
             self.assertEqual(
                 eval_stats["result"][0 * num_lms + lm_id],
@@ -344,7 +347,9 @@ class BaseGraphTest(TestCase):
                     f"capsule3DSolid was not detected by lm {lm_id}.",
                 )
 
-    def check_multilm_train_results(self, train_stats, num_lms, min_done):
+    def check_multilm_train_results(
+        self, train_stats: DataFrame, num_lms: int, min_done: int
+    ) -> None:
         for episode in range(4):
             no_match_count = 0
             for lm_id in range(num_lms):
@@ -373,7 +378,13 @@ class BaseGraphTest(TestCase):
                 f"Not enough correct LMs for train episode {episode}",
             )
 
-    def check_multilm_eval_results(self, eval_stats, num_lms, min_done, num_episodes=3):
+    def check_multilm_eval_results(
+        self,
+        eval_stats: DataFrame,
+        num_lms: int,
+        min_done: int,
+        num_episodes: int = 3,
+    ) -> None:
         for episode in range(num_episodes):
             correct_count = 0
             for lm_id in range(num_lms):


### PR DESCRIPTION
This PR is part of a larger effort to migrate integration tests to use MuJoCo instead of Habitat.

Outside of the new `/environment` options, the config changes consist of swapping the `/environment` from a Habitat version to an equivalent MuJoCo version.

I've added type hints to **most** of the functions and methods called from the test, to satisfy Mypy. There a small number remaining that either I couldn't determine the correct type easily, or setting the type would involve more invasive changes. I figured they could be delayed until a latter date.

> [!warning]
> **Breaking Changes**
> - Changed FOV calculation to correctly calculate for zooms