### PR TITLE
refactor!: split Runtime and Experiment aspects of Monty

### DIFF
--- a/src/tbp/monty/experiment/monty.py
+++ b/src/tbp/monty/experiment/monty.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from tbp.monty.frameworks.environments.environment import SemanticID
+from tbp.monty.frameworks.experiments.mode import ExperimentMode
+
+__all__ = [
+    "ExperimentMonty",
+]
+
+
+class ExperimentMonty(Protocol):
+    """Experiment interface to Monty model."""
+
+    def reset(self) -> None:
+        """Reset the internal state of this Monty model."""
+        ...
+
+    def fixme_set_ground_truth(
+        self,
+        primary_target: dict[str, Any] | None = None,
+        semantic_id_to_label: dict[SemanticID, str] | None = None,
+    ) -> None:
+        """Provide ground truth from experiment supervision.
+
+        Args:
+            primary_target: Optional primary target to recognize.
+            semantic_id_to_label: Optional mapping from IDs to labels.
+        """
+        ...
+
+    def update_ltm(self) -> None:
+        """Transfer short-term buffer to long-term memory."""
+        ...
+
+    def set_experiment_mode(self, mode: ExperimentMode) -> None:
+        """Set the experiment mode.
+
+        Update state variables based on which method (train or evaluate) is being
+        called at the experiment level.
+
+        Args:
+            mode: The experiment mode.
+        """
+        ...
+
+    def is_done(self) -> bool:
+        """Return `True` if the model has reached a terminal condition."""
+        ...

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -504,7 +504,7 @@ class MontyExperiment:
 
         self.reset_episode_rng()
 
-        self.model.pre_episode()
+        self.model.reset()
         self.env_interface.pre_episode(self.rng)
 
         self.max_steps = self.max_train_steps
@@ -530,7 +530,7 @@ class MontyExperiment:
         get 'confused'/'FP'.
         """
         self.logger_handler.post_episode(self.logger_args)
-        self.model.post_episode()
+        self.model.update_ltm()
 
         if self.experiment_mode is ExperimentMode.TRAIN:
             self.train_episodes += 1

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -65,19 +65,19 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
 
         self.reset_episode_rng()
 
+        self.model.reset()
         # TODO, eventually it would be better to pass
         # self.env_interface.semantic_id_to_label via an "Observation" object when this
         # is eventually implemented, such that we can ensure this information is never
         # inappropriately accessed and used
         if hasattr(self.env_interface, "semantic_id_to_label"):
-            # TODO: Fix invalid pre_episode signature call
-            self.model.pre_episode(
+            self.model.fixme_set_ground_truth(
                 self.env_interface.primary_target,
                 self.env_interface.semantic_id_to_label,
             )
         else:
-            # TODO: Fix invalid pre_episode signature call
-            self.model.pre_episode(self.env_interface.primary_target)
+            self.model.fixme_set_ground_truth(self.env_interface.primary_target)
+
         self.env_interface.pre_episode(self.rng)
 
         self.max_steps = self.max_train_steps

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -193,8 +193,8 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
 
         self.reset_episode_rng()
 
-        # TODO: Fix invalid pre_episode signature call
-        self.model.pre_episode(self.env_interface.primary_target)
+        self.model.reset()
+        self.model.fixme_set_ground_truth(self.env_interface.primary_target)
         self.env_interface.pre_episode(self.rng)
 
         self.max_steps = self.max_train_steps  # no eval mode here

--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -71,7 +71,66 @@ class Observations(Dict[AgentID, AgentObservations]):
     pass
 
 
-class Monty(ExperimentMonty, Snapshotable, metaclass=abc.ABCMeta):
+class RuntimeMonty(Protocol):
+    """Runtime interface to Monty."""
+
+    def step(
+        self,
+        ctx: RuntimeContext,
+        observations: Observations,
+        proprioceptive_state: ProprioceptiveState,
+    ) -> list[Action]:
+        """Take a matching, exploratory, or custom user-defined step.
+
+        Step taken depends on the value of self.step_type.
+
+        Args:
+            ctx: The runtime context.
+            observations: The observations from the environment.
+            proprioceptive_state: The proprioceptive state from the environment.
+
+        Returns:
+            The actions to take.
+        """
+        ...
+
+    def motor_only_step(
+        self,
+        ctx: RuntimeContext,
+        observations: Observations,
+        proprioceptive_state: ProprioceptiveState,
+    ) -> list[Action]:
+        """Take a step of the sensors and motor system only.
+
+        This skips stepping the learning modules.
+
+        Args:
+            ctx: The runtime context.
+            observations: The observations from the environment.
+            proprioceptive_state: The proprioceptive state from the environment.
+
+        Returns:
+            The actions to take.
+        """
+        ...
+
+    def aggregate_sensory_inputs(
+        self,
+        ctx: RuntimeContext,
+        observations: Observations,
+        proprioceptive_state: ProprioceptiveState,
+    ) -> None:
+        """Receive data from environment, organize on a per sensor module basis.
+
+        Args:
+            ctx: The runtime context.
+            observations: The observations from the environment.
+            proprioceptive_state: The proprioceptive state from the environment.
+        """
+        ...
+
+
+class Monty(ExperimentMonty, RuntimeMonty, Snapshotable, metaclass=abc.ABCMeta):
     def _matching_step(
         self,
         ctx: RuntimeContext,
@@ -124,18 +183,6 @@ class Monty(ExperimentMonty, Snapshotable, metaclass=abc.ABCMeta):
         observations: Observations,
         proprioceptive_state: ProprioceptiveState,
     ) -> list[Action]:
-        """Take a matching, exploratory, or custom user-defined step.
-
-        Step taken depends on the value of self.step_type.
-
-        Args:
-            ctx: The runtime context.
-            observations: The observations from the environment.
-            proprioceptive_state: The proprioceptive state from the environment.
-
-        Returns:
-            The actions to take.
-        """
         pass
 
     @abc.abstractmethod
@@ -145,18 +192,6 @@ class Monty(ExperimentMonty, Snapshotable, metaclass=abc.ABCMeta):
         observations: Observations,
         proprioceptive_state: ProprioceptiveState,
     ) -> list[Action]:
-        """Take a step of the sensors and motor system only.
-
-        This skips stepping the learning modules.
-
-        Args:
-            ctx: The runtime context.
-            observations: The observations from the environment.
-            proprioceptive_state: The proprioceptive state from the environment.
-
-        Returns:
-            The actions to take.
-        """
         pass
 
     @abc.abstractmethod
@@ -165,14 +200,7 @@ class Monty(ExperimentMonty, Snapshotable, metaclass=abc.ABCMeta):
         ctx: RuntimeContext,
         observations: Observations,
         proprioceptive_state: ProprioceptiveState,
-    ):
-        """Receive data from environment, organize on a per sensor module basis.
-
-        Args:
-            ctx: The runtime context.
-            observations: The observations from the environment.
-            proprioceptive_state: The proprioceptive state from the environment.
-        """
+    ) -> None:
         pass
 
     @abc.abstractmethod

--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -18,9 +18,11 @@ import numpy.typing as npt
 from tbp.monty.cmp import Goal, Message
 from tbp.monty.context import RuntimeContext
 from tbp.monty.experiment.learning_module import ExperimentLearningModule
+from tbp.monty.experiment.monty import ExperimentMonty
 from tbp.monty.experiment.sensor_module import ExperimentSensorModule
 from tbp.monty.frameworks.actions.actions import Action
 from tbp.monty.frameworks.agents import AgentID
+from tbp.monty.frameworks.environments.environment import SemanticID
 from tbp.monty.frameworks.experiments.mode import ExperimentMode
 from tbp.monty.frameworks.models.motor_system_state import (
     AgentState,
@@ -69,7 +71,7 @@ class Observations(Dict[AgentID, AgentObservations]):
     pass
 
 
-class Monty(Snapshotable, metaclass=abc.ABCMeta):
+class Monty(ExperimentMonty, Snapshotable, metaclass=abc.ABCMeta):
     def _matching_step(
         self,
         ctx: RuntimeContext,
@@ -243,30 +245,27 @@ class Monty(Snapshotable, metaclass=abc.ABCMeta):
     ###
 
     @abc.abstractmethod
-    def pre_episode(self) -> None:
-        """Recursively call pre_episode on child classes."""
+    def reset(self) -> None:
         pass
 
     @abc.abstractmethod
-    def post_episode(self):
-        """Recursively call post_episode on child classes."""
+    def fixme_set_ground_truth(
+        self,
+        primary_target: dict[str, Any] | None = None,
+        semantic_id_to_label: dict[SemanticID, str] | None = None,
+    ) -> None:
+        pass
+
+    @abc.abstractmethod
+    def update_ltm(self) -> None:
         pass
 
     @abc.abstractmethod
     def set_experiment_mode(self, mode: ExperimentMode) -> None:
-        """Set the experiment mode.
-
-        Update state variables based on which method (train or evaluate) is being
-        called at the experiment level.
-
-        Args:
-            mode: The experiment mode.
-        """
         pass
 
     @abc.abstractmethod
-    def is_done(self):
-        """Return bool to tell the experiment if we are done with this episode."""
+    def is_done(self) -> bool:
         pass
 
 

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -61,24 +61,30 @@ class MontyForGraphMatching(MontyBase):
 
     # =============== Public Interface Functions ===============
     # ------------------- Main Algorithm -----------------------
-    def pre_episode(self, primary_target, semantic_id_to_label=None) -> None:
-        """Reset values and call sub-pre_episode functions."""
+    def reset(self):
         self._is_done = False
         self.reset_episode_steps()
         self.switch_to_matching_step()
-        self.reset()
-        self.primary_target = primary_target
-        self.semantic_id_to_label = semantic_id_to_label
-
         for lm in self.learning_modules:
             lm.reset_stm()
-            lm.fixme_reset_ground_truth(primary_target)
 
         for sm in self.sensor_modules:
             sm.reset()
 
         self.motor_system.reset()
         self._goals = []
+        pass
+
+    def fixme_set_ground_truth(
+        self,
+        primary_target: dict[str, Any] | None = None,
+        semantic_id_to_label: dict[SemanticID, str] | None = None,
+    ) -> None:
+        self.primary_target = primary_target
+        self.semantic_id_to_label = semantic_id_to_label
+
+        for lm in self.learning_modules:
+            lm.fixme_reset_ground_truth(primary_target)
 
         logger.debug(
             f"Models in memory: {self.learning_modules[0].get_all_known_object_ids()}"
@@ -179,10 +185,6 @@ class MontyForGraphMatching(MontyBase):
         if num_lms_done >= self.min_lms_match:
             logger.info("\n\nMONTY DETECTED MATCH\n\n")
             return True
-
-    def reset(self):
-        """Reset monty status."""
-        pass
 
     # ------------------ Getters & Setters ---------------------
 

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -61,7 +61,7 @@ class MontyForGraphMatching(MontyBase):
 
     # =============== Public Interface Functions ===============
     # ------------------- Main Algorithm -----------------------
-    def reset(self):
+    def reset(self) -> None:
         self._is_done = False
         self.reset_episode_steps()
         self.switch_to_matching_step()
@@ -73,7 +73,6 @@ class MontyForGraphMatching(MontyBase):
 
         self.motor_system.reset()
         self._goals = []
-        pass
 
     def fixme_set_ground_truth(
         self,

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -167,7 +167,7 @@ class MontyBase(Monty):
         ctx: RuntimeContext,
         observations: Observations,
         proprioceptive_state: ProprioceptiveState,
-    ):
+    ) -> None:
         sensor_module_outputs = []
         for sensor_module in self.sensor_modules:
             raw_obs = self.get_observations(

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -10,10 +10,11 @@
 from __future__ import annotations
 
 import logging
-from typing import ClassVar, Sequence
+from typing import Any, ClassVar, Sequence
 
 from tbp.monty.cmp import Goal, Message
 from tbp.monty.frameworks.actions.actions import Action
+from tbp.monty.frameworks.environments.environment import SemanticID
 from tbp.monty.frameworks.experiments.mode import ExperimentMode
 from tbp.monty.frameworks.loggers.exp_logger import BaseMontyLogger, TestLogger
 from tbp.monty.frameworks.models.abstract_monty_classes import (
@@ -377,9 +378,8 @@ class MontyBase(Monty):
         self.step_type = "matching_step"
         for lm in self.learning_modules:
             lm.set_experiment_mode(mode)
-        # for sm in self.sensor_modules: sm.set_experiment_mode() unused & removed
 
-    def pre_episode(self):
+    def reset(self) -> None:
         # TODO: move most (all?) of this logic to Experiment
         self._is_done = False
         self.reset_episode_steps()
@@ -393,7 +393,14 @@ class MontyBase(Monty):
         self.motor_system.reset()
         self._goals = []
 
-    def post_episode(self):
+    def fixme_set_ground_truth(
+        self,
+        primary_target: dict[str, Any] | None = None,
+        semantic_id_to_label: dict[SemanticID, str] | None = None,
+    ) -> None:
+        pass
+
+    def update_ltm(self) -> None:
         # At the end of an episode we ask each learning module
         # to update their long-term memory from their short-term buffer.
         for lm in self.learning_modules:

--- a/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
@@ -70,12 +70,12 @@ class MontyForNoResetEvidenceGraphMatching(MontyForEvidenceGraphMatching):
         # As a workaround, we allow `reset` to run normally once (to complete
         # required initialization), and skip full resets on subsequent calls.
         # TODO: Remove initialization logic from `reset`
-        self.init_reset = False
-        self.init_ground_truth = False
+        self._super_reset_called = False
+        self._super_set_ground_truth_called = False
 
     def reset(self) -> None:
-        if not self.init_reset:
-            self.init_reset = True
+        if not self._super_reset_called:
+            self._super_reset_called = True
             return super().reset()
 
         # reset terminal state
@@ -92,8 +92,8 @@ class MontyForNoResetEvidenceGraphMatching(MontyForEvidenceGraphMatching):
         primary_target: dict[str, Any] | None = None,
         semantic_id_to_label: dict[SemanticID, str] | None = None,
     ) -> None:
-        if not self.init_ground_truth:
-            self.init_ground_truth = True
+        if not self._super_set_ground_truth_called:
+            self._super_set_ground_truth_called = True
             return super().fixme_set_ground_truth(primary_target, semantic_id_to_label)
 
         # keep target up-to-date for logging

--- a/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
@@ -8,9 +8,12 @@
 # https://opensource.org/licenses/MIT.
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 
 from tbp.monty.cmp import Message
+from tbp.monty.frameworks.environments.environment import SemanticID
 from tbp.monty.frameworks.models.evidence_matching.burst_sampling import (
     BurstSamplingHypothesesUpdater,
 )
@@ -49,30 +52,31 @@ class MontyForNoResetEvidenceGraphMatching(MontyForEvidenceGraphMatching):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Track whether `pre_episode` has been called at least once.
+        # Track whether `reset` has been called at least once.
         # There are two separate issues this helps avoid:
         #
         # 1. Some internal variables in SMs and LMs (e.g., `stepwise_targets_list`,
         #    `terminal_state`, `is_exploring`) are not initialized
-        #    in `__init__`, but only inside `pre_episode`. Ideally, these should be
-        #    initialized once in `__init__` and reset in `pre_episode`, but fixing
+        #    in `__init__`, but only inside `reset`. Ideally, these should be
+        #    initialized once in `__init__` and reset in `reset`, but fixing
         #    this would require changes across multiple classes.
         #
         # 2. The order of operations: Graphs are loaded into LMs *after* the Monty
-        #    object is constructed but *before* `pre_episode` is called. Some
+        #    object is constructed but *before* `reset` is called. Some
         #    functions (e.g., in `EvidenceGraphLM`) depend on the graph being loaded to
-        #    compute initial possible matches inside `pre_episode`, and this cannot
+        #    compute initial possible matches inside `reset`, and this cannot
         #    be safely moved into `__init__`.
         #
-        # As a workaround, we allow `pre_episode` to run normally once (to complete
+        # As a workaround, we allow `reset` to run normally once (to complete
         # required initialization), and skip full resets on subsequent calls.
-        # TODO: Remove initialization logic from `pre_episode`
-        self.init_pre_episode = False
+        # TODO: Remove initialization logic from `reset`
+        self.init_reset = False
+        self.init_ground_truth = False
 
-    def pre_episode(self, primary_target, semantic_id_to_label=None) -> None:
-        if not self.init_pre_episode:
-            self.init_pre_episode = True
-            return super().pre_episode(primary_target, semantic_id_to_label)
+    def reset(self) -> None:
+        if not self.init_reset:
+            self.init_reset = True
+            return super().reset()
 
         # reset terminal state
         self._is_done = False
@@ -80,15 +84,24 @@ class MontyForNoResetEvidenceGraphMatching(MontyForEvidenceGraphMatching):
         self.switch_to_matching_step()
         self._reset_terminal_states()
 
+        # reset LMs and SMs buffers to save memory
+        self._reset_modules_buffers()
+
+    def fixme_set_ground_truth(
+        self,
+        primary_target: dict[str, Any] | None = None,
+        semantic_id_to_label: dict[SemanticID, str] | None = None,
+    ) -> None:
+        if not self.init_ground_truth:
+            self.init_ground_truth = True
+            return super().fixme_set_ground_truth(primary_target, semantic_id_to_label)
+
         # keep target up-to-date for logging
         self.primary_target = primary_target
         self.semantic_id_to_label = semantic_id_to_label
         for lm in self.learning_modules:
             lm.primary_target = primary_target["object"]
             lm.primary_target_rotation_quat = primary_target["quat_rotation"]
-
-        # reset LMs and SMs buffers to save memory
-        self._reset_modules_buffers()
 
     def _reset_terminal_states(self):
         for lm in self.learning_modules:

--- a/tests/integration/frameworks/models/graph_learning_test.py
+++ b/tests/integration/frameworks/models/graph_learning_test.py
@@ -953,10 +953,11 @@ class GraphLearningTest(BaseGraphTest):
             for episode_num in range(tm.num_episodes):
                 exp.pre_episode()
                 # Normally the experiment `pre_episode` method would call the model
-                # `pre_episode` method, but it expects to feed data from an environment
+                # `reset` method, but it expects to feed data from an environment
                 # interface to the model, and we aren't using that, so we call it again
                 # with the correct target value.
-                monty.pre_episode(self.placeholder_target)
+                monty.reset()
+                monty.fixme_set_ground_truth(self.placeholder_target)
                 for step in range(tm.num_observations(episode_num)):
                     # Manually run through the internal Monty steps since we aren't
                     # using the data from the environment interface and are instead


### PR DESCRIPTION
The methods of `Monty` are segregated into "Methods that define the algorithm" and "Methods that interact with the experiment". This PR extracts a `RuntimeMonty` Protocol for the former, and an `ExperimentMonty` Protocol for the latter.

This segregation is in preparation for moving Experiment-related logic from Monty into the Experiment.

## Breaking Changes

- `Monty.pre_episode()` is split into `ExperimentMonty.reset()` and `ExperimentMonty.fixme_set_ground_truth()`
- `MontyForGraphMatching` (and its subclasses) use `ExperimentMonty.fixme_set_ground_truth()` to pass additional information into the model
- `Monty.post_episode()` becomes `ExperimentMonty.update_ltm()`
