### PR TITLE
chore: version 0.39.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.38.0"
+__version__ = "0.39.0"


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since 0.38.0.

<img width="2340" height="2030" alt="image" src="https://github.com/user-attachments/assets/d5efcdc4-1d46-438b-8cfb-799fcc61445a" />

## refactor!: change Resolution2D and SensorConfig to dataclasses (#1027)
- The type of `SensorConfig` changed from a TypedDict to a dataclass.
- The type of `Resolution2D` changed from a TypedDict to a dataclass.

## refactor!: split Runtime and Experiment aspects of MotorSystem, et. al. (#1026)
- `MotorSystem.pre_episode()` is renamed to `ExperimentMotorSystem.reset()`
- `MotorPolicySelector.pre_episode()` is renamed to `ExperimentMotorPolicySelector.reset()`
- `MotorPolicy.pre_episode()` is renamed to `ExperimentMotorPolicy.reset()`
- `MotorSystem.motor_only_step` is moved to `ExperimentMotorSystem.motor_only_step`

## refactor!: create MuJoCo version of graph_building_test.py (#1030)
- `MuJoCoSimulator` incorrectly returned RGB data for the "rgba" modality. It now returns data with an alpha component set to 255 (full opaque) since that's the only alpha value a camera can capture. The shape of the data has changed from `(height, width, 3)` to `(height, width, 4)`.