### PR TITLE
test: create MuJoCo version of hierarchy_test.py

### DIFF
--- a/src/tbp/monty/conf/environment/test_mujoco_2lm_dist_transforms.yaml
+++ b/src/tbp/monty/conf/environment/test_mujoco_2lm_dist_transforms.yaml
@@ -1,0 +1,31 @@
+# @package experiment.config.environment
+
+env_init_args:
+  agents:
+    - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+      _partial_: true
+      agent_id: agent_id_0
+      sensor_configs:
+        patch_0:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          zoom: 10.0
+        patch_1:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          zoom: 5.0
+        view_finder:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          zoom: 1.0
+      position:
+        - 0.0
+        - 1.5
+        - 0.2
+env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}

--- a/src/tbp/monty/conf/experiment/test/hierarchy/two_lms_constrained_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/hierarchy/two_lms_constrained_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp50_e3_t3_tot2500
+  - /monty/motor_system_config: naive_scan_10
+  - /monty/learning_module: evidence_2lm
+  - /monty/sensor_module: 2sm_camera_dist
+  - /monty/connectivity: 2lm_2sm
+  - /environment: test_mujoco_2lm_dist_transforms
+  - /env_interface: test_train_2obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor3
+  - /logging: silent_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.pretraining_experiments.MontySupervisedObjectPretrainingExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: all
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/hierarchy/two_lms_eval_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/hierarchy/two_lms_eval_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp50_e3_t3_tot2500
+  - /monty/motor_system_config: naive_scan_10
+  - /monty/learning_module: evidence_2lm
+  - /monty/sensor_module: 2sm_camera_dist
+  - /monty/connectivity: 2lm_2sm
+  - /environment: test_mujoco_2lm_dist_transforms
+  - /env_interface: test_eval_1obj_predefined_p2c
+  - /env_interface/transform: missing_depthto3d_sensor3
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    n_eval_epochs: 2
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/hierarchy/two_lms_heterarchy_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/hierarchy/two_lms_heterarchy_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp30_e3_t3_tot2500
+  - /monty/motor_system_config: naive_scan_10
+  - /monty/learning_module: evidence_2lm_small
+  - /monty/sensor_module: 2sm_camera_dist_d002
+  - /monty/connectivity: 2lm_2sm
+  - /environment: test_mujoco_2lm_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor3
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 35
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 2
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/hierarchy/two_lms_semisupervised_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/hierarchy/two_lms_semisupervised_mujoco.yaml
@@ -1,0 +1,32 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp50_e3_t3_tot2500
+  - /monty/motor_system_config: naive_scan_10
+  - /monty/learning_module: evidence_2lm
+  - /monty/sensor_module: 2sm_camera_dist
+  - /monty/connectivity: 2lm_2sm
+  - /environment: test_mujoco_2lm_dist_transforms
+  - /env_interface: test_train_2obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor3
+  - /logging: silent_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.pretraining_experiments.MontySupervisedObjectPretrainingExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 2
+    seed: 42
+    supervised_lm_ids:
+      - learning_module_1
+    logging:
+      run_name: ""
+    monty_config:
+      monty_args:
+        num_exploratory_steps: 0

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -69,7 +69,7 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
                 # original sensor positions were.
                 sensor_cfgs = agents_config[0].keywords["sensor_configs"]
                 self.sensor_pos = np.array(
-                    sensor["position"] for sensor in sensor_cfgs.values()
+                    [sensor["position"] for sensor in sensor_cfgs.values()]
                 )
         else:
             self.sensor_pos = np.array([0, 0, 0])

--- a/src/tbp/monty/frameworks/utils/logging_utils.py
+++ b/src/tbp/monty/frameworks/utils/logging_utils.py
@@ -18,6 +18,7 @@ from collections import deque
 from itertools import chain
 from pathlib import Path
 from sys import getsizeof
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -75,7 +76,10 @@ def load_stats(
     return train_stats, eval_stats, detailed_stats, lm_models
 
 
-def load_models_from_dir(exp_path, pretrained_dict=None):
+def load_models_from_dir(
+    exp_path: Path | str, pretrained_dict: Path | str | None = None
+) -> dict[str, Any]:
+    # TODO: return value needs a better type
     lm_models = {}
 
     if pretrained_dict is not None:

--- a/tests/mujoco/integration/frameworks/models/hierarchy_test.py
+++ b/tests/mujoco/integration/frameworks/models/hierarchy_test.py
@@ -7,15 +7,6 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-import pytest
-
-from tests import HYDRA_ROOT
-
-pytest.importorskip(
-    "habitat_sim",
-    reason="Habitat Sim optional dependency not installed.",
-)
-
 import shutil
 import tempfile
 import unittest
@@ -28,6 +19,7 @@ from tbp.monty.frameworks.models.object_model import GridObjectModel
 from tbp.monty.frameworks.utils.logging_utils import (
     load_models_from_dir,
 )
+from tests import HYDRA_ROOT
 
 
 class HierarchyTest(unittest.TestCase):
@@ -39,21 +31,21 @@ class HierarchyTest(unittest.TestCase):
             self.two_lms_heterarchy_cfg = hydra.compose(
                 config_name="experiment",
                 overrides=[
-                    "experiment=test/hierarchy/two_lms_heterarchy",
+                    "experiment=test/hierarchy/two_lms_heterarchy_mujoco",
                     f"experiment.config.logging.output_dir={self.output_dir}",
                 ],
             )
             self.two_lms_constrained_cfg = hydra.compose(
                 config_name="experiment",
                 overrides=[
-                    "experiment=test/hierarchy/two_lms_constrained",
+                    "experiment=test/hierarchy/two_lms_constrained_mujoco",
                     f"experiment.config.logging.output_dir={self.output_dir}",
                 ],
             )
             self.two_lms_semisupervised_cfg = hydra.compose(
                 config_name="experiment",
                 overrides=[
-                    "experiment=test/hierarchy/two_lms_semisupervised",
+                    "experiment=test/hierarchy/two_lms_semisupervised_mujoco",
                     f"experiment.config.logging.output_dir={self.output_dir}",
                     f"experiment.config.model_name_or_path={self.model_path}",
                 ],
@@ -61,7 +53,7 @@ class HierarchyTest(unittest.TestCase):
             self.two_lms_eval_cfg = hydra.compose(
                 config_name="experiment",
                 overrides=[
-                    "experiment=test/hierarchy/two_lms_eval",
+                    "experiment=test/hierarchy/two_lms_eval_mujoco",
                     f"experiment.config.logging.output_dir={self.output_dir}",
                     f"experiment.config.model_name_or_path={self.model_path}",
                 ],

--- a/tests/mujoco/integration/frameworks/models/hierarchy_test.py
+++ b/tests/mujoco/integration/frameworks/models/hierarchy_test.py
@@ -6,14 +6,17 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
+from __future__ import annotations
 
 import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 import hydra
 import pandas as pd
+from pandas import DataFrame
 
 from tbp.monty.frameworks.models.object_model import GridObjectModel
 from tbp.monty.frameworks.utils.logging_utils import (
@@ -23,7 +26,7 @@ from tests import HYDRA_ROOT
 
 
 class HierarchyTest(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.output_dir = Path(tempfile.mkdtemp())
         self.model_path = self.output_dir / "pretrained"
 
@@ -59,10 +62,10 @@ class HierarchyTest(unittest.TestCase):
                 ],
             )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         shutil.rmtree(self.output_dir)
 
-    def check_hierarchical_lm_train_results(self, train_stats):
+    def check_hierarchical_lm_train_results(self, train_stats: DataFrame) -> None:
         for episode in range(4):
             self.assertEqual(
                 train_stats["primary_performance"][episode * 2],
@@ -88,7 +91,7 @@ class HierarchyTest(unittest.TestCase):
                 "or have it as its most likely hypothesis.",
             )
 
-    def check_hierarchical_lm_eval_results(self, eval_stats):
+    def check_hierarchical_lm_eval_results(self, eval_stats: DataFrame) -> None:
         for episode in range(3):
             self.assertEqual(
                 eval_stats["primary_performance"][episode * 2],
@@ -99,7 +102,8 @@ class HierarchyTest(unittest.TestCase):
             # input channel). Will not test this here since maybe in the future this
             # will be better and it is not a feature of the system.
 
-    def check_hierarchical_models(self, models):
+    def check_hierarchical_models(self, models: dict[str, Any]) -> None:
+        # TODO: models needs a better type
         for model in ["new_object0", "new_object1"]:
             # Check that graph was extended when recognizing object.
             self.assertLess(
@@ -134,7 +138,7 @@ class HierarchyTest(unittest.TestCase):
             f"after extending the graph but only store {channel_keys}",
         )
 
-    def test_two_lm_heterarchy_experiment(self):
+    def test_two_lm_heterarchy_experiment(self) -> None:
         """Test two LMs stacked on top of each other.
 
         LM0 receives input from SM0
@@ -185,7 +189,7 @@ class HierarchyTest(unittest.TestCase):
         eval_stats = pd.read_csv(output_dir / "eval_stats.csv")
         self.check_hierarchical_lm_eval_results(eval_stats)
 
-    def test_semisupervised_stacked_lms_experiment(self):
+    def test_semisupervised_stacked_lms_experiment(self) -> None:
         """Test two LMs stacked on top of each other with semisupervised learning.
 
         First, both LMs learn with supervision. Then, we remove the supervision for LM_0


### PR DESCRIPTION
This PR is part of a larger effort to migrate integration tests to use MuJoCo instead of Habitat.

There's one substantive change to the tests here, and that's adding "cubeSolid" to the list of objects to one of the checks in the second test. There was a TODO about making it so that it would recognize "cubeSolid" and when I tried it both in the original and in the MuJoCo version, the test passed, so I think we can make the change and remove the TODO.

There's also a bug fix that I didn't catch until this test hit the code path that would trigger it. I was accidentally passing a generator to `np.array` instead of the collection it was supposed to generate. I was under the impression that this would work as originally written, but I might be misremembering something. What ends up happening is we get an `np.array` with a single element that is the unrealized generator, which obviously isn't what we want.