### PR TITLE
test: create MuJoCo version of no_reset_evidence_lm_test.py

### DIFF
--- a/src/tbp/monty/conf/experiment/test/no_reset_evidence_lm/pretraining_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/no_reset_evidence_lm/pretraining_mujoco.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: test_evidence_1lm_fw_p_hsv100_mmd0001_tol_p_pcl11
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: silent_warning_train
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.pretraining_experiments.MontySupervisedObjectPretrainingExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: all
+    logging:
+      output_dir: ${path.expanduser:${oc.env:MONTY_LOGS}/projects/monty_runs/}
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/no_reset_evidence_lm/unsupervised_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/no_reset_evidence_lm/unsupervised_mujoco.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+
+defaults:
+  - /monty: noresetevidencegraph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: test_noresetevidence_1lm
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_eval_1obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_debug_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 30
+    max_eval_steps: 30
+    max_total_steps: 60
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      monty_handlers: []
+      wandb_handlers: []
+      run_name: ""

--- a/tests/mujoco/integration/frameworks/models/no_reset_evidence_lm_test.py
+++ b/tests/mujoco/integration/frameworks/models/no_reset_evidence_lm_test.py
@@ -1,0 +1,126 @@
+# Copyright 2025-2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+import copy
+import shutil
+import tempfile
+from typing import Any
+
+import hydra
+import numpy as np
+import numpy.typing as npt
+
+from tbp.monty.frameworks.experiments.mode import ExperimentMode
+from tests import HYDRA_ROOT
+from tests.unit.resources.unit_test_utils import BaseGraphTest
+
+
+class NoResetEvidenceLMTest(BaseGraphTest):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.output_dir = tempfile.mkdtemp()
+
+        with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
+            self.pretraining_cfg = hydra.compose(
+                config_name="experiment",
+                overrides=[
+                    "experiment=test/no_reset_evidence_lm/pretraining_mujoco",
+                    f"experiment.config.logging.output_dir={self.output_dir}",
+                ],
+            )
+            self.unsupervised_cfg = hydra.compose(
+                config_name="experiment",
+                overrides=[
+                    "experiment=test/no_reset_evidence_lm/unsupervised_mujoco",
+                    f"experiment.config.logging.output_dir={self.output_dir}",
+                ],
+            )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.output_dir)
+
+    def assert_dicts_equal(
+        self,
+        d1: dict[Any, npt.NDArray[np.float64]],
+        d2: dict[Any, npt.NDArray[np.float64]],
+        msg: str,
+    ) -> None:
+        """Asserts that two dictionaries containing NumPy arrays are equal.
+
+        This method checks that the dictionaries have the same keys and that
+        the corresponding NumPy arrays are element-wise equal.
+
+        Args:
+            d1: The first dictionary to compare.
+            d2: The second dictionary to compare.
+            msg: The message to display if the assertion fails.
+        """
+        self.assertEqual(d1.keys(), d2.keys(), msg)
+        for key, d1_val in d1.items():
+            self.assertTrue(np.array_equal(d1_val, d2[key]), msg)
+
+    def test_no_reset_evidence_lm(self) -> None:
+        """Checks that unsupervised LM does not reset the evidence between episodes.
+
+        Note: We use the default `MontyForEvidenceGraphMatching` and `EvidenceGraphLM`
+        to train a Monty Experiment, then transfer the pretrained graphs to an
+        unsupervised Inference Experiment. Disabling the reset logic does not support
+        training at the moment.
+        """
+        train_exp = hydra.utils.instantiate(self.pretraining_cfg.experiment)
+        with train_exp:
+            train_exp.run()
+
+        eval_exp = hydra.utils.instantiate(self.unsupervised_cfg.experiment)
+        with eval_exp:
+            # load the eval experiment with the pretrained models
+            pretrained_models = train_exp.model.learning_modules[0].state_dict()
+            eval_exp.model.learning_modules[0].load_state_dict(pretrained_models)
+
+            eval_exp.experiment_mode = ExperimentMode.EVAL
+            eval_exp.model.set_experiment_mode(eval_exp.experiment_mode)
+            eval_exp.pre_epoch()
+
+            lm = eval_exp.model.learning_modules[0]
+
+            # first episode
+            self.assertEqual(
+                len(lm._hypotheses),
+                0,
+                "evidence dict should be empty before the first episode",
+            )
+            eval_exp.pre_episode()
+            episode_1_steps = eval_exp.run_episode_steps()
+            eval_exp.post_episode(episode_1_steps)
+            post_episode1_evidence = copy.deepcopy(
+                {graph_id: hyp.evidence for graph_id, hyp in lm._hypotheses.items()}
+            )
+            self.assertGreater(
+                len(post_episode1_evidence),
+                0,
+                "evidence dict should now contain evidence values of the first episode",
+            )
+
+            # second episode
+            eval_exp.pre_episode()
+            self.assert_dicts_equal(
+                post_episode1_evidence,
+                {graph_id: hyp.evidence for graph_id, hyp in lm._hypotheses.items()},
+                "evidence dict should not change between episodes",
+            )
+            episode_2_steps = eval_exp.run_episode_steps()
+            eval_exp.post_episode(episode_2_steps)
+            self.assertGreater(
+                len(lm._hypotheses),
+                0,
+                "evidence dict should contain evidence values",
+            )
+            eval_exp.post_epoch()

--- a/tests/mujoco/integration/frameworks/models/no_reset_evidence_lm_test.py
+++ b/tests/mujoco/integration/frameworks/models/no_reset_evidence_lm_test.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import copy
 import shutil
 import tempfile
-from typing import Any
 
 import hydra
 import numpy as np
@@ -49,8 +48,8 @@ class NoResetEvidenceLMTest(BaseGraphTest):
 
     def assert_dicts_equal(
         self,
-        d1: dict[Any, npt.NDArray[np.float64]],
-        d2: dict[Any, npt.NDArray[np.float64]],
+        d1: dict[str, npt.NDArray[np.float64]],
+        d2: dict[str, npt.NDArray[np.float64]],
         msg: str,
     ) -> None:
         """Asserts that two dictionaries containing NumPy arrays are equal.


### PR DESCRIPTION
This PR is part of a larger effort to migrate integration tests to use MuJoCo instead of Habitat.

No substantive changes here. I moved the `tearDown` method to the top of the class because I prefer the setup and teardown code to be adjacent to each other. I also removed some of the redundancy in the test docstring. The original version repeated itself and also described _how_ the code does what it does which is prone to drift when the code changes.