### PR TITLE
Update the readme docs script to normalize titles into slugs to match…

### DIFF
--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -75,14 +75,14 @@ class ReadMe:
         self.version = version
 
     def normalize_title_to_readme_slug(self, title: str) -> str:
-        """Normalize a ReadMe title into the slug format ReadMe generates.
+        # Normalize a ReadMe title into the slug format ReadMe generates.
 
-        ReadMe slugs are generally derived from titles by:
-        - lowercasing
-        - replacing whitespace with hyphens
-        - stripping punctuation/symbols/non-alphanumeric characters
-        - collapsing repeated hyphens
-        """
+        # ReadMe slugs are generally derived from titles by:
+        # - lowercasing
+        # - replacing whitespace with hyphens
+        # - stripping punctuation/symbols/non-alphanumeric characters
+        # - collapsing repeated hyphens
+        
         slug = title.lower()
         slug = re.sub(r"\s+", "-", slug)
         slug = re.sub(r"[^a-z0-9-]", "", slug)
@@ -197,7 +197,7 @@ class ReadMe:
 
     def create_category_if_not_exists(self, slug: str, title: str) -> tuple[str, bool]:
         readme_slug = self.normalize_title_to_readme_slug(title)
-
+        
         # Use the slug ReadMe would generate from the title, rather than the
         # hierarchy.md slug. This prevents case/style mismatches like CMP vs cmp.
         category = get(

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -74,6 +74,22 @@ class ReadMe:
     def __init__(self, version: str):
         self.version = version
 
+    def normalize_title_to_readme_slug(self, title: str) -> str:
+        """Normalize a ReadMe title into the slug format ReadMe generates.
+
+        ReadMe slugs are generally derived from titles by:
+        - lowercasing
+        - replacing whitespace with hyphens
+        - stripping punctuation/symbols/non-alphanumeric characters
+        - collapsing repeated hyphens
+        """
+        slug = title.lower()
+        slug = re.sub(r"\s+", "-", slug)
+        slug = re.sub(r"[^a-z0-9-]", "", slug)
+        slug = re.sub(r"-+", "-", slug)
+        # Strip leading/trailing hyphens that may have resulted from punctuation removal
+        return slug.strip("-")
+
     def get_categories(self) -> list[Any]:
         categories = get(f"{PREFIX}/categories", {"x-readme-version": self.version})
         if not categories:
@@ -180,8 +196,12 @@ class ReadMe:
             )
 
     def create_category_if_not_exists(self, slug: str, title: str) -> tuple[str, bool]:
+        readme_slug = self.normalize_title_to_readme_slug(title)
+
+        # Use the slug ReadMe would generate from the title, rather than the
+        # hierarchy.md slug. This prevents case/style mismatches like CMP vs cmp.
         category = get(
-            f"{PREFIX}/categories/{slug}", {"x-readme-version": self.version}
+            f"{PREFIX}/categories/{readme_slug}", {"x-readme-version": self.version}
         )
         if category is None:
             response = post(
@@ -299,11 +319,18 @@ class ReadMe:
         if "description" in doc:
             create_doc_request["excerpt"] = doc["description"]
 
-        doc_id = self.get_doc_id(doc["slug"])
+        """Find a ReadMe doc by the slug ReadMe would generate from its title.
+
+        This avoids mismatches where hierarchy.md has a different casing or
+        slug style than ReadMe's generated slug.
+        """
+        readme_slug = self.normalize_title_to_readme_slug(doc["title"])
+
+        doc_id = self.get_doc_id(readme_slug)
         created = doc_id is None
         if doc_id:
             if not put(
-                f"{PREFIX}/docs/{doc['slug']}",
+                f"{PREFIX}/docs/{readme_slug}",
                 create_doc_request,
                 {"x-readme-version": self.version},
             ):

--- a/tools/github_readme_sync/upload.py
+++ b/tools/github_readme_sync/upload.py
@@ -33,7 +33,7 @@ def upload(new_hierarchy, file_path: str, rdme: ReadMe):
             f"\n{BLUE}{category['title'].upper()}{GRAY}{created * ' [created]'}{RESET}"
         )
 
-        set_do_not_delete(to_be_deleted, category["slug"])
+        set_do_not_delete(to_be_deleted, category["title"])
 
         # Recursively process the hierarchy of children
         process_children(
@@ -76,7 +76,7 @@ def process_children(
             file_path=f"{file_path}/{path_prefix}{parent['slug']}",
         )
         print_child(path_prefix.count("/"), doc, created)
-        set_do_not_delete(to_be_deleted, child["slug"])
+        set_do_not_delete(to_be_deleted, child["title"])
 
         # If this child has children, call the function recursively
         if child.get("children"):
@@ -91,9 +91,9 @@ def process_children(
             )
 
 
-def set_do_not_delete(to_be_deleted: list, slug: str):
+def set_do_not_delete(to_be_deleted: list, title: str):
     for doc in to_be_deleted:
-        if doc["slug"] == slug:
+        if doc["title"] == title:
             # remove the item from the list
             to_be_deleted.remove(doc)
 


### PR DESCRIPTION
… the way readme automatically creates slugs, to avoid duplicate discrepancy errors we've been getting that have been changing our URLs unexpectedly