### PR TITLE
refactor!: re-create Monty each episode, instead of trying to reset

### DIFF
--- a/src/tbp/monty/experiment/learning_module.py
+++ b/src/tbp/monty/experiment/learning_module.py
@@ -10,6 +10,7 @@
 from typing import Protocol
 
 from tbp.monty.frameworks.experiments.mode import ExperimentMode
+from tbp.monty.memento import Memento
 
 __all__ = [
     "ExperimentLearningModule",
@@ -50,5 +51,17 @@ class ExperimentLearningModule(Protocol):
 
         Args:
             mode: The experiment mode.
+        """
+        ...
+
+    def snapshot_memory(self) -> Memento:
+        """Return a Memento represeting the long-term memory of this Learning Module."""
+        ...
+
+    def restore_memory(self, memento: Memento) -> None:
+        """Restore the long-term memory of this Learning Module from a snapshot.
+
+        Args:
+            memento: The snapshot of long-term memory.
         """
         ...

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -468,12 +468,12 @@ class MontyExperiment:
         if len(self._recreation_state) != len(self.model.learning_modules):
             self._recreation_state = [{} for _ in self.model.learning_modules]
 
-    def _recreation_capture(self) -> None:
+    def _recreation_snapshot(self) -> None:
         if self.recreation_mode:
             self._recreation_lazy_init()
             self.model.update_ltm()
             for idx, lm in enumerate(self.model.learning_modules):
-                memo: Memento = lm.graph_memory.state_dict()
+                memo: Memento = lm.snapshot_memory()
                 self._recreation_state[idx] = memo
         else:
             self.model.update_ltm()
@@ -487,7 +487,7 @@ class MontyExperiment:
                 # lm.reset()
                 memo: Memento = self._recreation_state[idx]
                 if memo:
-                    lm.graph_memory.load_state_dict(memo)
+                    lm.restore_memory(memo)
             # for sm in self.sensor_modules:
             #     sm.reset()
             # self.motor_system.reset()
@@ -584,7 +584,7 @@ class MontyExperiment:
         """
         self.logger_handler.post_episode(self.logger_args)
 
-        self._recreation_capture()
+        self._recreation_snapshot()
 
         if self.experiment_mode is ExperimentMode.TRAIN:
             self.train_episodes += 1

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -483,6 +483,7 @@ class MontyExperiment:
             self._recreation_lazy_init()
             self.model = self.init_model(self.config["monty_config"])
             self.model.set_experiment_mode(self.experiment_mode)
+            self.logger_handler.model = self.model
             for idx, lm in enumerate(self.model.learning_modules):
                 # lm.reset()
                 memo: Memento = self._recreation_state[idx]

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -464,7 +464,7 @@ class MontyExperiment:
     ####
 
     def _recreation_lazy_init(self) -> None:
-        assert(self.recreation_mode)
+        assert self.recreation_mode
         if len(self._recreation_state) != len(self.model.learning_modules):
             self._recreation_state = [{} for _ in self.model.learning_modules]
 
@@ -472,9 +472,9 @@ class MontyExperiment:
         if self.recreation_mode:
             self._recreation_lazy_init()
             self.model.update_ltm()
-            for (id, lm) in enumerate(self.model.learning_modules):
+            for idx, lm in enumerate(self.model.learning_modules):
                 memo: Memento = lm.graph_memory.state_dict()
-                self._recreation_state[id] = memo
+                self._recreation_state[idx] = memo
         else:
             self.model.update_ltm()
 
@@ -483,9 +483,9 @@ class MontyExperiment:
             self._recreation_lazy_init()
             self.model = self.init_model(self.config["monty_config"])
             self.model.set_experiment_mode(self.experiment_mode)
-            for (id, lm) in enumerate(self.model.learning_modules):
+            for idx, lm in enumerate(self.model.learning_modules):
                 # lm.reset()
-                memo: Memento = self._recreation_state[id]
+                memo: Memento = self._recreation_state[idx]
                 if memo:
                     lm.graph_memory.load_state_dict(memo)
             # for sm in self.sensor_modules:

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -482,6 +482,7 @@ class MontyExperiment:
         if self.recreation_mode:
             self._recreation_lazy_init()
             self.model = self.init_model(self.config["monty_config"])
+            self.model.set_experiment_mode(self.experiment_mode)
             for (id, lm) in enumerate(self.model.learning_modules):
                 # lm.reset()
                 memo: Memento = self._recreation_state[id]
@@ -491,6 +492,7 @@ class MontyExperiment:
             #     sm.reset()
             # self.motor_system.reset()
         else:
+            self.model.set_experiment_mode(self.experiment_mode)
             self.model.reset()
 
     def pre_step(self, _step, _observation):
@@ -656,7 +658,6 @@ class MontyExperiment:
         logger.info(f"running {self.n_train_epochs} train epochs")
         self.experiment_mode = ExperimentMode.TRAIN
         self.logger_handler.pre_train(self.logger_args)
-        self.model.set_experiment_mode(self.experiment_mode)
         for _ in range(self.n_train_epochs):
             self.run_epoch()
         self.logger_handler.post_train(self.logger_args)
@@ -668,7 +669,6 @@ class MontyExperiment:
         # TODO: check that number of eval epochs is at least as many as length
         # of environment interface number of rotations
         self.logger_handler.pre_eval(self.logger_args)
-        self.model.set_experiment_mode(self.experiment_mode)
         for _ in range(self.n_eval_epochs):
             self.run_epoch()
         self.logger_handler.post_eval(self.logger_args)

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -43,6 +43,7 @@ from tbp.monty.frameworks.utils.dataclass_utils import (
     get_subset_of_args,
 )
 from tbp.monty.frameworks.utils.live_plotter import LivePlotter
+from tbp.monty.memento import Memento
 
 __all__ = ["MontyExperiment"]
 
@@ -66,6 +67,10 @@ class MontyExperiment:
             config: config specifying variables of the experiment.
         """
         self.config = config
+
+        # Feature flag for "recreation" episode/epoch strategy.
+        self.recreation_mode: bool = True
+        self._recreation_state: list[Memento] = []
 
         self.rng = np.random.RandomState(config["seed"])
 
@@ -458,6 +463,36 @@ class MontyExperiment:
     # Methods for running the experiment
     ####
 
+    def _recreation_lazy_init(self) -> None:
+        assert(self.recreation_mode)
+        if len(self._recreation_state) != len(self.model.learning_modules):
+            self._recreation_state = [{} for _ in self.model.learning_modules]
+
+    def _recreation_capture(self) -> None:
+        if self.recreation_mode:
+            self._recreation_lazy_init()
+            self.model.update_ltm()
+            for (id, lm) in enumerate(self.model.learning_modules):
+                memo: Memento = lm.graph_memory.state_dict()
+                self._recreation_state[id] = memo
+        else:
+            self.model.update_ltm()
+
+    def _recreation_restore(self) -> None:
+        if self.recreation_mode:
+            self._recreation_lazy_init()
+            self.model = self.init_model(self.config["monty_config"])
+            for (id, lm) in enumerate(self.model.learning_modules):
+                # lm.reset()
+                memo: Memento = self._recreation_state[id]
+                if memo:
+                    lm.graph_memory.load_state_dict(memo)
+            # for sm in self.sensor_modules:
+            #     sm.reset()
+            # self.motor_system.reset()
+        else:
+            self.model.reset()
+
     def pre_step(self, _step, _observation):
         """Hook for anything you want to do before a step."""
         self.logger_handler.pre_step(self.logger_args)
@@ -519,7 +554,8 @@ class MontyExperiment:
 
         self.reset_episode_rng()
 
-        self.model.reset()
+        self._recreation_restore()
+
         self.env_interface.pre_episode(self.rng)
 
         self.max_steps = self.max_train_steps
@@ -545,7 +581,8 @@ class MontyExperiment:
         get 'confused'/'FP'.
         """
         self.logger_handler.post_episode(self.logger_args)
-        self.model.update_ltm()
+
+        self._recreation_capture()
 
         if self.experiment_mode is ExperimentMode.TRAIN:
             self.train_episodes += 1

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -65,7 +65,8 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
 
         self.reset_episode_rng()
 
-        self.model.reset()
+        self._recreation_restore()
+
         # TODO, eventually it would be better to pass
         # self.env_interface.semantic_id_to_label via an "Observation" object when this
         # is eventually implemented, such that we can ensure this information is never

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -201,7 +201,7 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
 
         self.reset_episode_rng()
 
-        self.model.reset()
+        self._recreation_restore()
         self.model.fixme_set_ground_truth(self.env_interface.primary_target)
         self.env_interface.pre_episode(self.rng)
 

--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -380,6 +380,14 @@ class LearningModule(
     def set_experiment_mode(self, mode: ExperimentMode) -> None:
         pass
 
+    @abc.abstractmethod
+    def snapshot_memory(self) -> Memento:
+        pass
+
+    @abc.abstractmethod
+    def restore_memory(self, memento: Memento) -> None:
+        pass
+
     ###
     # Methods that define the algorithm
     ###

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -928,15 +928,21 @@ class GraphLM(LearningModule):
             dict(lm_processed_steps=lm_processed), update_time=False
         )
 
+    def snapshot_memory(self) -> Memento:
+        return self.graph_memory.state_dict()
+
+    def restore_memory(self, memento: Memento) -> None:
+        self.graph_memory.load_state_dict(memento)
+
     def state_dict(self) -> Memento:
         return dict(
-            graph_memory=self.graph_memory.state_dict(),
+            graph_memory=self.snapshot_memory(),
             target_to_graph_id=self.target_to_graph_id,
             graph_id_to_target=self.graph_id_to_target,
         )
 
     def load_state_dict(self, memento: Memento) -> None:
-        self.graph_memory.load_state_dict(memento["graph_memory"])
+        self.restore_memory(memento["graph_memory"])
         self.target_to_graph_id = memento["target_to_graph_id"]
         self.graph_id_to_target = memento["graph_id_to_target"]
 

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -555,8 +555,11 @@ class GraphLM(LearningModule):
         self.target_to_graph_id = {}
         self.graph_id_to_target = {}
         self.primary_target = None
+        self.possible_matches = {}
+        self.possible_paths = {}
         self.detected_object = None
         self.detected_pose = [None for _ in range(7)]
+        self.detected_rotation_r = None
         # Will always be set during experiment setup, just setting here for unit tests
         self.has_detailed_logger = False
         self.symmetry_evidence = 0

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -139,6 +139,7 @@ class MontyBase(Monty):
                 "sensor_module id; no more, no less!"
             )
 
+        self._is_done = False
         self._actions: list[Action] = []
         self._goals: list[Goal] = []
 

--- a/src/tbp/monty/frameworks/models/sensor_modules.py
+++ b/src/tbp/monty/frameworks/models/sensor_modules.py
@@ -404,11 +404,12 @@ class Probe(SensorModule):
         """
         super().__init__()
 
-        self.is_exploring = False
         self.sensor_module_id = sensor_module_id
         self.state: SensorState | None = None
         self.save_raw_obs = save_raw_obs
 
+        # TODO: Goes away once experiment/telemetry code is extracted
+        self.is_exploring = False
         self._snapshot_telemetry = SnapshotTelemetry()
 
     def state_dict(self) -> Memento:
@@ -611,6 +612,8 @@ class CameraSM(SensorModule):
         # TODO: give more descriptive & distinct names
         self.sensor_module_id = sensor_module_id
         self.save_raw_obs = save_raw_obs
+        # TODO: Goes away once experiment code is extracted
+        self.is_exploring = False
 
     def reset(self) -> None:
         self._snapshot_telemetry.reset()

--- a/tests/unit/frameworks/models/fakes/learning_modules.py
+++ b/tests/unit/frameworks/models/fakes/learning_modules.py
@@ -44,6 +44,12 @@ class FakeLearningModule(LearningModule):
     def send_out_vote(self) -> Any:
         pass
 
+    def snapshot_memory(self) -> Memento:
+        return {}
+
+    def restore_memory(self, memento: Memento) -> None:
+        pass
+
     def state_dict(self) -> Memento:
         return dict(test_attr_1=self.test_attr_1, test_attr_2=self.test_attr_2)
 


### PR DESCRIPTION
Re-create Monty model between episodes, with snapshot and restore of long-term memory in LMs and explicit Experiment-related state management.

## Breaking Changes

- Require LM's to implement `snapshot_memory()` and `restore_memory()`
- _TBD_

## Benchmarks

_TBD_
