### PR TITLE
test: create MuJoCo version of sensor_module_test.py

### DIFF
--- a/src/tbp/monty/conf/experiment/test/sensor_module/base_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/sensor_module/base_mujoco.yaml
@@ -1,0 +1,31 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: displacement_1lm
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined_perobj
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      monty_handlers:
+        - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.BasicCSVStatsHandler}
+        - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.DetailedJSONHandler}
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/sensor_module/feature_change_sensor_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/sensor_module/feature_change_sensor_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp100_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: displacement_1lm
+  - /monty/sensor_module: camera_dist
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined_perobj
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 1
+    n_eval_epochs: 1
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/src/tbp/monty/conf/experiment/test/sensor_module/sensor_feature_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/sensor_module/sensor_feature_mujoco.yaml
@@ -1,0 +1,28 @@
+# @package _global_
+
+defaults:
+  - /monty: graph_exp20_e3_t3_tot2500
+  - /monty/motor_system_config: informed_random_walk_5
+  - /monty/learning_module: displacement_1lm
+  - /monty/sensor_module: camera_dist_wo_posefullydefined
+  - /monty/connectivity: 1lm_1sm
+  - /environment: test_mujoco_dist_transforms
+  - /env_interface: test_train_2obj_predefined_eval_1obj_predefined_perobj
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: detailed_info_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    n_eval_epochs: 3
+    model_name_or_path: ''
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    logging:
+      run_name: ""

--- a/tests/mujoco/integration/frameworks/models/sensor_module_test.py
+++ b/tests/mujoco/integration/frameworks/models/sensor_module_test.py
@@ -1,0 +1,103 @@
+# Copyright 2025-2026 Thousand Brains Project
+# Copyright 2022-2024 Numenta Inc.
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+import shutil
+import tempfile
+import unittest
+
+import hydra
+
+from tbp.monty.context import RuntimeContext
+from tbp.monty.frameworks.actions.actions import Action
+from tbp.monty.frameworks.experiments.mode import ExperimentMode
+from tests import HYDRA_ROOT
+
+
+class SensorModuleTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.output_dir = tempfile.mkdtemp()
+
+        with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
+            self.base_cfg = hydra.compose(
+                config_name="experiment",
+                overrides=[
+                    "experiment=test/sensor_module/base_mujoco",
+                    f"experiment.config.logging.output_dir={self.output_dir}",
+                ],
+            )
+            self.sensor_feature_cfg = hydra.compose(
+                config_name="experiment",
+                overrides=[
+                    "experiment=test/sensor_module/sensor_feature_mujoco",
+                    f"experiment.config.logging.output_dir={self.output_dir}",
+                ],
+            )
+            self.feature_change_sensor_cfg = hydra.compose(
+                config_name="experiment",
+                overrides=[
+                    "experiment=test/sensor_module/feature_change_sensor_mujoco",
+                    f"experiment.config.logging.output_dir={self.output_dir}",
+                ],
+            )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.output_dir)
+
+    def test_can_set_up(self) -> None:
+        exp = hydra.utils.instantiate(self.base_cfg.experiment)
+        with exp:
+            exp.experiment_mode = ExperimentMode.TRAIN
+            exp.model.set_experiment_mode(exp.experiment_mode)
+            exp.pre_epoch()
+            exp.pre_episode()
+            ctx = RuntimeContext(rng=exp.rng)
+            actions: list[Action] = []
+            for _ in range(2):
+                observations, proprioceptive_state = exp.env_interface.step(actions)
+                actions = exp.model.step(ctx, observations, proprioceptive_state)
+
+    def test_features_in_sensor(self) -> None:
+        """Check that correct features are returned by sensor module."""
+        exp = hydra.utils.instantiate(self.sensor_feature_cfg.experiment)
+        with exp:
+            exp.experiment_mode = ExperimentMode.TRAIN
+            exp.model.set_experiment_mode(exp.experiment_mode)
+            exp.pre_epoch()
+            exp.pre_episode()
+            ctx = RuntimeContext(rng=exp.rng)
+            observations, proprioceptive_state = exp.env_interface.step([])
+            exp.model.aggregate_sensory_inputs(ctx, observations, proprioceptive_state)
+
+            # Dig the features list out of the hydra config
+            config = self.sensor_feature_cfg.experiment.config
+            sensor_modules = config.monty_config.sensor_modules
+            tested_features = sensor_modules.sensor_module_0.features
+            for feature in tested_features:
+                if feature in ["pose_vectors", "pose_fully_defined", "on_object"]:
+                    self.assertIn(
+                        feature,
+                        exp.model.sensor_module_outputs[
+                            0
+                        ].morphological_features.keys(),
+                        f"{feature} not returned by SM",
+                    )
+                else:
+                    self.assertIn(
+                        feature,
+                        exp.model.sensor_module_outputs[
+                            0
+                        ].non_morphological_features.keys(),
+                        f"{feature} not returned by SM",
+                    )
+
+    def test_feature_change_sm(self):
+        exp = hydra.utils.instantiate(self.feature_change_sensor_cfg.experiment)
+        with exp:
+            exp.run()
+            # TODO: test that only new features are given to LM


### PR DESCRIPTION
This PR is part of a larger effort to migrate integration tests to use MuJoCo instead of Habitat.

The only real change here outside of which configs the tests load is replacing the `while` loop with a simpler `for` loop in `test_can_set_up`.

That said, I'm not sure that test is doing anything useful, and the same goes for `test_feature_change_sm`. In the latter case, it's an unfinished test. These both take some non-zero amount of time to run and don't really test any results of the experiments they run.