### PR TITLE
chore: Future work widget updates

### DIFF
--- a/docs/contributing/documentation/future-work-widget-metadata.md
+++ b/docs/contributing/documentation/future-work-widget-metadata.md
@@ -108,11 +108,3 @@ Is the work completed, or is it in progress? [Edit future-work-status.md](https:
 > **evergreen** refers to tasks that benefit from continual work and input. For example, updates to our documentation or designing new testbeds or demos for Monty. Most evergreen tasks are not listed in the future work table as they aren't large, self-contained chunks of work (see our [ways to contribute](../../contributing/why-contribute.md) page for more ways to contribute). However, some are significant projects of their own so we want to recognize people who are working on those and provide guidance in the task descriptions.
 > 
 > **completed** marks tasks that are done. We keep those in our docs for future reference and to acknowledge those that have contributed to it.
-
-# Tags
-
-Tags is a comma separated list of keywords, useful for filtering the future work items. [Edit future-work-tags.md](https://github.com/thousandbrainsproject/tbp.monty/edit/main/docs/snippets/future-work-tags.md).
-
-> [!NOTE] Tags are currently not used.
-
-!snippet[../../snippets/future-work-tags.md]

--- a/docs/future-work/project-roadmap.md
+++ b/docs/future-work/project-roadmap.md
@@ -14,9 +14,9 @@ Click on the name to view the detail page for that task.  Click on the any of th
 [block:embed]
 {
   "html": false,
-  "url": "https://futureworkwidget.thousandbrains.ai/index.html?columns=title,estimated-scope,status,improved-metric,skills",
+  "url": "https://futureworkwidget.thousandbrains.ai/index.html?columns=title,status,estimated-scope,output-type,skills,improved-metric,rfc",
   "provider": "futureworkwidget.thousandbrains.ai",
-  "href": "https://futureworkwidget.thousandbrains.ai/index.html?columns=title,estimated-scope,status,improved-metric,skills,",
+  "href": "https://futureworkwidget.thousandbrains.ai/index.html?columns=title,status,estimated-scope,output-type,skills,improved-metric,rfc,",
   "typeOfEmbed": "iframe",
   "height": "800px",
   "iframe": true

--- a/tools/future_work_widget/README.md
+++ b/tools/future_work_widget/README.md
@@ -66,12 +66,11 @@ Controls which columns are displayed in the table and in what order.
 - `output-type` - Type of output expected
 - `rfc` - Related RFC link or reference
 - `status` - Current status with contributor avatars
-- `tags` - Categorization tags
 - `skills` - Required skills for the work
 
 **Examples:**
 - Show only title and status: `?columns=title,status`
-- Show title, tags, and skills: `?columns=title,tags,skills`
+- Show title and skills: `?columns=title,skills`
 - Show all columns (default): No parameter needed
 
 **Note:** Column names are case-insensitive and whitespace around commas is ignored.

--- a/tools/future_work_widget/app/css/future-work-widget.css
+++ b/tools/future_work_widget/app/css/future-work-widget.css
@@ -34,14 +34,70 @@ body {
 }
 
 .badge-status {
-  padding: 2px 4px;
-  border-radius: 4px;
   margin-bottom: 2px;
-  font-size: 0.7rem;
-  display: inline-block;
-  background-color: #ffffff;
-  color: #666;
-  border: 1px solid #999;
+}
+
+.badge.badge-status-open {
+  background-color: #cce5ff;
+  color: #004085;
+}
+
+.badge.badge-status-open:hover {
+  background-color: #b8daff;
+}
+
+.badge.badge-status-scoping {
+  background-color: #9bd4f5;
+  color: #004a70;
+}
+
+.badge.badge-status-scoping:hover {
+  background-color: #7ec8f0;
+}
+
+.badge.badge-status-scoped {
+  background-color: #00a0df;
+  color: #ffffff;
+}
+
+.badge.badge-status-scoped:hover {
+  background-color: #0088c0;
+}
+
+.badge.badge-status-in-progress {
+  background-color: #2f2b5c;
+  color: #ffffff;
+}
+
+.badge.badge-status-in-progress:hover {
+  background-color: #1f1b3c;
+}
+
+.badge.badge-status-paused {
+  background-color: #e8d5f5;
+  color: #5a3d7a;
+}
+
+.badge.badge-status-paused:hover {
+  background-color: #d9c0ed;
+}
+
+.badge.badge-status-completed {
+  background-color: #d4edda;
+  color: #155724;
+}
+
+.badge.badge-status-completed:hover {
+  background-color: #c3e6cb;
+}
+
+.badge.badge-status-evergreen {
+  background-color: #7c3aed;
+  color: #ffffff;
+}
+
+.badge.badge-status-evergreen:hover {
+  background-color: #6d28d9;
 }
 
 .badge-size-small {

--- a/tools/future_work_widget/app/css/future-work-widget.css
+++ b/tools/future_work_widget/app/css/future-work-widget.css
@@ -255,8 +255,9 @@ body {
 
 .tabulator-cell.wrap-text .badge,
 .tabulator-cell.wrap-text .badge-skills {
-  display: inline-block;
-  margin: 2px;
+  display: block;
+  margin: 2px 0;
+  width: fit-content;
 }
 
 .tabulator-cell {

--- a/tools/future_work_widget/app/css/future-work-widget.css
+++ b/tools/future_work_widget/app/css/future-work-widget.css
@@ -92,12 +92,12 @@ body {
 }
 
 .badge.badge-status-evergreen {
-  background-color: #7c3aed;
+  background-color: #004085;
   color: #ffffff;
 }
 
 .badge.badge-status-evergreen:hover {
-  background-color: #6d28d9;
+  background-color: #003566;
 }
 
 .badge-size-small {

--- a/tools/future_work_widget/app/js/future-work-widget.js
+++ b/tools/future_work_widget/app/js/future-work-widget.js
@@ -156,13 +156,13 @@ const TableConfig = {
 
   getAllColumns() {
     return [
-      { title: 'Title', field: 'title', formatter: ColumnFormatters.formatTitleWithLinksColumn, width: 200, cssClass: 'wrap-text', variableHeight: true },
-      { title: 'Scope', field: 'estimated-scope', formatter: ColumnFormatters.formatSizeColumn },
-      { title: 'Metric', field: 'improved-metric', formatter: ColumnFormatters.formatBadgeColumn, maxWidth: 200, cssClass: 'wrap-text' },
-      { title: 'Output Type', field: 'output-type', formatter: ColumnFormatters.formatBadgeColumn },
-      { title: 'RFC', field: 'rfc', formatter: ColumnFormatters.formatRfcColumn },
-      { title: 'Status', field: 'status', formatter: ColumnFormatters.formatStatusColumn },
-      { title: 'Skills', field: 'skills', formatter: ColumnFormatters.formatSkillsColumn, widthGrow: 2, cssClass: 'wrap-text' }
+      { title: 'Topic', field: 'title', formatter: ColumnFormatters.formatTitleWithLinksColumn, width: 200, cssClass: 'wrap-text', variableHeight: true },
+      { title: 'Scope', field: 'estimated-scope', formatter: ColumnFormatters.formatSizeColumn, maxWidth: 80 },
+      { title: 'Metric', field: 'improved-metric', formatter: ColumnFormatters.formatBadgeColumn, maxWidth: 100, cssClass: 'wrap-text', variableHeight: true },
+      { title: 'Output', field: 'output-type', formatter: ColumnFormatters.formatBadgeColumn, maxWidth: 100, cssClass: 'wrap-text', variableHeight: true },
+      { title: 'RFC', field: 'rfc', formatter: ColumnFormatters.formatRfcColumn, maxWidth: 80 },
+      { title: 'Status', field: 'status', formatter: ColumnFormatters.formatStatusColumn, maxWidth: 100, cssClass: 'wrap-text', variableHeight: true },
+      { title: 'Skills', field: 'skills', formatter: ColumnFormatters.formatSkillsColumn, maxWidth: 120, cssClass: 'wrap-text', variableHeight: true }
     ];
   },
 
@@ -218,7 +218,7 @@ const FutureWorkWidget = {
   createTable(data) {
     return new Tabulator('#table', {
       data: data,
-      layout: 'fitDataStretch',
+      layout: 'fitData',
       columns: TableConfig.getDisplayColumns(),
       groupBy: 'path2'
     });

--- a/tools/future_work_widget/app/js/future-work-widget.js
+++ b/tools/future_work_widget/app/js/future-work-widget.js
@@ -78,7 +78,7 @@ const ColumnFormatters = {
     const url = urlPrefix ? `${urlPrefix}${value}` : value;
     return `<a href="${url}" target="_blank" rel="noopener noreferrer" title="${escapeHtml(url)}"><i class="${icon}"></i></a>`;
   },
-  formatTagsColumn: (cell) => ColumnFormatters.formatArrayOrStringColumn(cell.getValue(), BADGE_CLASS),
+  formatBadgeColumn: (cell) => ColumnFormatters.formatArrayOrStringColumn(cell.getValue(), BADGE_CLASS),
   formatSkillsColumn: (cell) => ColumnFormatters.formatArrayOrStringColumn(cell.getValue(), BADGE_SKILLS_CLASS),
   formatSizeColumn(cell) {
     const value = (cell.getValue() || '').trim().toLowerCase();
@@ -157,11 +157,10 @@ const TableConfig = {
     return [
       { title: 'Title', field: 'title', formatter: ColumnFormatters.formatTitleWithLinksColumn, width: 200, cssClass: 'wrap-text', variableHeight: true },
       { title: 'Scope', field: 'estimated-scope', formatter: ColumnFormatters.formatSizeColumn },
-      { title: 'Metric', field: 'improved-metric', formatter: ColumnFormatters.formatTagsColumn, maxWidth: 200, cssClass: 'wrap-text' },
-      { title: 'Output Type', field: 'output-type', formatter: ColumnFormatters.formatTagsColumn },
+      { title: 'Metric', field: 'improved-metric', formatter: ColumnFormatters.formatBadgeColumn, maxWidth: 200, cssClass: 'wrap-text' },
+      { title: 'Output Type', field: 'output-type', formatter: ColumnFormatters.formatBadgeColumn },
       { title: 'RFC', field: 'rfc', formatter: ColumnFormatters.formatRfcColumn },
       { title: 'Status', field: 'status', formatter: ColumnFormatters.formatStatusColumn },
-      { title: 'Tags', field: 'tags', formatter: ColumnFormatters.formatTagsColumn, widthGrow: 2, cssClass: 'wrap-text' },
       { title: 'Skills', field: 'skills', formatter: ColumnFormatters.formatSkillsColumn, widthGrow: 2, cssClass: 'wrap-text' }
     ];
   },
@@ -250,7 +249,7 @@ const FutureWorkWidget = {
         }
 
         const searchableText = [
-          data.title, data.tags, data.skills, data.status,
+          data.title, data.skills, data.status,
           data.contributor, data['estimated-scope'], data['improved-metric'],
           data['output-type'], data.rfc, data.link, data.path2
         ]

--- a/tools/future_work_widget/app/js/future-work-widget.js
+++ b/tools/future_work_widget/app/js/future-work-widget.js
@@ -110,11 +110,12 @@ const ColumnFormatters = {
   },
   formatStatusColumn(cell) {
     const rowData = cell.getRow().getData();
-    const status = cell.getValue() || '';
+    const status = (cell.getValue() || '').trim();
     const contributor = rowData.contributor || '';
 
+    const normalizedStatus = status.toLowerCase();
     const statusText = status
-      ? `<span class="${BADGE_STATUS_CLASS}">${escapeHtml(status)}</span>`
+      ? `<span class="badge ${BADGE_STATUS_CLASS} ${BADGE_STATUS_CLASS}-${escapeHtml(normalizedStatus)}" data-search-value="${escapeHtml(status)}" style="cursor: pointer;">${escapeHtml(status)}</span>`
       : '';
 
     if (!contributor) return statusText;

--- a/tools/future_work_widget/tests/build_test.py
+++ b/tools/future_work_widget/tests/build_test.py
@@ -140,14 +140,6 @@ class TestBuild(unittest.TestCase):
         """Test validation and transformation of fields including arrays and URLs."""
         transformation_cases = [
             {
-                "name": "tags_transformation",
-                "snippet_file": "future-work-tags.md",
-                "snippet_content": "`accuracy` `pose` `learning` `multiobj`",
-                "field_name": "tags",
-                "input_value": "accuracy,learning",
-                "expected_result": ["accuracy", "learning"],
-            },
-            {
                 "name": "output_type_transformation",
                 "snippet_file": "future-work-output-type.md",
                 "snippet_content": "`documentation` `website` `tutorial`",
@@ -224,15 +216,15 @@ class TestBuild(unittest.TestCase):
     def test_json_output_validation_errors(self):
         """Test JSON output mode with validation errors."""
         snippets_dir = self._create_snippets(
-            {"future-work-tags.md": "`accuracy` `pose` `learning`"}
+            {"future-work-skills.md": "`python` `github-actions` `javascript`"}
         )
 
         input_data = [
             self._create_future_work_item(
                 path="docs/future-work/test-item.md",
                 path2="test-item",
-                title="Test item with invalid tags",
-                tags="invalid-tag,accuracy",
+                title="Test item with invalid skills",
+                skills="invalid-skill,python",
             )
         ]
 
@@ -249,10 +241,10 @@ class TestBuild(unittest.TestCase):
         self.assertEqual(len(result.errors), 1)
 
         error = result.errors[0]
-        self.assertIn("Invalid tags value 'invalid-tag'", error.message)
+        self.assertIn("Invalid skills value 'invalid-skill'", error.message)
         self.assertEqual(error.file, "docs/future-work/test-item.md")
         self.assertEqual(error.line, 1)
-        self.assertEqual(error.field, "tags")
+        self.assertEqual(error.field, "skills")
         self.assertEqual(error.level, "error")
         self.assertEqual(error.annotation_level, "failure")
         self.assertIn("test-item.md", error.title)
@@ -260,14 +252,14 @@ class TestBuild(unittest.TestCase):
     def test_json_output_too_many_items_error(self):
         """Test JSON output mode with too many comma-separated items."""
         max_items = 10
-        too_many_tags = ",".join([f"tag{i}" for i in range(max_items + 1)])
+        too_many_skills = ",".join([f"skill{i}" for i in range(max_items + 1)])
 
         input_data = [
             self._create_future_work_item(
                 path="docs/future-work/test-limits.md",
                 path2="test-limits",
-                title="Test item with too many tags",
-                tags=too_many_tags,
+                title="Test item with too many skills",
+                skills=too_many_skills,
             )
         ]
 
@@ -289,7 +281,7 @@ class TestBuild(unittest.TestCase):
         self.assertIn(str(max_items), error.message)
         self.assertEqual(error.file, "docs/future-work/test-limits.md")
         self.assertEqual(error.line, 1)
-        self.assertEqual(error.field, "tags")
+        self.assertEqual(error.field, "skills")
         self.assertEqual(error.level, "error")
         self.assertEqual(error.annotation_level, "failure")
         self.assertIn("test-limits.md", error.title)
@@ -324,15 +316,15 @@ class TestBuild(unittest.TestCase):
                 ],
             },
             {
-                "name": "tags_validation",
-                "snippet_file": "future-work-tags.md",
-                "snippet_content": "`accuracy` `pose` `learning` `multiobj`",
-                "field_name": "tags",
-                "valid_value": "accuracy,learning",
-                "invalid_value": "accuracy,invalid-tag,learning",
+                "name": "skills_validation",
+                "snippet_file": "future-work-skills.md",
+                "snippet_content": "`python` `github-actions` `javascript`",
+                "field_name": "skills",
+                "valid_value": "python,javascript",
+                "invalid_value": "python,invalid-skill,javascript",
                 "expected_error_fragments": [
-                    "Invalid tags value 'invalid-tag'",
-                    "accuracy, learning, multiobj, pose",
+                    "Invalid skills value 'invalid-skill'",
+                    "github-actions, javascript, python",
                 ],
             },
             {

--- a/tools/future_work_widget/tests/validator_test.py
+++ b/tools/future_work_widget/tests/validator_test.py
@@ -34,11 +34,6 @@ class TestLoadAllowedValues(unittest.TestCase):
         snippets_dir = self.temp_path / "snippets"
         snippets_dir.mkdir()
 
-        expected_tags = ["accuracy", "pose", "learning", "multiobj"]
-        tags_file = snippets_dir / "future-work-tags.md"
-        with tags_file.open("w", encoding="utf-8") as f:
-            f.write(" ".join(f"`{tag}`" for tag in expected_tags))
-
         expected_skills = ["python", "github-actions", "JS", "HTML"]
         skills_file = snippets_dir / "future-work-skills.md"
         with skills_file.open("w", encoding="utf-8") as f:
@@ -46,9 +41,7 @@ class TestLoadAllowedValues(unittest.TestCase):
 
         allowed_values = load_allowed_values(snippets_dir)
 
-        self.assertIn("tags", allowed_values)
         self.assertIn("skills", allowed_values)
-        self.assertEqual(sorted(allowed_values["tags"]), sorted(expected_tags))
         self.assertEqual(sorted(allowed_values["skills"]), sorted(expected_skills))
 
     def test_missing_validation_files_graceful(self):
@@ -71,7 +64,6 @@ class TestFutureWorkRecord(unittest.TestCase):
             "path1": "future-work",
             "path2": "test-item",
             "title": "Test item",
-            "tags": "accuracy,learning",
             "skills": "python,javascript",
             "contributor": "alice,bob",
             "output-type": "documentation,website",
@@ -81,7 +73,6 @@ class TestFutureWorkRecord(unittest.TestCase):
         validated = FutureWorkRecord.model_validate(record)
         self.assertEqual(validated.path1, "future-work")
         self.assertEqual(validated.path2, "test-item")
-        self.assertEqual(validated.tags, ["accuracy", "learning"])
         self.assertEqual(validated.skills, ["python", "javascript"])
         self.assertEqual(validated.contributor, ["alice", "bob"])
         self.assertEqual(validated.output_type, ["documentation", "website"])
@@ -104,14 +95,14 @@ class TestFutureWorkRecord(unittest.TestCase):
 
     def test_comma_separated_field_limits(self):
         max_items = MAX_COMMA_SEPARATED_ITEMS
-        too_many_tags = ",".join([f"tag{i}" for i in range(max_items + 1)])
+        too_many_skills = ",".join([f"skill{i}" for i in range(max_items + 1)])
 
         record = {
             "path": "future-work/test-item.md",
             "path1": "future-work",
             "path2": "test-item",
             "title": "Test item",
-            "tags": too_many_tags,
+            "skills": too_many_skills,
         }
 
         with self.assertRaises(ValidationError) as cm:
@@ -162,15 +153,15 @@ class TestFutureWorkRecord(unittest.TestCase):
             "path1": "future-work",
             "path2": "test-item",
             "title": "Test item",
-            "tags": "accuracy",
+            "skills": "python",
         }
 
-        allowed_values = {"tags": ["accuracy", "pose"]}
+        allowed_values = {"skills": ["python", "github-actions"]}
 
         validated = FutureWorkRecord.model_validate(
             record, context={"allowed_values": allowed_values}
         )
-        self.assertEqual(validated.tags, ["accuracy"])
+        self.assertEqual(validated.skills, ["python"])
 
     def test_validation_with_invalid_allowed_values(self):
         record = {
@@ -178,10 +169,10 @@ class TestFutureWorkRecord(unittest.TestCase):
             "path1": "future-work",
             "path2": "test-item",
             "title": "Test item",
-            "tags": "invalid_tag",
+            "skills": "invalid_skill",
         }
 
-        allowed_values = {"tags": ["accuracy", "pose"]}
+        allowed_values = {"skills": ["python", "github-actions"]}
 
         with self.assertRaises(ValidationError) as cm:
             FutureWorkRecord.model_validate(
@@ -189,7 +180,7 @@ class TestFutureWorkRecord(unittest.TestCase):
             )
 
         errors = cm.exception.errors()
-        self.assertTrue(any("Invalid tags value" in e["msg"] for e in errors))
+        self.assertTrue(any("Invalid skills value" in e["msg"] for e in errors))
 
     def test_validation_with_invalid_output_type(self):
         record = {

--- a/tools/future_work_widget/validator.py
+++ b/tools/future_work_widget/validator.py
@@ -108,14 +108,6 @@ class FutureWorkRecord(BaseModel):
         str | None,
         Field(default=None, description="Current status of the work"),
     ]
-    tags: Annotated[
-        list[str] | None,
-        Field(
-            default=None,
-            description="Categorization tags for the work item",
-            max_length=10,
-        ),
-    ]
     skills: Annotated[
         list[str] | None,
         Field(
@@ -197,7 +189,7 @@ class FutureWorkRecord(BaseModel):
 
         return parsed_items
 
-    @field_validator("tags", "skills", "output_type", "improved_metric", mode="before")
+    @field_validator("skills", "output_type", "improved_metric", mode="before")
     @classmethod
     def validate_comma_separated_list(
         cls, v: Any, info: ValidationInfo


### PR DESCRIPTION
A couple of updates to our future work table widget:
- remove unused tag option
- display all columns by default (since otherwise the values are not visible anywhere)
- reorder columns
- Color the entries in status column