### PR TITLE
fix: more complete object initializers

### DIFF
--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -555,8 +555,11 @@ class GraphLM(LearningModule):
         self.target_to_graph_id = {}
         self.graph_id_to_target = {}
         self.primary_target = None
+        self.possible_matches = {}
+        self.possible_paths = {}
         self.detected_object = None
         self.detected_pose = [None for _ in range(7)]
+        self.detected_rotation_r = None
         # Will always be set during experiment setup, just setting here for unit tests
         self.has_detailed_logger = False
         self.symmetry_evidence = 0

--- a/src/tbp/monty/frameworks/models/graph_matching.py
+++ b/src/tbp/monty/frameworks/models/graph_matching.py
@@ -528,6 +528,9 @@ class MontyForGraphMatching(MontyBase):
 class GraphLM(LearningModule):
     """General Learning Module that contains a graph memory."""
 
+    possible_paths: dict[str, Any]
+    detected_rotation_r: Rotation | None
+
     def __init__(self, initialize_base_modules=True) -> None:
         """Initialize general Learning Module based on graphs.
 
@@ -574,8 +577,8 @@ class GraphLM(LearningModule):
         TODO integrate this into `reset_stm` and/or `fixme_reset_ground_truth`?
         """
         (
+            self.possible_matches,
             self.possible_paths,
-            self.possible_poses,
         ) = self.graph_memory.get_initial_hypotheses()
 
     def reset_stm(self) -> None:

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -36,6 +36,8 @@ logger = logging.getLogger(__name__)
 class MontyBase(Monty):
     LOGGING_REGISTRY: ClassVar[dict[str, type[BaseMontyLogger]]] = {"TEST": TestLogger}
 
+    _is_done: bool
+
     def __init__(
         self,
         sensor_modules: Sequence[SensorModule],
@@ -139,7 +141,7 @@ class MontyBase(Monty):
                 "sensor_module id; no more, no less!"
             )
 
-        self._is_done: bool = False
+        self._is_done = False
         self._actions: list[Action] = []
         self._goals: list[Goal] = []
 

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -139,6 +139,7 @@ class MontyBase(Monty):
                 "sensor_module id; no more, no less!"
             )
 
+        self._is_done: bool = False
         self._actions: list[Action] = []
         self._goals: list[Goal] = []
 

--- a/src/tbp/monty/frameworks/models/sensor_modules.py
+++ b/src/tbp/monty/frameworks/models/sensor_modules.py
@@ -607,6 +607,7 @@ class CameraSM(SensorModule):
         self._snapshot_telemetry = SnapshotTelemetry()
         # Tests check sm.features, not sure if this should be exposed
         self.features = features
+        self.is_exploring = False
         self.processed_obs: list[dict[str, Any]] = []
         # TODO: give more descriptive & distinct names
         self.sensor_module_id = sensor_module_id


### PR DESCRIPTION
Some of the model elements set properties in `reset()` that are not initialized by `__init__()`. This PR provides more complete object initialization at creation time. This is part of the preparation for re-creating the model rather than trying to reset selectively.

## Benchmarks

### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 10.29 | 10.29 | 0 | ⬜ |
| runtime (min) | 3 | 2 | -1 | ✅ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 3.64 | 3.64 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 12 | 11 | -1 | ✅ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99 | 99 | 0 | ⬜ |
| used_mlh (%) | 2 | 2 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 15.85 | 15.85 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 7 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 9.82 | 9.82 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 6 | 7 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 30 | 30 | 0 | ⬜ |
| rotation_error (deg) | 12.85 | 12.85 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 22 | 23 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 5.22 | 5.22 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 13 | 12 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 53.2 | 53.2 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 19 | 20 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.57 | 98.57 | 0 | ⬜ |
| used_mlh (%) | 2.14 | 2.14 | 0 | ⬜ |
| match_steps | 49 | 49 | 0 | ⬜ |
| rotation_error (deg) | 2.39 | 2.39 | 0 | ⬜ |
| runtime (min) | 6 | 5 | -1 | ✅ |
| episode_runtime (sec) | 19 | 18 | -1 | ✅ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| used_mlh (%) | 26 | 26 | 0 | ⬜ |
| match_steps | 177 | 177 | 0 | ⬜ |
| rotation_error (deg) | 20 | 20.04 | 0.04 | ❌ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 31 | 29 | -2 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| used_mlh (%) | 27 | 27 | 0 | ⬜ |
| match_steps | 166 | 166 | 0 | ⬜ |
| rotation_error (deg) | 16.89 | 16.89 | 0 | ⬜ |
| runtime (min) | 19 | 20 | 1 | ❌ |
| episode_runtime (sec) | 133 | 145 | 12 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 68 | 68 | 0 | ⬜ |
| used_mlh (%) | 68 | 68 | 0 | ⬜ |
| match_steps | 14 | 14 | 0 | ⬜ |
| rotation_error (deg) | 92.93 | 92.93 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 7 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10multi_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 48.57 | 48.57 | 0 | ⬜ |
| used_mlh (%) | 1.43 | 1.43 | 0 | ⬜ |
| match_steps | 32 | 32 | 0 | ⬜ |
| rotation_error (deg) | 37.74 | 37.74 | 0 | ⬜ |
| runtime (min) | 36 | 34 | -2 | ✅ |
| episode_runtime (sec) | 2 | 1 | -1 | ✅ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.27 | 98.27 | 0 | ⬜ |
| used_mlh (%) | 8.66 | 8.66 | 0 | ⬜ |
| match_steps | 75 | 75 | 0 | ⬜ |
| rotation_error (deg) | 13.68 | 13.68 | 0 | ⬜ |
| runtime (min) | 12 | 12 | 0 | ⬜ |
| episode_runtime (sec) | 24 | 23 | -1 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 4.76 | 4.76 | 0 | ⬜ |
| match_steps | 43 | 43 | 0 | ⬜ |
| rotation_error (deg) | 2.27 | 2.27 | 0 | ⬜ |
| runtime (min) | 12 | 13 | 1 | ❌ |
| episode_runtime (sec) | 24 | 26 | 2 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96.97 | 96.97 | 0 | ⬜ |
| used_mlh (%) | 16.88 | 16.88 | 0 | ⬜ |
| match_steps | 123 | 123 | 0 | ⬜ |
| rotation_error (deg) | 24.63 | 24.63 | 0 | ⬜ |
| runtime (min) | 22 | 22 | 0 | ⬜ |
| episode_runtime (sec) | 57 | 56 | -1 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99.57 | 99.57 | 0 | ⬜ |
| used_mlh (%) | 15.58 | 15.58 | 0 | ⬜ |
| match_steps | 93 | 93 | 0 | ⬜ |
| rotation_error (deg) | 21.91 | 21.91 | 0 | ⬜ |
| runtime (min) | 36 | 32 | -4 | ✅ |
| episode_runtime (sec) | 97 | 88 | -9 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 92.21 | 92.21 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 38 | 38 | 0 | ⬜ |
| rotation_error (deg) | 47.4 | 47.4 | 0 | ⬜ |
| runtime (min) | 10 | 10 | 0 | ⬜ |
| episode_runtime (sec) | 96 | 101 | 5 | ❌ |
| num_episodes | 77 | 77 | 0 | ⬜ |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 12 | 10 | -2 | ✅ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 23 | 21 | -2 | ✅ |
| episode_runtime (sec) | 12 | 11 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 90 | 90 | 0 | ⬜ |
| used_mlh (%) | 85 | 85 | 0 | ⬜ |
| match_steps | 444 | 444 | 0 | ⬜ |
| runtime (min) | 25 | 26 | 1 | ❌ |
| episode_runtime (sec) | 164 | 170 | 6 | ❌ |
| num_episodes | 120 | 120 | 0 | ⬜ |

### world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 66.67 | 66.67 | 0 | ⬜ |
| used_mlh (%) | 62.5 | 62.5 | 0 | ⬜ |
| match_steps | 374 | 374 | 0 | ⬜ |
| runtime (min) | 10 | 10 | 0 | ⬜ |
| episode_runtime (sec) | 11 | 11 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### dark_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 29.17 | 29.17 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 242 | 242 | 0 | ⬜ |
| runtime (min) | 8 | 7 | -1 | ✅ |
| episode_runtime (sec) | 9 | 8 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### bright_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 37.5 | 37.5 | 0 | ⬜ |
| used_mlh (%) | 64.58 | 64.58 | 0 | ⬜ |
| match_steps | 413 | 413 | 0 | ⬜ |
| runtime (min) | 11 | 11 | 0 | ⬜ |
| episode_runtime (sec) | 12 | 13 | 1 | ❌ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### hand_intrusion_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 43.75 | 43.75 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 272 | 272 | 0 | ⬜ |
| runtime (min) | 9 | 9 | 0 | ⬜ |
| episode_runtime (sec) | 10 | 10 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### multi_object_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 25 | 25 | 0 | ⬜ |
| used_mlh (%) | 2.08 | 2.08 | 0 | ⬜ |
| match_steps | 158 | 158 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 6 | 6 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### infer_comp_lvl1_with_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 89.29 | 89.29 | 0 | ⬜ |
| used_mlh (%) | 84.52 | 84.52 | 0 | ⬜ |
| match_steps | 415 | 415 | 0 | ⬜ |
| rotation_error (deg) | 56.28 | 56.28 | 0 | ⬜ |
| avg_prediction_error | 0.25 | 0.25 | 0 | ⬜ |
| runtime (min) | 33 | 36 | 3 | ❌ |
| num_episodes | 84 | 84 | 0 | ⬜ |

### infer_comp_lvl1_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 86.9 | 86.9 | 0 | ⬜ |
| used_mlh (%) | 29.76 | 29.76 | 0 | ⬜ |
| match_steps | 34 | 34 | 0 | ⬜ |
| rotation_error (deg) | 58.33 | 58.33 | 0 | ⬜ |
| avg_prediction_error | 0.29 | 0.29 | 0 | ⬜ |
| runtime (min) | 5 | 4 | -1 | ✅ |
| num_episodes | 84 | 84 | 0 | ⬜ |

### infer_comp_lvl2_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 86.67 | 86.67 | 0 | ⬜ |
| used_mlh (%) | 32.38 | 32.38 | 0 | ⬜ |
| match_steps | 40 | 40 | 0 | ⬜ |
| rotation_error (deg) | 42.34 | 42.34 | 0 | ⬜ |
| avg_prediction_error | 0.29 | 0.29 | 0 | ⬜ |
| runtime (min) | 13 | 12 | -1 | ✅ |
| num_episodes | 210 | 210 | 0 | ⬜ |

### infer_comp_lvl3_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 72 | 72 | 0 | ⬜ |
| used_mlh (%) | 42.57 | 42.57 | 0 | ⬜ |
| match_steps | 34 | 34 | 0 | ⬜ |
| rotation_error (deg) | 49.35 | 49.35 | 0 | ⬜ |
| avg_prediction_error | 0.3 | 0.3 | 0 | ⬜ |
| runtime (min) | 19 | 19 | 0 | ⬜ |
| num_episodes | 350 | 350 | 0 | ⬜ |
