### PR TITLE
feat: introduce `recreation_mode` feature flag

### DIFF
--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -57,7 +57,7 @@ class MontyExperiment:
     and episode).
     """
 
-    recreation_mode: bool
+    _recreation_mode: bool
     _step_hook: StepHook
 
     def __init__(self, config: DictConfig) -> None:
@@ -69,7 +69,7 @@ class MontyExperiment:
         self.config = config
 
         # Feature flag for "recreation" episode/epoch strategy.
-        self.recreation_mode = False
+        self._recreation_mode = False
 
         self.rng = np.random.RandomState(config["seed"])
 
@@ -463,14 +463,14 @@ class MontyExperiment:
     ####
 
     def _recreation_snapshot(self) -> None:
-        if self.recreation_mode:
+        if self._recreation_mode:
             self.model.update_ltm()
             # TODO: create a snapshot of the episodic state
         else:
             self.model.update_ltm()
 
     def _recreation_restore(self) -> None:
-        if self.recreation_mode:
+        if self._recreation_mode:
             # TODO: restore episodic state from the snapshot
             self.model.set_experiment_mode(self.experiment_mode)
             self.model.reset()

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -57,6 +57,7 @@ class MontyExperiment:
     and episode).
     """
 
+    recreation_mode: bool
     _step_hook: StepHook
 
     def __init__(self, config: DictConfig) -> None:
@@ -66,6 +67,9 @@ class MontyExperiment:
             config: config specifying variables of the experiment.
         """
         self.config = config
+
+        # Feature flag for "recreation" episode/epoch strategy.
+        self.recreation_mode = False
 
         self.rng = np.random.RandomState(config["seed"])
 
@@ -458,6 +462,21 @@ class MontyExperiment:
     # Methods for running the experiment
     ####
 
+    def _recreation_snapshot(self) -> None:
+        if self.recreation_mode:
+            self.model.update_ltm()
+            # TODO: create a snapshot of the episodic state
+        else:
+            self.model.update_ltm()
+
+    def _recreation_restore(self) -> None:
+        if self.recreation_mode:
+            # TODO: restore episodic state from the snapshot
+            self.model.set_experiment_mode(self.experiment_mode)
+            self.model.reset()
+        else:
+            self.model.reset()
+
     def pre_step(self, _step, _observation) -> None:
         """Hook for anything you want to do before a step."""
         self.logger_handler.pre_step(self.logger_args)
@@ -519,7 +538,8 @@ class MontyExperiment:
 
         self.reset_episode_rng()
 
-        self.model.reset()
+        self._recreation_restore()
+
         self.env_interface.pre_episode(self.rng)
 
         self.max_steps = self.max_train_steps
@@ -545,7 +565,8 @@ class MontyExperiment:
         get 'confused'/'FP'.
         """
         self.logger_handler.post_episode(self.logger_args)
-        self.model.update_ltm()
+
+        self._recreation_snapshot()
 
         if self.experiment_mode is ExperimentMode.TRAIN:
             self.train_episodes += 1

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -65,7 +65,8 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
 
         self.reset_episode_rng()
 
-        self.model.reset()
+        self._recreation_restore()
+
         # TODO, eventually it would be better to pass
         # self.env_interface.semantic_id_to_label via an "Observation" object when this
         # is eventually implemented, such that we can ensure this information is never

--- a/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/pretraining_experiments.py
@@ -201,7 +201,8 @@ class MontySupervisedObjectPretrainingExperiment(MontyExperiment):
 
         self.reset_episode_rng()
 
-        self.model.reset()
+        self._recreation_restore()
+
         self.model.fixme_set_ground_truth(self.env_interface.primary_target)
         self.env_interface.pre_episode(self.rng)
 


### PR DESCRIPTION
Create an Experiment feature flag `recreation_mode` to control the episodic strategy. `False` means use the current strategy of `reset` between episodes. `True` means use a new strategy of re-creating the model and restoring long-term memory. The initial/default value is `False`.

## Benchmarks

### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 10.29 | 10.29 | 0 | ⬜ |
| runtime (min) | 3 | 2 | -1 | ✅ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 3.64 | 3.64 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 12 | 12 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99 | 99 | 0 | ⬜ |
| used_mlh (%) | 2 | 2 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 15.85 | 15.85 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 7 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 9.82 | 9.82 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 6 | 6 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 30 | 30 | 0 | ⬜ |
| rotation_error (deg) | 12.85 | 12.85 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 22 | 23 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 5.22 | 5.22 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 13 | 12 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 53.2 | 53.2 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 19 | 22 | 3 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.57 | 98.57 | 0 | ⬜ |
| used_mlh (%) | 2.14 | 2.14 | 0 | ⬜ |
| match_steps | 49 | 49 | 0 | ⬜ |
| rotation_error (deg) | 2.39 | 2.39 | 0 | ⬜ |
| runtime (min) | 6 | 5 | -1 | ✅ |
| episode_runtime (sec) | 19 | 18 | -1 | ✅ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| used_mlh (%) | 26 | 26 | 0 | ⬜ |
| match_steps | 177 | 177 | 0 | ⬜ |
| rotation_error (deg) | 20 | 20.04 | 0.04 | ❌ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 31 | 29 | -2 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| used_mlh (%) | 27 | 27 | 0 | ⬜ |
| match_steps | 166 | 166 | 0 | ⬜ |
| rotation_error (deg) | 16.89 | 16.89 | 0 | ⬜ |
| runtime (min) | 19 | 19 | 0 | ⬜ |
| episode_runtime (sec) | 133 | 139 | 6 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 68 | 68 | 0 | ⬜ |
| used_mlh (%) | 68 | 68 | 0 | ⬜ |
| match_steps | 14 | 14 | 0 | ⬜ |
| rotation_error (deg) | 92.93 | 92.93 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 7 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10multi_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 48.57 | 48.57 | 0 | ⬜ |
| used_mlh (%) | 1.43 | 1.43 | 0 | ⬜ |
| match_steps | 32 | 32 | 0 | ⬜ |
| rotation_error (deg) | 37.74 | 37.74 | 0 | ⬜ |
| runtime (min) | 36 | 35 | -1 | ✅ |
| episode_runtime (sec) | 2 | 1 | -1 | ✅ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.27 | 98.27 | 0 | ⬜ |
| used_mlh (%) | 8.66 | 8.66 | 0 | ⬜ |
| match_steps | 75 | 75 | 0 | ⬜ |
| rotation_error (deg) | 13.68 | 13.68 | 0 | ⬜ |
| runtime (min) | 12 | 11 | -1 | ✅ |
| episode_runtime (sec) | 24 | 22 | -2 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 4.76 | 4.76 | 0 | ⬜ |
| match_steps | 43 | 43 | 0 | ⬜ |
| rotation_error (deg) | 2.27 | 2.27 | 0 | ⬜ |
| runtime (min) | 12 | 13 | 1 | ❌ |
| episode_runtime (sec) | 24 | 27 | 3 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96.97 | 96.97 | 0 | ⬜ |
| used_mlh (%) | 16.88 | 16.88 | 0 | ⬜ |
| match_steps | 123 | 123 | 0 | ⬜ |
| rotation_error (deg) | 24.63 | 24.63 | 0 | ⬜ |
| runtime (min) | 22 | 22 | 0 | ⬜ |
| episode_runtime (sec) | 57 | 57 | 0 | ⬜ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99.57 | 99.57 | 0 | ⬜ |
| used_mlh (%) | 15.58 | 15.58 | 0 | ⬜ |
| match_steps | 93 | 93 | 0 | ⬜ |
| rotation_error (deg) | 21.91 | 21.91 | 0 | ⬜ |
| runtime (min) | 36 | 36 | 0 | ⬜ |
| episode_runtime (sec) | 97 | 99 | 2 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 92.21 | 92.21 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 38 | 38 | 0 | ⬜ |
| rotation_error (deg) | 47.4 | 47.4 | 0 | ⬜ |
| runtime (min) | 10 | 10 | 0 | ⬜ |
| episode_runtime (sec) | 96 | 94 | -2 | ✅ |
| num_episodes | 77 | 77 | 0 | ⬜ |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 12 | 12 | 0 | ⬜ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 23 | 23 | 0 | ⬜ |
| episode_runtime (sec) | 12 | 12 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 90 | 90 | 0 | ⬜ |
| used_mlh (%) | 85 | 85 | 0 | ⬜ |
| match_steps | 444 | 444 | 0 | ⬜ |
| runtime (min) | 25 | 23 | -2 | ✅ |
| episode_runtime (sec) | 164 | 151 | -13 | ✅ |
| num_episodes | 120 | 120 | 0 | ⬜ |

### world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 66.67 | 66.67 | 0 | ⬜ |
| used_mlh (%) | 62.5 | 62.5 | 0 | ⬜ |
| match_steps | 374 | 374 | 0 | ⬜ |
| runtime (min) | 10 | 9 | -1 | ✅ |
| episode_runtime (sec) | 11 | 11 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### dark_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 29.17 | 29.17 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 242 | 242 | 0 | ⬜ |
| runtime (min) | 8 | 8 | 0 | ⬜ |
| episode_runtime (sec) | 9 | 8 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### bright_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 37.5 | 37.5 | 0 | ⬜ |
| used_mlh (%) | 64.58 | 64.58 | 0 | ⬜ |
| match_steps | 413 | 413 | 0 | ⬜ |
| runtime (min) | 11 | 10 | -1 | ✅ |
| episode_runtime (sec) | 12 | 11 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### hand_intrusion_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 43.75 | 43.75 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 272 | 272 | 0 | ⬜ |
| runtime (min) | 9 | 9 | 0 | ⬜ |
| episode_runtime (sec) | 10 | 10 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### multi_object_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 25 | 25 | 0 | ⬜ |
| used_mlh (%) | 2.08 | 2.08 | 0 | ⬜ |
| match_steps | 158 | 158 | 0 | ⬜ |
| runtime (min) | 6 | 5 | -1 | ✅ |
| episode_runtime (sec) | 6 | 5 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### infer_comp_lvl1_with_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 89.29 | 89.29 | 0 | ⬜ |
| used_mlh (%) | 84.52 | 84.52 | 0 | ⬜ |
| match_steps | 415 | 415 | 0 | ⬜ |
| rotation_error (deg) | 56.28 | 56.28 | 0 | ⬜ |
| avg_prediction_error | 0.25 | 0.25 | 0 | ⬜ |
| runtime (min) | 33 | 38 | 5 | ❌ |
| num_episodes | 84 | 84 | 0 | ⬜ |

### infer_comp_lvl1_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 86.9 | 86.9 | 0 | ⬜ |
| used_mlh (%) | 29.76 | 29.76 | 0 | ⬜ |
| match_steps | 34 | 34 | 0 | ⬜ |
| rotation_error (deg) | 58.33 | 58.33 | 0 | ⬜ |
| avg_prediction_error | 0.29 | 0.29 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| num_episodes | 84 | 84 | 0 | ⬜ |

### infer_comp_lvl2_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 86.67 | 86.67 | 0 | ⬜ |
| used_mlh (%) | 32.38 | 32.38 | 0 | ⬜ |
| match_steps | 40 | 40 | 0 | ⬜ |
| rotation_error (deg) | 42.34 | 42.34 | 0 | ⬜ |
| avg_prediction_error | 0.29 | 0.29 | 0 | ⬜ |
| runtime (min) | 13 | 12 | -1 | ✅ |
| num_episodes | 210 | 210 | 0 | ⬜ |

### infer_comp_lvl3_with_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 72 | 72 | 0 | ⬜ |
| used_mlh (%) | 42.57 | 42.57 | 0 | ⬜ |
| match_steps | 34 | 34 | 0 | ⬜ |
| rotation_error (deg) | 49.35 | 49.35 | 0 | ⬜ |
| avg_prediction_error | 0.3 | 0.3 | 0 | ⬜ |
| runtime (min) | 19 | 17 | -2 | ✅ |
| num_episodes | 350 | 350 | 0 | ⬜ |

