### PR TITLE
chore: version 0.40.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.39.0"
+__version__ = "0.40.0"


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since 0.39.0.

<img width="1195" height="864" alt="Screenshot 2026-06-25 at 11 40 11" src="https://github.com/user-attachments/assets/aa1d37d2-ddc9-4143-a7f3-2b19ebc85cb1" />

## refactor!: split Runtime and Experiment aspects of Monty (#1035)

- `Monty.pre_episode()` is split into `ExperimentMonty.reset()` and `ExperimentMonty.fixme_set_ground_truth()`
- `MontyForGraphMatching` (and its subclasses) use `ExperimentMonty.fixme_set_ground_truth()` to pass additional information into the model
- `Monty.post_episode()` becomes `ExperimentMonty.update_ltm()`

## refactor!: create MuJoCo version of graph_learning_test.py (#1033)

- Changed FOV calculation to correctly calculate for zooms
