### PR TITLE
chore: updating documentation to explain how we validate slug and file path accuracy

### DIFF
--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -11,6 +11,52 @@ Our documentation is held in Markdown files in the Monty repo under the [`/docs`
 
 > 📘 Edits to the documentation need to be submitted in the form of PRs to the Monty repository.
 
+## Understanding `hierarchy.md`
+
+The `hierarchy.md` file defines both the navigation hierarchy and the expected location of every documentation file.
+
+Each entry has the following format:
+
+```text
+# category-slug: Category Title
+- [document-slug](category-slug/document-slug.md) <!-- check-links-ignore -->
+  - [subdocument-slug](category-slug/document-slug/subdocument-slug.md) <!-- check-links-ignore -->
+```
+
+> [!NOTE]
+> The `<!-- check-links-ignore -->` comments in the examples are only used to prevent the documentation link checker from validating these example paths. They are not part of the `hierarchy.md` syntax and should not be added to real entries.
+
+There are two important parts:
+
+* **Text inside `[]`** is the document's **slug** (the URL-safe name, all lowercase, without the `.md` extension). The indentation of the `[]` entries defines the parent/child hierarchy shown in the documentation.
+* **Text inside `()`** is the **exact relative file path** to the Markdown file, including the `.md` extension.
+
+The file path inside `()` must match the hierarchy exactly:
+
+1. Start with the **category slug** (the text before the `:` in the category heading).
+2. For each level of nesting, add the slug from the corresponding `[]` entry as another directory.
+3. End with the Markdown filename (`.md`).
+
+For example:
+
+```text
+# how-to-use-monty: How to Use Monty
+- [tutorials](how-to-use-monty/tutorials.md) <!-- check-links-ignore --> 
+  - [running-your-first-experiment](how-to-use-monty/tutorials/running-your-first-experiment.md) <!-- check-links-ignore -->
+```
+This corresponds to the following files in the repo:
+
+```text
+docs/
+└── how-to-use-monty/ 
+    ├── tutorials.md
+    └── tutorials/
+        └── running-your-first-experiment.md
+```
+
+If the indentation, slugs, or file paths do not match the directory structure, the documentation sync tool will report a hierarchy mismatch during validation.
+
+
 # Linting
 
 We use [Vale](https://vale.sh/) to lint our documentation. The linting process checks for spelling errors and ensures that headings follow the [APA title case style](https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case).

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -17,10 +17,10 @@ The `hierarchy.md` file defines both the navigation hierarchy and the expected l
 
 Each entry has the following format:
 
-```markdown
+```markdown Markdown
 # category-slug: Category Title
-- [document-slug](category-slug/document-slug.md)
-  - [subdocument-slug](category-slug/document-slug/subdocument-slug.md)
+- [document-slug](category-slug/document-slug.md) <!-- check-links-ignore --> 
+  - [subdocument-slug](category-slug/document-slug/subdocument-slug.md) <!-- check-links-ignore --> 
 ```
 
 There are two important parts:

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -121,7 +121,7 @@ docs/
 ```
 
 If the indentation, slugs, or file paths do not match the directory structure, the documentation sync tool will report a hierarchy mismatch during validation.
-Validation will automatically be run via Github actions during a pull request, but you can proactively check if your indentation, slugs and file paths
+Validation will automatically be run via \bGitHub\b actions during a pull request, but you can proactively check if your indentation, slugs and file paths
 are correct by running `python -m tools.github_readme_sync.cli check docs` from the `tbp.monty` directory. 
 
 ## An Example New Document

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -38,8 +38,8 @@ For example:
 
 ```markdown Markdown
 # how-to-use-monty: How to Use Monty
-- [tutorials](how-to-use-monty/tutorials.md) <!-- check-links-ignore --> 
-  - [running-your-first-experiment](how-to-use-monty/tutorials/running-your-first-experiment.md) <!-- check-links-ignore -->
+- [tutorials](how-to-use-monty/tutorials.md <!-- check-links-ignore -->)
+  - [running-your-first-experiment](how-to-use-monty/tutorials/running-your-first-experiment.md <!-- check-links-ignore -->)
 ```
 
 > [!NOTE]

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -210,7 +210,8 @@ To create a new category, simply create a new folder inside the `/docs` folder a
 
 In our documentation sync tool there is a flag to check internal links, image references and hierarchy file references.  This is a good way to ensure that all links are working correctly before submitting a PR.
 
-To check the links, [activate the conda environment](../how-to-use-monty/getting-started.md#miniconda), and then run the following command:
+To check the links, [activate the conda environment](../how-to-use-monty/getting-started.md#miniconda), and then run the following command
+from the `tbp.monty` directory:
 
 ```
 python -m tools.github_readme_sync.cli check docs

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -132,7 +132,7 @@ are correct by following the instructions in [Checking Links](#checking-links).
 - [some-existing-doc](/my-category/placeholder-example-doc.md)
 ```
 
-After adding a corresponding line in the `/docs/hierarchy.md` file for your new document, create your Markdown document `/docs/my-category/new-placeholder-example-doc.md` and add the appropriate Frontmatter (see the example below). The Title does not *need* to match the slug and document name exactly, but should be similar,
+After adding a corresponding line in the `/docs/hierarchy.md` file for your new document, create your Markdown document `/docs/my-category/new-placeholder-example-doc.md` and add the appropriate Frontmatter (see the example below). *The Title does not need to match the slug and document name exactly*, but should be similar,
 for clarity of understanding. 
 
 ```markdown

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -17,18 +17,15 @@ The `hierarchy.md` file defines both the navigation hierarchy and the expected l
 
 Each entry has the following format:
 
-```text
+```markdown
 # category-slug: Category Title
-- [document-slug](category-slug/document-slug.md) <!-- check-links-ignore -->
-  - [subdocument-slug](category-slug/document-slug/subdocument-slug.md) <!-- check-links-ignore -->
+- [document-slug](category-slug/document-slug.md)
+  - [subdocument-slug](category-slug/document-slug/subdocument-slug.md)
 ```
-
-> [!NOTE]
-> The `<!-- check-links-ignore -->` comments in the examples are only used to prevent the documentation link checker from validating these example paths. They are not part of the `hierarchy.md` syntax and should not be added to real entries.
 
 There are two important parts:
 
-* **Text inside `[]`** is the document's **slug** (the URL-safe name, all lowercase, without the `.md` extension). The indentation of the `[]` entries defines the parent/child hierarchy shown in the documentation.
+* **Text inside `[]`** is the document's **slug** (the URL-safe name, **all lowercase**, without the `.md` extension). The indentation of the `[]` entries defines the parent/child hierarchy shown in the documentation.
 * **Text inside `()`** is the **exact relative file path** to the Markdown file, including the `.md` extension.
 
 The file path inside `()` must match the hierarchy exactly:
@@ -39,11 +36,15 @@ The file path inside `()` must match the hierarchy exactly:
 
 For example:
 
-```text
+```markdown Markdown
 # how-to-use-monty: How to Use Monty
 - [tutorials](how-to-use-monty/tutorials.md) <!-- check-links-ignore --> 
   - [running-your-first-experiment](how-to-use-monty/tutorials/running-your-first-experiment.md) <!-- check-links-ignore -->
 ```
+
+> [!NOTE]
+> The `<!-- check-links-ignore -->` comments in the example above is only used to prevent the documentation link checker from validating these example paths. They are not part of the `hierarchy.md` syntax and should not be added to real entries.
+
 This corresponds to the following files in the repo:
 
 ```text
@@ -122,6 +123,8 @@ This is the simplest flow.  To modify a document simply edit the Markdown file i
 
 To create a new document, create the new file in the category directory, then add a corresponding line in the `/docs/hierarchy.md` file.
 
+See [Understanding `hierarchy.md`](#understanding-hierarchymd) for in-depth instructions on the proper syntax. 
+
 ```markdown Markdown
 # my-category: My Category
 - [my-new-doc](/my-category/new-placeholder-example-doc.md)
@@ -153,7 +156,7 @@ Continue with the [Pull Requests](pull-requests.md) process.
 Documents that are nested under other documents require that you create a folder with the same name as the parent document but without the `.md` extension.  Then, you place any sub-documents in that folder.  For example, if you were creating a document called `new-placeholder-example-doc.md` beneath the document `Category One/some-existing-doc.md` file you would create a folder called `category-one/some-existing-doc` and place the new document in that folder.
 
 
-And then update the `hierarchy.md` file
+And then update the `hierarchy.md` file. See [Understanding `hierarchy.md`](#understanding-hierarchymd) for in-depth instructions on the proper syntax. 
 
 ```markdown markdown
 # category-one: Category One

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -7,56 +7,9 @@ title: Documentation
 
 # Overview
 
-Our documentation is held in Markdown files in the Monty repo under the [`/docs` folder](https://github.com/thousandbrainsproject/tbp.monty/tree/main/docs/). This documentation is synchronized to readme.com for viewing whenever a change is made. The order of sections, documents, and subdocuments is maintained by a hierarchy file called `/docs/hierarchy.md`. This is a fairly straightforward Markdown document that is used to tell readme how to order the categories, documents and sub-documents.
+Our documentation is held in Markdown files in the Monty repo under the [`/docs` folder](https://github.com/thousandbrainsproject/tbp.monty/tree/main/docs/). This documentation is synchronized to readme.com for viewing whenever a change is made. The order of sections, documents, and subdocuments is maintained by a hierarchy file called `/docs/hierarchy.md`. This is a fairly straightforward Markdown document that is used to tell readme how to order the categories, documents and sub-documents. See [Understanding `hierarchy.md`](#understanding-hierarchymd) for in-depth instructions on the proper syntax. 
 
 > 📘 Edits to the documentation need to be submitted in the form of PRs to the Monty repository.
-
-## Understanding `hierarchy.md`
-
-The `hierarchy.md` file defines both the navigation hierarchy and the expected location of every documentation file.
-
-Each entry has the following format:
-
-```markdown Markdown
-# category-slug: Category Title
-- [document-slug](category-slug/document-slug.md) <!-- check-links-ignore --> 
-  - [subdocument-slug](category-slug/document-slug/subdocument-slug.md) <!-- check-links-ignore --> 
-```
-
-There are two important parts:
-
-* **Text inside `[]`** is the document's **slug** (the URL-safe name, **all lowercase**, without the `.md` extension). The indentation of the `[]` entries defines the parent/child hierarchy shown in the documentation.
-* **Text inside `()`** is the **exact relative file path** to the Markdown file, including the `.md` extension.
-
-The file path inside `()` must match the hierarchy exactly:
-
-1. Start with the **category slug** (the text before the `:` in the category heading).
-2. For each level of nesting, add the slug from the corresponding `[]` entry as another directory.
-3. End with the Markdown filename (`.md`).
-
-For example:
-
-```markdown Markdown
-# how-to-use-monty: How to Use Monty
-- [tutorials](how-to-use-monty/tutorials.md <!-- check-links-ignore -->)
-  - [running-your-first-experiment](how-to-use-monty/tutorials/running-your-first-experiment.md <!-- check-links-ignore -->)
-```
-
-> [!NOTE]
-> The `<!-- check-links-ignore -->` comments in the example above is only used to prevent the documentation link checker from validating these example paths. They are not part of the `hierarchy.md` syntax and should not be added to real entries.
-
-This corresponds to the following files in the repo:
-
-```text
-docs/
-└── how-to-use-monty/ 
-    ├── tutorials.md
-    └── tutorials/
-        └── running-your-first-experiment.md
-```
-
-If the indentation, slugs, or file paths do not match the directory structure, the documentation sync tool will report a hierarchy mismatch during validation.
-
 
 # Linting
 
@@ -123,7 +76,55 @@ This is the simplest flow.  To modify a document simply edit the Markdown file i
 
 To create a new document, create the new file in the category directory, then add a corresponding line in the `/docs/hierarchy.md` file.
 
-See [Understanding `hierarchy.md`](#understanding-hierarchymd) for in-depth instructions on the proper syntax. 
+## Understanding `hierarchy.md`
+
+The `hierarchy.md` file defines both the navigation hierarchy and the expected location of every documentation file.
+
+Each entry has the following format:
+
+```markdown Markdown
+# category-slug: Category Title
+- [document-slug](category-slug/document-slug.md) <!-- check-links-ignore --> 
+  - [subdocument-slug](category-slug/document-slug/subdocument-slug.md) <!-- check-links-ignore --> 
+```
+
+There are two important parts:
+
+* **Text inside `[]`** is the document's **slug** (the URL-safe name, **all lowercase**, without the `.md` extension). The indentation of the `[]` entries defines the parent/child hierarchy shown in the documentation. This slug also defines the URL address for the doc, so **ensure it's a unique slug in the entire `hierarchy.md` file.** For example, a slug of `[document-slug]` would be rendered at the following URL: https://docs.thousandbrains.org/docs/document-slug
+* **Text inside `()`** is the **exact relative file path** to the Markdown file, including the `.md` extension.
+
+The file path inside `()` must exactly match the hierarchy of where the file exists under 'docs':
+
+1. Start with the **category slug** (the text before the `:` in the category heading).
+2. For each level of nesting, add the slug from the corresponding `[]` entry as another directory.
+3. End with the Markdown filename (`.md`).
+
+For example:
+
+```markdown Markdown
+# how-to-use-monty: How to Use Monty
+- [tutorials](how-to-use-monty/tutorials.md <!-- check-links-ignore -->)
+  - [running-your-first-experiment](how-to-use-monty/tutorials/running-your-first-experiment.md <!-- check-links-ignore -->)
+```
+
+> [!NOTE]
+> The `<!-- check-links-ignore -->` comments in the example above is only used to prevent the documentation link checker from validating these example paths. They are not part of the `hierarchy.md` syntax and should not be added to real entries.
+
+This corresponds to the following files in the repo:
+
+```text
+docs/
+└── how-to-use-monty/ 
+    ├── tutorials.md
+    └── tutorials/
+        └── running-your-first-experiment.md
+```
+
+If the indentation, slugs, or file paths do not match the directory structure, the documentation sync tool will report a hierarchy mismatch during validation.
+Validation will automatically be run via Github actions during a pull request, but you can proactively check if your indentation, slugs and file paths
+are correct by running `python -m tools.github_readme_sync.cli check docs` from the `tbp.monty` directory. 
+
+## An Example New Document
 
 ```markdown Markdown
 # my-category: My Category
@@ -131,7 +132,8 @@ See [Understanding `hierarchy.md`](#understanding-hierarchymd) for in-depth inst
 - [some-existing-doc](/my-category/placeholder-example-doc.md)
 ```
 
-Then, create your Markdown document `/docs/my-category/new-placeholder-example-doc.md` and add the appropriate Frontmatter.
+After adding a corresponding line in the `/docs/hierarchy.md` file for your new document, create your Markdown document `/docs/my-category/new-placeholder-example-doc.md` and add the appropriate Frontmatter (see the example below). The Title does not *need* to match the slug and document name exactly, but should be similar,
+for clarity of understanding. 
 
 ```markdown
 ---
@@ -154,7 +156,6 @@ Continue with the [Pull Requests](pull-requests.md) process.
 ## Creating Sub-Documents
 
 Documents that are nested under other documents require that you create a folder with the same name as the parent document but without the `.md` extension.  Then, you place any sub-documents in that folder.  For example, if you were creating a document called `new-placeholder-example-doc.md` beneath the document `Category One/some-existing-doc.md` file you would create a folder called `category-one/some-existing-doc` and place the new document in that folder.
-
 
 And then update the `hierarchy.md` file. See [Understanding `hierarchy.md`](#understanding-hierarchymd) for in-depth instructions on the proper syntax. 
 

--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -121,8 +121,8 @@ docs/
 ```
 
 If the indentation, slugs, or file paths do not match the directory structure, the documentation sync tool will report a hierarchy mismatch during validation.
-Validation will automatically be run via \bGitHub\b actions during a pull request, but you can proactively check if your indentation, slugs and file paths
-are correct by running `python -m tools.github_readme_sync.cli check docs` from the `tbp.monty` directory. 
+Validation will automatically be run via GitHub Actions during a pull request, but you can proactively check if your indentation, slugs and file paths
+are correct by following the instructions in [Checking Links](#checking-links). 
 
 ## An Example New Document
 

--- a/tools/github_readme_sync/constants.py
+++ b/tools/github_readme_sync/constants.py
@@ -10,7 +10,7 @@
 
 import re
 
-IGNORE_DOCS = ["placeholder-example-doc", "some-existing-doc"]
+IGNORE_DOCS = ["placeholder-example-doc", "some-existing-doc", "document-slug"]
 IGNORE_IMAGES = ["docs-only-example.png"]
 IGNORE_TABLES = ["example-table-for-docs.csv"]
 IGNORE_YOUTUBE = ["example-video-id"]

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -420,6 +420,9 @@ class ReadMe:
     def correct_file_locations(self, body: str) -> str:
         def replace_path(match):
             matched_text = match.group(0)
+
+            if "check-links-ignore" in matched_text:
+                return matched_text
             if any(placeholder in matched_text for placeholder in IGNORE_DOCS):
                 return matched_text
 


### PR DESCRIPTION
I'll be able to remove the  <!-- check-links-ignore --> from this section in the next PR, once the new constants to ignore are merged.

```markdown Markdown
# category-slug: Category Title
- [document-slug](category-slug/document-slug.md) <!-- check-links-ignore --> 
  - [subdocument-slug](category-slug/document-slug/subdocument-slug.md) <!-- check-links-ignore --> 
```

I have to leave the <!-- check-links-ignore --> for the tutorial path example, because those are a real pathway, and we don't want to ignore the actual docs on that pathway.

```markdown Markdown
# how-to-use-monty: How to Use Monty
- [tutorials](how-to-use-monty/tutorials.md) <!-- check-links-ignore --> 
  - [running-your-first-experiment](how-to-use-monty/tutorials/running-your-first-experiment.md) <!-- check-links-ignore -->
```
