### PR TITLE
docs: remove unnecessary ignore link checker to clean up documentation

### DIFF
--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -84,8 +84,8 @@ Each entry has the following format:
 
 ```markdown Markdown
 # category-slug: Category Title
-- [document-slug](category-slug/document-slug.md) <!-- check-links-ignore --> 
-  - [subdocument-slug](category-slug/document-slug/subdocument-slug.md) <!-- check-links-ignore --> 
+- [document-slug](category-slug/document-slug.md) 
+  - [subdocument-slug](category-slug/document-slug/subdocument-slug.md) 
 ```
 
 There are two important parts:


### PR DESCRIPTION
In the last PR (#1065), I had to include the ignore link checker for the "document-slug" because I needed the update to the constants.py to be merged first (https://github.com/thousandbrainsproject/tbp.monty/pull/1065/changes#diff-9bf9ff52bb73ac6fb8db51704efe020ae281fbc1ea819d762aa21bd8e008a576).

Now that constant.py ignores "document-slug", I can remove the  <!-- check-links-ignore --> 

I have to leave  <!-- check-links-ignore -->  for the [tutorials](how-to-use-monty/tutorials.md <!-- check-links-ignore -->) section, because that's a real pathway that would be expressed in hierarchy.md, that I wanted to show for educational purposes and we don't want to ignore that pathway when checking the real docs.

