### PR TITLE
fix: pop step_hook from config to avoid error when saving live plotter

### DIFF
--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -101,9 +101,7 @@ class MontyExperiment:
 
         self._rng_seed_history: list[int] = []
 
-        self._step_hook = (
-            config["step_hook"] if "step_hook" in config else NoOpStepHook()
-        )
+        self._step_hook = config.pop("step_hook", NoOpStepHook())
 
     def reset_episode_rng(self):
         """Resets the random number generator using episode-specific seed."""


### PR DESCRIPTION
A configured step_hook is currently stored on self.config in MontyExperiment. When save_state_dir runs at the end of an episode, that config is serialized with torch.save. When using tbp.teleop, the hook holds an unpicklable object, so the save raises `TypeError: cannot pickle 'FigureCanvasQTAgg' object`, causing the run to crash.

As @ramyamounir suggested, this changes the hook to be popped out of self.config instead, so the live hook is held only as self._step_hook and never reaches the serialized config.