### PR TITLE
chore: version 0.41.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.40.0"
+__version__ = "0.41.0"


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since 0.40.0.

<img width="2347" height="1792" alt="image" src="https://github.com/user-attachments/assets/7adacafa-9147-4a28-ad40-32e14e97c101" />

## feat!: vocus2 benchmark configs and new pretrained models (#1041)
- pretrained models updated from v12 to v13