### PR TITLE
chore: update ycb_10objs.csv randrot_noise_10simobj_dist_agent

### DIFF
--- a/benchmarks/ycb_10objs.csv
+++ b/benchmarks/ycb_10objs.csv
@@ -8,7 +8,7 @@ randrot_noise_10distinctobj_surf_agent,100.00,0.00,30,12.85,4,21,100
 randrot_10distinctobj_surf_agent,100.00,0.00,28,5.22,3,13,100
 randrot_noise_10distinctobj_5lms_dist_agent,100.00,0.00,39,53.20,4,21,100
 base_10simobj_surf_agent,98.57,2.14,49,2.39,5,16,140
-randrot_noise_10simobj_dist_agent,97.00,26.00,177,20.0,6,30,100
+randrot_noise_10simobj_dist_agent,97.00,26.00,177,20.04,6,30,100
 randrot_noise_10simobj_surf_agent,98.00,27.00,166,16.89,16,116,100
 randomrot_rawnoise_10distinctobj_surf_agent,68.00,68.00,14,92.93,5,7,100
 base_10multi_distinctobj_dist_agent,48.57,1.43,32,37.74,32,1,140


### PR DESCRIPTION
The results of the `randrot_noise_10simobj_dist_agent` slightly changed as a result of #1041. This updates the CSV to match so it doesn't get flagged as a change in benchmark results anymore.