### PR TITLE
test: fix GetGoodViewTest to confirm agent moves

### DIFF
--- a/src/tbp/monty/conf/environment/habitat_dist_agent_posz05.yaml
+++ b/src/tbp/monty/conf/environment/habitat_dist_agent_posz05.yaml
@@ -1,0 +1,52 @@
+# @package experiment.config.environment
+
+env_init_args:
+  objects:
+    - name: coneSolid
+      position:
+        - 0.0
+        - 1.5
+        - -0.1
+  scene_id: null
+  seed: 42
+  data_path: null
+  agents:
+    agent_args:
+      agent_id: agent_id_0
+      sensor_ids:
+        - patch
+        - view_finder
+      height: 0.0
+      position:
+        - 0.0
+        - 1.5
+        - 0.5
+      resolutions:
+        - - 64
+          - 64
+        - - 64
+          - 64
+      positions:
+        - - 0.0
+          - 0.0
+          - 0.0
+        - - 0.0
+          - 0.0
+          - 0.0
+      rotations:
+        - - 1.0
+          - 0.0
+          - 0.0
+          - 0.0
+        - - 1.0
+          - 0.0
+          - 0.0
+          - 0.0
+      semantics:
+        - false
+        - false
+      zooms:
+        - 10.0
+        - 1.0
+    agent_type: ${monty.class:tbp.monty.simulators.habitat.MultiSensorAgent}
+env_init_func: ${monty.class:tbp.monty.simulators.habitat.environment.HabitatEnvironment}

--- a/src/tbp/monty/conf/environment/mujoco_dist_agent_posz05.yaml
+++ b/src/tbp/monty/conf/environment/mujoco_dist_agent_posz05.yaml
@@ -1,0 +1,25 @@
+# @package experiment.config.environment
+
+env_init_args:
+  agents:
+    - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+      _partial_: true
+      agent_id: agent_id_0
+      sensor_configs:
+        patch:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          zoom: 10.0
+        view_finder:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          zoom: 1.0
+      position:
+        - 0.0
+        - 1.5
+        - 0.5
+env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}

--- a/src/tbp/monty/conf/experiment/test/integration/positioning_procedures/get_good_view/dist_agent_too_far_away.yaml
+++ b/src/tbp/monty/conf/experiment/test/integration/positioning_procedures/get_good_view/dist_agent_too_far_away.yaml
@@ -6,10 +6,10 @@ defaults:
   - /monty/learning_module: displacement_1lm
   - /monty/sensor_module: camera_dist
   - /monty/connectivity: 1lm_1sm
-  - /environment: habitat_dist_agent
+  - /environment: habitat_dist_agent_posz05
   - /env_interface: test_train_2obj_predefined_eval_1obj_cubeSolid_predefined
-  - /env_interface/positioning_procedures_train: getgoodview_mop1_viewfinder_patch
-  - /env_interface/positioning_procedures_eval: getgoodview_mop1_viewfinder_patch
+  - /env_interface/positioning_procedures_train: getgoodview_viewfinder_patch
+  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
   - /env_interface/transform: missing_depthto3d_sensor2_semantic0
   - /logging: detailed_info_monty_runs
 

--- a/src/tbp/monty/conf/experiment/test/integration/positioning_procedures/get_good_view/dist_agent_too_far_away_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/test/integration/positioning_procedures/get_good_view/dist_agent_too_far_away_mujoco.yaml
@@ -6,10 +6,10 @@ defaults:
   - /monty/learning_module: displacement_1lm
   - /monty/sensor_module: camera_dist
   - /monty/connectivity: 1lm_1sm
-  - /environment: mujoco_dist_agent
+  - /environment: mujoco_dist_agent_posz05
   - /env_interface: test_train_2obj_predefined_eval_1obj_cubeSolid_predefined
-  - /env_interface/positioning_procedures_train: getgoodview_mop1_viewfinder_patch
-  - /env_interface/positioning_procedures_eval: getgoodview_mop1_viewfinder_patch
+  - /env_interface/positioning_procedures_train: getgoodview_viewfinder_patch
+  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
   - /env_interface/transform: missing_depthto3d_sensor2_semantic0
   - /logging: detailed_info_monty_runs
 

--- a/tests/integration/positioning_procedures/get_good_view_test.py
+++ b/tests/integration/positioning_procedures/get_good_view_test.py
@@ -59,6 +59,7 @@ class GetGoodViewTest(unittest.TestCase):
         """
         with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
             config = hydra_config("dist_agent_too_far_away", self.output_dir)
+            agent_cfg = config.experiment.config.environment.env_init_args.agents
             agent_id = config.experiment.config.train_env_interface_args[
                 "positioning_procedures"
             ][0].agent_id
@@ -74,12 +75,17 @@ class GetGoodViewTest(unittest.TestCase):
                 target_perc_on_target_obj = GOOD_VIEW_PERCENTAGE_DEFAULT
                 target_closest_point = GOOD_VIEW_DISTANCE_DEFAULT
 
-                observation, _ = exp.env_interface.step([])
+                observation, state = exp.env_interface.step([])
                 view = observation[agent_id]["view_finder"]
                 semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
                 perc_on_target_obj = get_perc_on_obj_semantic(
                     semantic, semantic_id=SemanticID(1)
                 )
+
+                # Make sure we've actually moved
+                assert not np.allclose(
+                    state[agent_id].position, agent_cfg.agent_args.position
+                ), "Agent did not move."
 
                 assert perc_on_target_obj >= target_perc_on_target_obj, (
                     f"Initial view is not good enough, {perc_on_target_obj} "
@@ -109,6 +115,7 @@ class GetGoodViewTest(unittest.TestCase):
         """
         with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
             config = hydra_config("multi_object_target_not_visible", self.output_dir)
+            agent_cfg = config.experiment.config.environment.env_init_args.agents
             agent_id = config.experiment.config.train_env_interface_args[
                 "positioning_procedures"
             ][0].agent_id
@@ -116,8 +123,6 @@ class GetGoodViewTest(unittest.TestCase):
                 config.experiment
             )
             with exp:
-                exp.train()
-
                 exp.experiment_mode = ExperimentMode.EVAL
                 exp.model.set_experiment_mode(exp.experiment_mode)
                 exp.pre_epoch()
@@ -126,12 +131,17 @@ class GetGoodViewTest(unittest.TestCase):
                 target_perc_on_target_obj = GOOD_VIEW_PERCENTAGE_DEFAULT
                 target_closest_point = GOOD_VIEW_DISTANCE_DEFAULT
 
-                observation, _ = exp.env_interface.step([])
+                observation, state = exp.env_interface.step([])
                 view = observation[agent_id]["view_finder"]
                 semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
                 perc_on_target_obj = get_perc_on_obj_semantic(
                     semantic, semantic_id=SemanticID(1)
                 )
+
+                # Make sure we've actually moved
+                assert not np.allclose(
+                    state[agent_id].position, agent_cfg.agent_args.position
+                ), "Agent did not move."
 
                 assert perc_on_target_obj >= target_perc_on_target_obj, (
                     f"Initial view is not good enough, {perc_on_target_obj} "

--- a/tests/integration/positioning_procedures/get_good_view_test.py
+++ b/tests/integration/positioning_procedures/get_good_view_test.py
@@ -123,6 +123,8 @@ class GetGoodViewTest(unittest.TestCase):
                 config.experiment
             )
             with exp:
+                exp.train()
+
                 exp.experiment_mode = ExperimentMode.EVAL
                 exp.model.set_experiment_mode(exp.experiment_mode)
                 exp.pre_epoch()

--- a/tests/mujoco/integration/positioning_procedures/get_good_view_test.py
+++ b/tests/mujoco/integration/positioning_procedures/get_good_view_test.py
@@ -118,6 +118,8 @@ class GetGoodViewTest(unittest.TestCase):
                 config.experiment
             )
             with exp:
+                exp.train()
+
                 exp.experiment_mode = ExperimentMode.EVAL
                 exp.model.set_experiment_mode(exp.experiment_mode)
                 exp.pre_epoch()

--- a/tests/mujoco/integration/positioning_procedures/get_good_view_test.py
+++ b/tests/mujoco/integration/positioning_procedures/get_good_view_test.py
@@ -53,6 +53,7 @@ class GetGoodViewTest(unittest.TestCase):
         """
         with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
             config = hydra_config("dist_agent_too_far_away", self.output_dir)
+            agent_cfg = config.experiment.config.environment.env_init_args.agents[0]
             agent_id = config.experiment.config.train_env_interface_args[
                 "positioning_procedures"
             ][0].agent_id
@@ -69,11 +70,16 @@ class GetGoodViewTest(unittest.TestCase):
                 target_closest_point = GOOD_VIEW_DISTANCE_DEFAULT
 
                 assert exp.env_interface is not None  # for type narrowing
-                observation, _ = exp.env_interface.step([])
+                observation, state = exp.env_interface.step([])
                 view = observation[agent_id][SensorID("view_finder")]
                 semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
                 perc_on_target_obj = get_perc_on_obj_semantic(
                     semantic, semantic_id=SemanticID(1)
+                )
+
+                # Make sure we've actually moved
+                assert not np.allclose(agent_cfg.position, state[agent_id].position), (
+                    "Agent did not move."
                 )
 
                 assert perc_on_target_obj >= target_perc_on_target_obj, (
@@ -104,6 +110,7 @@ class GetGoodViewTest(unittest.TestCase):
         """
         with hydra.initialize_config_dir(version_base=None, config_dir=str(HYDRA_ROOT)):
             config = hydra_config("multi_object_target_not_visible", self.output_dir)
+            agent_cfg = config.experiment.config.environment.env_init_args.agents[0]
             agent_id = config.experiment.config.train_env_interface_args[
                 "positioning_procedures"
             ][0].agent_id
@@ -111,8 +118,6 @@ class GetGoodViewTest(unittest.TestCase):
                 config.experiment
             )
             with exp:
-                exp.train()
-
                 exp.experiment_mode = ExperimentMode.EVAL
                 exp.model.set_experiment_mode(exp.experiment_mode)
                 exp.pre_epoch()
@@ -122,7 +127,7 @@ class GetGoodViewTest(unittest.TestCase):
                 target_closest_point = GOOD_VIEW_DISTANCE_DEFAULT
 
                 assert exp.env_interface is not None  # for type narrowing
-                observation, _ = exp.env_interface.step([])
+                observation, state = exp.env_interface.step([])
                 view = observation[agent_id][SensorID("view_finder")]
                 semantic = view["semantic_3d"][:, 3].reshape(view["depth"].shape)
                 perc_on_target_obj = get_perc_on_obj_semantic(
@@ -137,6 +142,11 @@ class GetGoodViewTest(unittest.TestCase):
                 points_on_target_obj = semantic == 1
                 closest_point_on_target_obj = np.min(
                     view["depth"][points_on_target_obj]
+                )
+
+                # Make sure we've actually moved
+                assert not np.allclose(agent_cfg.position, state[agent_id].position), (
+                    "Agent did not move."
                 )
 
                 assert closest_point_on_target_obj > target_closest_point, (


### PR DESCRIPTION
While investigating some code coverage differences between the MuJoCo tests and the Habitat tests, I noticed that the `GetGoodViewTest.test_agent_too_far_away` test doesn't actually test what it is supposed to test. As written, the agent doesn't actually move, and most of the positioning procedure is skipped.

First, I updated the test to assert that the agent position has changed to make the test verify that it moves. Then with a failing test, I updated the starting position of the agent to make it have to move closer to the object, making the test pass.

There are some additional changes that I'll note with comments where they appear. I think there were a few mistakes in the configurations and the tests that I'm attempting to fix here, but don't by themselves fix the original problem.