### PR TITLE
refactor!: move `motor_only_step` hack from `reset` to `fixme` helper

### DIFF
--- a/src/tbp/monty/experiment/motor_system.py
+++ b/src/tbp/monty/experiment/motor_system.py
@@ -19,6 +19,18 @@ __all__ = [
 class ExperimentMotorSystem(Protocol):
     """Experiment interface to a Motor System."""
 
+    def fixme_init_policies(self) -> None:
+        """Perform post-instantiate initialization of this Motor System.
+
+        This is part of the work to remove `reset()` in favor or Hydra instantiation.
+        It is used to provide a reference to the Motor System so the `SurfacePolicy`
+        and its subclasses can override the `motor_only_step` property.
+
+        TODO: This whole mechanism is a hack for the benefit of `SurfacePolicy` et. al.
+        What we should be doing is using a positioning procedure for SMs instead.
+        """
+        ...
+
     def reset(self) -> None:
         """Reset the internal state of this Motor System."""
         ...
@@ -35,22 +47,44 @@ class ExperimentMotorSystem(Protocol):
 class ExperimentMotorPolicySelector(Protocol):
     """Experiment interface to a Motor Policy Selector."""
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:
-        """Reset the internal state of this Motor Policy Selector.
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        """Perform post-instantiate initialization of this Motor Policy Selector.
+
+        This is part of the work to remove `reset()` in favor or Hydra instantiation.
+        It is used to provide a reference to the Motor System so the `SurfacePolicy`
+        and its subclasses can override the `motor_only_step` property.
+
+        TODO: This whole mechanism is a hack for the benefit of `SurfacePolicy` et. al.
+        What we should be doing is using a positioning procedure for SMs instead.
 
         Args:
             motor_system: The associated Motor System.
         """
         ...
 
+    def reset(self) -> None:
+        """Reset the internal state of this Motor Policy Selector."""
+        ...
+
 
 class ExperimentMotorPolicy(Protocol):
     """Experiment interface to a Motor Policy."""
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:
-        """Reset the internal state of this Motor Policy.
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        """Perform post-instantiate initialization of this Motor Policy.
+
+        This is part of the work to remove `reset()` in favor or Hydra instantiation.
+        It is used to provide a reference to the Motor System so the `SurfacePolicy`
+        and its subclasses can override the `motor_only_step` property.
+
+        TODO: This whole mechanism is a hack for the benefit of `SurfacePolicy` et. al.
+        What we should be doing is using a positioning procedure for SMs instead.
 
         Args:
             motor_system: The associated Motor System.
         """
+        ...
+
+    def reset(self) -> None:
+        """Reset the internal state of this Motor Policy."""
         ...

--- a/src/tbp/monty/experiment/motor_system.py
+++ b/src/tbp/monty/experiment/motor_system.py
@@ -19,18 +19,6 @@ __all__ = [
 class ExperimentMotorSystem(Protocol):
     """Experiment interface to a Motor System."""
 
-    def fixme_init_policies(self) -> None:
-        """Perform post-instantiate initialization of this Motor System.
-
-        This is part of the work to remove `reset()` in favor or Hydra instantiation.
-        It is used to provide a reference to the Motor System so the `SurfacePolicy`
-        and its subclasses can override the `motor_only_step` property.
-
-        TODO: This whole mechanism is a hack for the benefit of `SurfacePolicy` et. al.
-        What we should be doing is using a positioning procedure for SMs instead.
-        """
-        ...
-
     def reset(self) -> None:
         """Reset the internal state of this Motor System."""
         ...
@@ -48,14 +36,15 @@ class ExperimentMotorPolicySelector(Protocol):
     """Experiment interface to a Motor Policy Selector."""
 
     def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
-        """Perform post-instantiate initialization of this Motor Policy Selector.
+        """Provide access to the Motor System during initialization.
 
         This is part of the work to remove `reset()` in favor or Hydra instantiation.
         It is used to provide a reference to the Motor System so the `SurfacePolicy`
         and its subclasses can override the `motor_only_step` property.
 
         TODO: This whole mechanism is a hack for the benefit of `SurfacePolicy` et. al.
-        What we should be doing is using a positioning procedure for SMs instead.
+        What we should be doing is supporting more complex actions, like
+        "follow surface in this direction," whose details are left to the simulator.
 
         Args:
             motor_system: The associated Motor System.
@@ -71,14 +60,15 @@ class ExperimentMotorPolicy(Protocol):
     """Experiment interface to a Motor Policy."""
 
     def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
-        """Perform post-instantiate initialization of this Motor Policy.
+        """Provide access to the Motor System during initialization.
 
         This is part of the work to remove `reset()` in favor or Hydra instantiation.
         It is used to provide a reference to the Motor System so the `SurfacePolicy`
         and its subclasses can override the `motor_only_step` property.
 
         TODO: This whole mechanism is a hack for the benefit of `SurfacePolicy` et. al.
-        What we should be doing is using a positioning procedure for SMs instead.
+        What we should be doing is supporting more complex actions, like
+        "follow surface in this direction," whose details are left to the simulator.
 
         Args:
             motor_system: The associated Motor System.

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -421,7 +421,6 @@ class MontyExperiment:
 
         sensor_modules = instantiate(config.pop("sensor_modules"))
         motor_system = instantiate(config.pop("motor_system_config"))
-        motor_system.fixme_init_policies()
 
         # Create mapping between sensor modules, learning modules and agents
         sm_to_lm_matrix = instantiate(config.pop("sm_to_lm_matrix"))

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -421,6 +421,7 @@ class MontyExperiment:
 
         sensor_modules = instantiate(config.pop("sensor_modules"))
         motor_system = instantiate(config.pop("motor_system_config"))
+        motor_system.fixme_init_policies()
 
         # Create mapping between sensor modules, learning modules and agents
         sm_to_lm_matrix = instantiate(config.pop("sm_to_lm_matrix"))

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -141,7 +141,11 @@ class MotorPolicy(RuntimeMotorPolicy, ExperimentMotorPolicy, Snapshotable, abc.A
     """The abstract scaffold for motor policies."""
 
     @abc.abstractmethod
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        pass
+
+    @abc.abstractmethod
+    def reset(self) -> None:
         pass
 
     @abc.abstractmethod
@@ -206,7 +210,10 @@ class BasePolicy(MotorPolicy):
         """
         return MotorPolicyResult([self.action_sampler.sample(self.agent_id, ctx.rng)])
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        pass
+
+    def reset(self) -> None:
         pass
 
     def state_dict(self) -> Memento:
@@ -276,7 +283,10 @@ class InformedPolicyRandomWalk(MotorPolicy):
 
         return MotorPolicyResult([])
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:  # noqa: ARG002
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        pass
+
+    def reset(self) -> None:
         self._undo_action = None
 
     def state_dict(self) -> Memento:
@@ -400,7 +410,10 @@ class PredefinedPolicy(MotorPolicy):
         self.episode_step += 1
         return MotorPolicyResult(actions)
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:  # noqa: ARG002
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        pass
+
+    def reset(self) -> None:
         self.episode_step = 0
 
     def state_dict(self) -> Memento:
@@ -449,7 +462,10 @@ class JumpToGoal(MotorPolicy):
             "undo_jump_actions": self._undo_actions,
         }
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:  # noqa: ARG002
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        pass
+
+    def reset(self) -> None:
         self._undo_action = None
         self._reset_jump_state()
 
@@ -697,10 +713,13 @@ class InformedPolicy(BasePolicy):
         self._pre_jump_state: AgentState | None = None
         self._undo_jump_actions: list[Action] = []
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        return super().fixme_provide_motor_system(motor_system)
+
+    def reset(self) -> None:
         self._undo_action = None
         self._reset_jump_state()
-        return super().reset(motor_system)
+        return super().reset()
 
     def __call__(
         self,
@@ -1010,8 +1029,11 @@ class NaiveScanPolicy(InformedPolicy):
         self.step_on_action += 1
         return MotorPolicyResult([self._naive_scan_actions[self.current_action_id]])
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:
-        super().reset(motor_system)
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        return super().fixme_provide_motor_system(motor_system)
+
+    def reset(self) -> None:
+        super().reset()
         self.steps_per_action = 1
         self.current_action_id = 0
         self.step_on_action = 0
@@ -1075,7 +1097,14 @@ class SurfacePolicy(InformedPolicy):
         self.last_surface_policy_action: Action | None = None
         self._telemetry = SurfacePolicyTelemetry()
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        # TODO: This is a hack. What we should be doing is using a positioning
+        #       procedure for surface agents instead.
+        motor_system.motor_only_step = True
+
+        return super().fixme_provide_motor_system(motor_system)
+
+    def reset(self) -> None:
         self.tangential_angle = 0
         self.touch_search_amount = 0  # Track how many rotations the agent has made
         # along the horizontal plane searching for an object; when this reaches 360,
@@ -1084,11 +1113,7 @@ class SurfacePolicy(InformedPolicy):
 
         self.last_surface_policy_action = None
 
-        # TODO: This is a hack. What we should be doing is using a positioning
-        #       procedure for surface agents instead.
-        motor_system.motor_only_step = True
-
-        return super().reset(motor_system)
+        return super().reset()
 
     def _touch_object(
         self,
@@ -1753,8 +1778,11 @@ class SurfacePolicyCurvatureInformed(SurfacePolicy):
         self.tangent_norms = []  # As for tangent_locs; helpful for distinguishing
         # locations as being on different surfaces
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:
-        super().reset(motor_system)
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        return super().fixme_provide_motor_system(motor_system)
+
+    def reset(self) -> None:
+        super().reset()
         self._init_SurfacePolicyCurvatureInformed()
 
     def __call__(

--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -1098,8 +1098,8 @@ class SurfacePolicy(InformedPolicy):
         self._telemetry = SurfacePolicyTelemetry()
 
     def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
-        # TODO: This is a hack. What we should be doing is using a positioning
-        #       procedure for surface agents instead.
+        # TODO: This is a hack. What we should be doing is
+        #       using more sophisticated actions for surface agents instead.
         motor_system.motor_only_step = True
 
         return super().fixme_provide_motor_system(motor_system)

--- a/src/tbp/monty/frameworks/models/motor_policy_selectors.py
+++ b/src/tbp/monty/frameworks/models/motor_policy_selectors.py
@@ -93,8 +93,11 @@ class SinglePolicySelector(MotorPolicySelector):
         # TODO: Get rid of this once we have another path for telemetry.
         self._selected_goals: list[Goal | None] = []
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:
-        self._policy.reset(motor_system)
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        self._policy.fixme_provide_motor_system(motor_system)
+
+    def reset(self) -> None:
+        self._policy.reset()
         self._selected_goals = []
 
     def state_dict(self) -> Memento:
@@ -135,10 +138,15 @@ class DistantPolicySelector(MotorPolicySelector):
         self._selected_policies: list[MotorPolicy] = []
         self._selected_goals: list[Goal | None] = []
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:
-        self._jump_to_goal.reset(motor_system)
-        self._look_at_goal.reset(motor_system)
-        self._default.reset(motor_system)
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        self._jump_to_goal.fixme_provide_motor_system(motor_system)
+        self._look_at_goal.fixme_provide_motor_system(motor_system)
+        self._default.fixme_provide_motor_system(motor_system)
+
+    def reset(self) -> None:
+        self._jump_to_goal.reset()
+        self._look_at_goal.reset()
+        self._default.reset()
 
         self._is_jumping = False
         self._selected_policies = []

--- a/src/tbp/monty/frameworks/models/motor_system.py
+++ b/src/tbp/monty/frameworks/models/motor_system.py
@@ -93,6 +93,14 @@ class MotorSystem(RuntimeMotorSystem, ExperimentMotorSystem):
             z_defined_pc=[],
         )
 
+        # TODO: Passing self to policy selector is a hack. What we should be
+        # doing is using more sophisticated actions for surface agents instead.
+        # We only do this so that SurfacePolicy and its descendants can set
+        # motor_only_step to True.
+        # Undoing this hack should probably happen when motor_only_step is moved
+        # to Monty itself.
+        self._policy_selector.fixme_provide_motor_system(self)
+
     @property
     def motor_only_step(self) -> bool:
         """When `True`, suppress Learning Module processing."""
@@ -105,15 +113,6 @@ class MotorSystem(RuntimeMotorSystem, ExperimentMotorSystem):
     @property
     def action_sequence(self) -> list[tuple[list[Action], dict[AgentID, Any] | None]]:
         return self._action_sequence
-
-    def fixme_init_policies(self) -> None:
-        # TODO: Passing self to policy selector is a hack. What we should be
-        # doing is using a positioning procedure for surface agents instead.
-        # We only do this so that SurfacePolicy and its descendants can set
-        # motor_only_step to True.
-        # Undoing this hack should probably happen when motor_only_step is moved
-        # to Monty itself.
-        self._policy_selector.fixme_provide_motor_system(self)
 
     def reset(self) -> None:
         self._policy_selector.reset()

--- a/src/tbp/monty/frameworks/models/motor_system.py
+++ b/src/tbp/monty/frameworks/models/motor_system.py
@@ -106,14 +106,17 @@ class MotorSystem(RuntimeMotorSystem, ExperimentMotorSystem):
     def action_sequence(self) -> list[tuple[list[Action], dict[AgentID, Any] | None]]:
         return self._action_sequence
 
-    def reset(self) -> None:
-        # TODO: Passing self to policy reset() is a hack. What we should be
+    def fixme_init_policies(self) -> None:
+        # TODO: Passing self to policy selector is a hack. What we should be
         # doing is using a positioning procedure for surface agents instead.
         # We only do this so that SurfacePolicy and its descendants can set
         # motor_only_step to True.
         # Undoing this hack should probably happen when motor_only_step is moved
         # to Monty itself.
-        self._policy_selector.reset(self)
+        self._policy_selector.fixme_provide_motor_system(self)
+
+    def reset(self) -> None:
+        self._policy_selector.reset()
         self._action_sequence = []
         self._telemetry_surface_action_details = SurfacePolicyActionDetailsTelemetry(
             pc_heading=[],

--- a/src/tbp/monty/frameworks/models/salience/motor_policy.py
+++ b/src/tbp/monty/frameworks/models/salience/motor_policy.py
@@ -68,7 +68,10 @@ class LookAtGoal(MotorPolicy):
         self._agent_id = agent_id
         self._sensor_id = sensor_id
 
-    def reset(self, motor_system: ExperimentMotorSystem) -> None:
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        pass
+
+    def reset(self) -> None:
         pass
 
     def load_state_dict(self, memento: Memento) -> None:

--- a/tests/integration/frameworks/models/policy_test.py
+++ b/tests/integration/frameworks/models/policy_test.py
@@ -641,8 +641,9 @@ class PolicyTest(unittest.TestCase):
         )
         policy_selector = SinglePolicySelector(policy)
         motor_system = MotorSystem(policy_selector)
+        motor_system.fixme_init_policies()
         policy.max_pc_bias_steps = 2
-        policy.reset(motor_system)
+        policy.reset()
 
         rng = np.random.RandomState(123)
         ctx = RuntimeContext(rng)
@@ -766,12 +767,13 @@ class PolicyTest(unittest.TestCase):
         )
         policy_selector = SinglePolicySelector(policy)
         motor_system = MotorSystem(policy_selector)
+        motor_system.fixme_init_policies()
 
         # Overwrite min_general_steps default value so that we more quickly transition
         # into taking PC steps when testing this
         initial_min_general_steps = 1
         policy.min_general_steps = initial_min_general_steps
-        policy.reset(motor_system)
+        policy.reset()
 
         rng = np.random.RandomState(123)
         ctx = RuntimeContext(rng)
@@ -999,7 +1001,8 @@ class PolicyTest(unittest.TestCase):
         )
         policy_selector = SinglePolicySelector(policy)
         motor_system = MotorSystem(policy_selector)
-        policy.reset(motor_system)
+        motor_system.fixme_init_policies()
+        policy.reset()
 
         # The target displacement of the agent from the object; used to determine
         # the validity of the final agent location

--- a/tests/integration/frameworks/models/policy_test.py
+++ b/tests/integration/frameworks/models/policy_test.py
@@ -16,8 +16,6 @@ from tbp.monty.frameworks.models.abstract_monty_classes import LearningModule
 from tbp.monty.frameworks.models.motor_policies import (
     SurfacePolicyCurvatureInformed,
 )
-from tbp.monty.frameworks.models.motor_policy_selectors import SinglePolicySelector
-from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.hydra import instantiate_experiment
 from tests import HYDRA_ROOT
 
@@ -639,9 +637,6 @@ class PolicyTest(unittest.TestCase):
         policy: SurfacePolicyCurvatureInformed = hydra.utils.instantiate(
             self.policy_cfg_fragment
         )
-        policy_selector = SinglePolicySelector(policy)
-        motor_system = MotorSystem(policy_selector)
-        motor_system.fixme_init_policies()
         policy.max_pc_bias_steps = 2
         policy.reset()
 
@@ -765,9 +760,6 @@ class PolicyTest(unittest.TestCase):
         policy: SurfacePolicyCurvatureInformed = hydra.utils.instantiate(
             self.policy_cfg_fragment
         )
-        policy_selector = SinglePolicySelector(policy)
-        motor_system = MotorSystem(policy_selector)
-        motor_system.fixme_init_policies()
 
         # Overwrite min_general_steps default value so that we more quickly transition
         # into taking PC steps when testing this
@@ -999,9 +991,6 @@ class PolicyTest(unittest.TestCase):
         policy: SurfacePolicyCurvatureInformed = hydra.utils.instantiate(
             self.policy_cfg_fragment
         )
-        policy_selector = SinglePolicySelector(policy)
-        motor_system = MotorSystem(policy_selector)
-        motor_system.fixme_init_policies()
         policy.reset()
 
         # The target displacement of the agent from the object; used to determine

--- a/tests/mujoco/integration/frameworks/models/policy_test.py
+++ b/tests/mujoco/integration/frameworks/models/policy_test.py
@@ -645,8 +645,9 @@ class AdvancedPolicyTest(unittest.TestCase):
         )
         policy_selector = SinglePolicySelector(policy)
         motor_system = MotorSystem(policy_selector)
+        motor_system.fixme_init_policies()
         policy.max_pc_bias_steps = 2
-        policy.reset(motor_system)
+        policy.reset()
 
         rng = np.random.RandomState(123)
         ctx = RuntimeContext(rng)
@@ -770,12 +771,13 @@ class AdvancedPolicyTest(unittest.TestCase):
         )
         policy_selector = SinglePolicySelector(policy)
         motor_system = MotorSystem(policy_selector)
+        motor_system.fixme_init_policies()
 
         # Overwrite min_general_steps default value so that we more quickly transition
         # into taking PC steps when testing this
         initial_min_general_steps = 1
         policy.min_general_steps = initial_min_general_steps
-        policy.reset(motor_system)
+        policy.reset()
 
         rng = np.random.RandomState(123)
         ctx = RuntimeContext(rng)
@@ -1012,7 +1014,8 @@ class AdvancedPolicyTest(unittest.TestCase):
         )
         policy_selector = SinglePolicySelector(policy)
         motor_system = MotorSystem(policy_selector)
-        policy.reset(motor_system)
+        motor_system.fixme_init_policies()
+        policy.reset()
 
         # The target displacement of the agent from the object; used to determine
         # the validity of the final agent location

--- a/tests/mujoco/integration/frameworks/models/policy_test.py
+++ b/tests/mujoco/integration/frameworks/models/policy_test.py
@@ -46,8 +46,6 @@ from tbp.monty.frameworks.models.goal_generation import (
 from tbp.monty.frameworks.models.motor_policies import (
     SurfacePolicyCurvatureInformed,
 )
-from tbp.monty.frameworks.models.motor_policy_selectors import SinglePolicySelector
-from tbp.monty.frameworks.models.motor_system import MotorSystem
 from tbp.monty.frameworks.models.motor_system_state import (
     AgentState,
     MotorSystemState,
@@ -643,9 +641,6 @@ class AdvancedPolicyTest(unittest.TestCase):
         policy: SurfacePolicyCurvatureInformed = hydra.utils.instantiate(
             self.policy_cfg_fragment
         )
-        policy_selector = SinglePolicySelector(policy)
-        motor_system = MotorSystem(policy_selector)
-        motor_system.fixme_init_policies()
         policy.max_pc_bias_steps = 2
         policy.reset()
 
@@ -769,9 +764,6 @@ class AdvancedPolicyTest(unittest.TestCase):
         policy: SurfacePolicyCurvatureInformed = hydra.utils.instantiate(
             self.policy_cfg_fragment
         )
-        policy_selector = SinglePolicySelector(policy)
-        motor_system = MotorSystem(policy_selector)
-        motor_system.fixme_init_policies()
 
         # Overwrite min_general_steps default value so that we more quickly transition
         # into taking PC steps when testing this
@@ -1012,9 +1004,6 @@ class AdvancedPolicyTest(unittest.TestCase):
         policy: SurfacePolicyCurvatureInformed = hydra.utils.instantiate(
             self.policy_cfg_fragment
         )
-        policy_selector = SinglePolicySelector(policy)
-        motor_system = MotorSystem(policy_selector)
-        motor_system.fixme_init_policies()
         policy.reset()
 
         # The target displacement of the agent from the object; used to determine

--- a/tests/unit/frameworks/models/motor_policy_selectors_test.py
+++ b/tests/unit/frameworks/models/motor_policy_selectors_test.py
@@ -91,10 +91,14 @@ class SinglePolicySelectorTest(unittest.TestCase):
             best_goal,
         )
 
-    def test_reset_calls_reset_on_policy(self):
+    def test_provide_motor_system_calls_provide_motor_system_on_policy(self):
         motor_system = Mock()
-        self.selector.reset(motor_system)
-        self.policy.reset.assert_called_once_with(motor_system)
+        self.selector.fixme_provide_motor_system(motor_system)
+        self.policy.fixme_provide_motor_system.assert_called_once_with(motor_system)
+
+    def test_reset_calls_reset_on_policy(self):
+        self.selector.reset()
+        self.policy.reset.assert_called_once_with()
 
     def test_state_dict_includes_policy_state_dict(self):
         state_dict = Mock()

--- a/tests/unit/frameworks/models/motor_policy_selectors_test.py
+++ b/tests/unit/frameworks/models/motor_policy_selectors_test.py
@@ -91,7 +91,9 @@ class SinglePolicySelectorTest(unittest.TestCase):
             best_goal,
         )
 
-    def test_provide_motor_system_calls_provide_motor_system_on_policy(self):
+    def test_fixme_provide_motor_system_calls_fixme_provide_motor_system_on_policy(
+        self,
+    ):
         motor_system = Mock()
         self.selector.fixme_provide_motor_system(motor_system)
         self.policy.fixme_provide_motor_system.assert_called_once_with(motor_system)

--- a/tests/unit/frameworks/models/motor_system_test.py
+++ b/tests/unit/frameworks/models/motor_system_test.py
@@ -21,7 +21,9 @@ class MotorSystemTest(unittest.TestCase):
 
     def test_init_policies_calls_provide_motor_system_on_policy_selector(self):
         self.motor_system.fixme_init_policies()
-        self.policy_selector.fixme_provide_motor_system.assert_called_once_with(self.motor_system)
+        self.policy_selector.fixme_provide_motor_system.assert_called_once_with(
+            self.motor_system
+        )
 
     def test_reset_calls_reset_on_policy_selector(self):
         self.motor_system.reset()

--- a/tests/unit/frameworks/models/motor_system_test.py
+++ b/tests/unit/frameworks/models/motor_system_test.py
@@ -19,12 +19,6 @@ class MotorSystemTest(unittest.TestCase):
         self.policy_selector = Mock()
         self.motor_system = MotorSystem(self.policy_selector)
 
-    def test_init_policies_calls_provide_motor_system_on_policy_selector(self):
-        self.motor_system.fixme_init_policies()
-        self.policy_selector.fixme_provide_motor_system.assert_called_once_with(
-            self.motor_system
-        )
-
     def test_reset_calls_reset_on_policy_selector(self):
         self.motor_system.reset()
         self.policy_selector.reset.assert_called_once_with()

--- a/tests/unit/frameworks/models/motor_system_test.py
+++ b/tests/unit/frameworks/models/motor_system_test.py
@@ -19,9 +19,13 @@ class MotorSystemTest(unittest.TestCase):
         self.policy_selector = Mock()
         self.motor_system = MotorSystem(self.policy_selector)
 
+    def test_init_policies_calls_provide_motor_system_on_policy_selector(self):
+        self.motor_system.fixme_init_policies()
+        self.policy_selector.fixme_provide_motor_system.assert_called_once_with(self.motor_system)
+
     def test_reset_calls_reset_on_policy_selector(self):
         self.motor_system.reset()
-        self.policy_selector.reset.assert_called_once_with(self.motor_system)
+        self.policy_selector.reset.assert_called_once_with()
 
     def test_state_dict_returns_state_dict_of_policy(self):
         state_dict = Mock()


### PR DESCRIPTION
This is part of the work to remove `reset()` in favor or Hydra instantiation.

The `SurfacePolicy` (and subclasses) wants access to the `MotorSystem` so it can override the `motor_only_step` property. This is an existing hack that is not in scope to fix at this time. Previously, the `reset()` method from `MotorPolicySelector` downward was "enhanced" to pass the `MotorSystem` along. That parameter has been removed.

Now the `MotorPolicySelector` and `MotorPolicy` have new `fixme_provide_motor_system()` methods that pass along the `MotorSystem`. The `__init()__` method in `MotorSystem` that passes itself to the `MotorPolicySelector`. All of the related logic has been stripped out of `reset()`, which now has no parameters.

## Breaking Changes
- The `reset()` methods of `MotorPolicySelector` and `MotorPolicy` no longer take a `MotorPolicy`.
- The `fixme_provide_motor_system()` methods of `MotorPolicySelector` and `MotorPolicy` handle the prior hack.
- The `__init__()` method of `MotorSystem` performs the required initialization.

## Benchmarks

### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 10.29 | 10.29 | 0 | ⬜ |
| runtime (min) | 2 | 3 | 1 | ❌ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 3.64 | 3.64 | 0 | ⬜ |
| runtime (min) | 4 | 3 | -1 | ✅ |
| episode_runtime (sec) | 11 | 10 | -1 | ✅ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99 | 99 | 0 | ⬜ |
| used_mlh (%) | 2 | 2 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 15.85 | 15.85 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 6 | 7 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 9.82 | 9.82 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 6 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 30 | 30 | 0 | ⬜ |
| rotation_error (deg) | 12.85 | 12.85 | 0 | ⬜ |
| runtime (min) | 4 | 5 | 1 | ❌ |
| episode_runtime (sec) | 21 | 21 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 5.22 | 5.22 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 13 | 12 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 53.2 | 53.2 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 21 | 21 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.57 | 98.57 | 0 | ⬜ |
| used_mlh (%) | 2.14 | 2.14 | 0 | ⬜ |
| match_steps | 49 | 49 | 0 | ⬜ |
| rotation_error (deg) | 2.39 | 2.39 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 16 | 17 | 1 | ❌ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| used_mlh (%) | 26 | 26 | 0 | ⬜ |
| match_steps | 177 | 177 | 0 | ⬜ |
| rotation_error (deg) | 20.04 | 20.04 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 30 | 27 | -3 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| used_mlh (%) | 27 | 27 | 0 | ⬜ |
| match_steps | 166 | 166 | 0 | ⬜ |
| rotation_error (deg) | 16.89 | 16.89 | 0 | ⬜ |
| runtime (min) | 16 | 18 | 2 | ❌ |
| episode_runtime (sec) | 116 | 129 | 13 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 68 | 68 | 0 | ⬜ |
| used_mlh (%) | 68 | 68 | 0 | ⬜ |
| match_steps | 14 | 14 | 0 | ⬜ |
| rotation_error (deg) | 92.93 | 92.93 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 8 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10multi_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 48.57 | 48.57 | 0 | ⬜ |
| used_mlh (%) | 1.43 | 1.43 | 0 | ⬜ |
| match_steps | 32 | 32 | 0 | ⬜ |
| rotation_error (deg) | 37.74 | 37.74 | 0 | ⬜ |
| runtime (min) | 32 | 35 | 3 | ❌ |
| episode_runtime (sec) | 1 | 2 | 1 | ❌ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.27 | 98.27 | 0 | ⬜ |
| used_mlh (%) | 8.66 | 8.66 | 0 | ⬜ |
| match_steps | 75 | 75 | 0 | ⬜ |
| rotation_error (deg) | 13.68 | 13.68 | 0 | ⬜ |
| runtime (min) | 12 | 13 | 1 | ❌ |
| episode_runtime (sec) | 24 | 24 | 0 | ⬜ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 4.76 | 4.76 | 0 | ⬜ |
| match_steps | 43 | 43 | 0 | ⬜ |
| rotation_error (deg) | 2.27 | 2.27 | 0 | ⬜ |
| runtime (min) | 12 | 15 | 3 | ❌ |
| episode_runtime (sec) | 24 | 28 | 4 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96.97 | 96.97 | 0 | ⬜ |
| used_mlh (%) | 16.88 | 16.88 | 0 | ⬜ |
| match_steps | 123 | 123 | 0 | ⬜ |
| rotation_error (deg) | 24.63 | 24.63 | 0 | ⬜ |
| runtime (min) | 20 | 24 | 4 | ❌ |
| episode_runtime (sec) | 52 | 57 | 5 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99.57 | 99.57 | 0 | ⬜ |
| used_mlh (%) | 15.58 | 15.58 | 0 | ⬜ |
| match_steps | 93 | 93 | 0 | ⬜ |
| rotation_error (deg) | 21.91 | 21.91 | 0 | ⬜ |
| runtime (min) | 35 | 37 | 2 | ❌ |
| episode_runtime (sec) | 95 | 93 | -2 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 92.21 | 92.21 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 38 | 38 | 0 | ⬜ |
| rotation_error (deg) | 47.4 | 47.4 | 0 | ⬜ |
| runtime (min) | 10 | 12 | 2 | ❌ |
| episode_runtime (sec) | 99 | 96 | -3 | ✅ |
| num_episodes | 77 | 77 | 0 | ⬜ |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 10 | 10 | 0 | ⬜ |
| episode_runtime (sec) | 4 | 5 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 23 | 19 | -4 | ✅ |
| episode_runtime (sec) | 12 | 10 | -2 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 90 | 90 | 0 | ⬜ |
| used_mlh (%) | 85 | 85 | 0 | ⬜ |
| match_steps | 444 | 444 | 0 | ⬜ |
| runtime (min) | 27 | 26 | -1 | ✅ |
| episode_runtime (sec) | 174 | 168 | -6 | ✅ |
| num_episodes | 120 | 120 | 0 | ⬜ |

### world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 66.67 | 66.67 | 0 | ⬜ |
| used_mlh (%) | 62.5 | 62.5 | 0 | ⬜ |
| match_steps | 374 | 374 | 0 | ⬜ |
| runtime (min) | 10 | 9 | -1 | ✅ |
| episode_runtime (sec) | 11 | 11 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### dark_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 29.17 | 29.17 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 242 | 242 | 0 | ⬜ |
| runtime (min) | 8 | 8 | 0 | ⬜ |
| episode_runtime (sec) | 9 | 9 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### bright_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 37.5 | 37.5 | 0 | ⬜ |
| used_mlh (%) | 64.58 | 64.58 | 0 | ⬜ |
| match_steps | 413 | 413 | 0 | ⬜ |
| runtime (min) | 12 | 11 | -1 | ✅ |
| episode_runtime (sec) | 14 | 12 | -2 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### hand_intrusion_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 43.75 | 43.75 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 272 | 272 | 0 | ⬜ |
| runtime (min) | 9 | 8 | -1 | ✅ |
| episode_runtime (sec) | 10 | 9 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### multi_object_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 25 | 25 | 0 | ⬜ |
| used_mlh (%) | 2.08 | 2.08 | 0 | ⬜ |
| match_steps | 158 | 158 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 6 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### base_infer_objects_with_stickers_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 81.14 | 81.14 | 0 | ⬜ |
| used_mlh (%) | 90.57 | 90.57 | 0 | ⬜ |
| match_steps | 457 | 457 | 0 | ⬜ |
| rotation_error (deg) | 39.83 | 39.83 | 0 | ⬜ |
| avg_prediction_error | 0.2 | 0.2 | 0 | ⬜ |
| runtime (min) | 596 | 251 | -345 | ✅ |
| num_episodes | 350 | 350 | 0 | ⬜ |

### base_infer_objects_with_stickers_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 72 | 72 | 0 | ⬜ |
| used_mlh (%) | 42.57 | 42.57 | 0 | ⬜ |
| match_steps | 34 | 34 | 0 | ⬜ |
| rotation_error (deg) | 49.35 | 49.35 | 0 | ⬜ |
| avg_prediction_error | 0.3 | 0.3 | 0 | ⬜ |
| runtime (min) | 19 | 19 | 0 | ⬜ |
| num_episodes | 350 | 350 | 0 | ⬜ |
