### PR TITLE
refactor: isolate common MotorPolicy init/reset code

### DIFF
--- a/src/tbp/monty/frameworks/models/motor_policies.py
+++ b/src/tbp/monty/frameworks/models/motor_policies.py
@@ -184,6 +184,12 @@ class BasePolicy(MotorPolicy):
         self.agent_id = agent_id
         self.action_sampler = action_sampler
 
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        pass
+
+    def reset(self) -> None:
+        pass
+
     def __call__(
         self,
         ctx: RuntimeContext,
@@ -210,12 +216,6 @@ class BasePolicy(MotorPolicy):
         """
         return MotorPolicyResult([self.action_sampler.sample(self.agent_id, ctx.rng)])
 
-    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
-        pass
-
-    def reset(self) -> None:
-        pass
-
     def state_dict(self) -> Memento:
         return {}
 
@@ -231,6 +231,8 @@ class InformedPolicyRandomWalk(MotorPolicy):
     however, there are likely better random walk policies to use.
     """
 
+    _undo_action: Action | None
+
     def __init__(
         self,
         agent_id: AgentID,
@@ -245,7 +247,18 @@ class InformedPolicyRandomWalk(MotorPolicy):
         super().__init__()
         self.agent_id = agent_id
         self.action_sampler = action_sampler
-        self._undo_action: Action | None = None
+
+        # TODO: make this part of `__init__()` after `reset()` is removed.
+        self._init_InformedPolicyRandomWalk()
+
+    def _init_InformedPolicyRandomWalk(self) -> None:  # noqa: N802
+        self._undo_action = None
+
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        pass
+
+    def reset(self) -> None:
+        self._init_InformedPolicyRandomWalk()
 
     def __call__(
         self,
@@ -282,12 +295,6 @@ class InformedPolicyRandomWalk(MotorPolicy):
             return MotorPolicyResult([action])
 
         return MotorPolicyResult([])
-
-    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
-        pass
-
-    def reset(self) -> None:
-        self._undo_action = None
 
     def state_dict(self) -> Memento:
         return {"undo_action": self._undo_action}
@@ -396,6 +403,11 @@ class PredefinedPolicy(MotorPolicy):
     ) -> None:
         self.agent_id = agent_id
         self.action_list: list[Action] = PredefinedPolicy.read_action_file(file_name)
+
+        # TODO: make this part of `__init__()` after `reset()` is removed.
+        self._init_PredefinedPolicy()
+
+    def _init_PredefinedPolicy(self) -> None:  # noqa: N802
         self.episode_step = 0
 
     def __call__(
@@ -414,7 +426,7 @@ class PredefinedPolicy(MotorPolicy):
         pass
 
     def reset(self) -> None:
-        self.episode_step = 0
+        self._init_PredefinedPolicy()
 
     def state_dict(self) -> Memento:
         return {"episode_step": self.episode_step}
@@ -430,6 +442,11 @@ class JumpToGoal(MotorPolicy):
     of relying on PositioningProcedure.depth_at_center for undo check.
     """
 
+    _undo_action: Action | None
+    _is_jumping: bool
+    _pre_jump_state: AgentState | None
+    _undo_actions: list[Action]
+
     def __init__(self, agent_id: AgentID, sensor_id: SensorID) -> None:
         """Initialize policy.
 
@@ -440,11 +457,12 @@ class JumpToGoal(MotorPolicy):
         self._agent_id = agent_id
         self._sensor_id = sensor_id
 
-        self._undo_action: Action | None = None
+        # TODO: make this part of `__init__()` after `reset()` is removed.
+        self._init_JumpToGoal()
 
-        self._is_jumping: bool = False
-        self._pre_jump_state: AgentState | None = None
-        self._undo_actions: list[Action] = []
+    def _init_JumpToGoal(self) -> None:  # noqa: N802
+        self._undo_action = None
+        self._reset_jump_state()
 
     def load_state_dict(self, memento: Memento) -> None:
         self._agent_id = memento["agent_id"]
@@ -466,8 +484,7 @@ class JumpToGoal(MotorPolicy):
         pass
 
     def reset(self) -> None:
-        self._undo_action = None
-        self._reset_jump_state()
+        self._init_JumpToGoal()
 
     def __call__(
         self,
@@ -692,6 +709,12 @@ class InformedPolicy(BasePolicy):
 
     """
 
+    _undo_action: Action | None
+    _is_jumping: bool
+    _is_undoing_jump: bool
+    _pre_jump_state: AgentState | None
+    _undo_jump_actions: list[Action]
+
     def __init__(
         self,
         use_goal_driven_actions=False,
@@ -706,20 +729,20 @@ class InformedPolicy(BasePolicy):
         """
         super().__init__(**kwargs)
         self.use_goal_driven_actions = use_goal_driven_actions
-        self._undo_action: Action | None = None
 
-        self._is_jumping: bool = False
-        self._is_undoing_jump: bool = False
-        self._pre_jump_state: AgentState | None = None
-        self._undo_jump_actions: list[Action] = []
+        # TODO: make this part of `__init__()` after `reset()` is removed.
+        self._init_InformedPolicy()
+
+    def _init_InformedPolicy(self) -> None:  # noqa: N802
+        self._undo_action = None
+        self._reset_jump_state()
 
     def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
         return super().fixme_provide_motor_system(motor_system)
 
     def reset(self) -> None:
-        self._undo_action = None
-        self._reset_jump_state()
-        return super().reset()
+        super().reset()
+        self._init_InformedPolicy()
 
     def __call__(
         self,
@@ -985,6 +1008,11 @@ class NaiveScanPolicy(InformedPolicy):
             TurnRight(agent_id=self.agent_id, rotation_degrees=fixed_amount),
         ]
         self.fixed_amount = fixed_amount
+
+        # TODO: make this part of `__init__()` after `reset()` is removed.
+        self._init_NaiveScanPolicy()
+
+    def _init_NaiveScanPolicy(self) -> None:  # noqa: N802
         self.steps_per_action = 1
         self.current_action_id = 0
         self.step_on_action = 0
@@ -1034,9 +1062,7 @@ class NaiveScanPolicy(InformedPolicy):
 
     def reset(self) -> None:
         super().reset()
-        self.steps_per_action = 1
-        self.current_action_id = 0
-        self.step_on_action = 0
+        self._init_NaiveScanPolicy()
 
     def check_cycle_action(self):
         """Makes sure we move in a spiral.
@@ -1073,6 +1099,8 @@ class SurfacePolicy(InformedPolicy):
     functions for moving along an object based on its surface normal.
     """
 
+    last_surface_policy_action: Action | None
+
     def __init__(
         self,
         alpha,
@@ -1089,22 +1117,16 @@ class SurfacePolicy(InformedPolicy):
             **kwargs: ?
         """
         super().__init__(**kwargs)
-        self.tangential_angle = 0
         self.alpha = alpha
         self.desired_object_distance = desired_object_distance
 
         self.attempting_to_find_object: bool = False
-        self.last_surface_policy_action: Action | None = None
         self._telemetry = SurfacePolicyTelemetry()
 
-    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
-        # TODO: This is a hack. What we should be doing is
-        #       using more sophisticated actions for surface agents instead.
-        motor_system.motor_only_step = True
+        # TODO: make this part of `__init__()` after `reset()` is removed.
+        self._init_SurfacePolicy()
 
-        return super().fixme_provide_motor_system(motor_system)
-
-    def reset(self) -> None:
+    def _init_SurfacePolicy(self) -> None:  # noqa: N802
         self.tangential_angle = 0
         self.touch_search_amount = 0  # Track how many rotations the agent has made
         # along the horizontal plane searching for an object; when this reaches 360,
@@ -1113,7 +1135,16 @@ class SurfacePolicy(InformedPolicy):
 
         self.last_surface_policy_action = None
 
-        return super().reset()
+    def fixme_provide_motor_system(self, motor_system: ExperimentMotorSystem) -> None:
+        super().fixme_provide_motor_system(motor_system)
+
+        # TODO: This is a hack. What we should be doing is
+        #       using more sophisticated actions for surface agents instead.
+        motor_system.motor_only_step = True
+
+    def reset(self) -> None:
+        super().reset()
+        self._init_SurfacePolicy()
 
     def _touch_object(
         self,


### PR DESCRIPTION
Put common init/reset code into `_init<ClassName>()` methods and extract some typed properties.

## Benchmarks

### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 10.29 | 10.29 | 0 | ⬜ |
| runtime (min) | 2 | 3 | 1 | ❌ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 3.64 | 3.64 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 11 | 11 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99 | 99 | 0 | ⬜ |
| used_mlh (%) | 2 | 2 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 15.85 | 15.85 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 6 | 7 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 9.82 | 9.82 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 7 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 30 | 30 | 0 | ⬜ |
| rotation_error (deg) | 12.85 | 12.85 | 0 | ⬜ |
| runtime (min) | 4 | 5 | 1 | ❌ |
| episode_runtime (sec) | 21 | 22 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 5.22 | 5.22 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 13 | 11 | -2 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 53.2 | 53.2 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 21 | 20 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.57 | 98.57 | 0 | ⬜ |
| used_mlh (%) | 2.14 | 2.14 | 0 | ⬜ |
| match_steps | 49 | 49 | 0 | ⬜ |
| rotation_error (deg) | 2.39 | 2.39 | 0 | ⬜ |
| runtime (min) | 5 | 6 | 1 | ❌ |
| episode_runtime (sec) | 16 | 17 | 1 | ❌ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| used_mlh (%) | 26 | 26 | 0 | ⬜ |
| match_steps | 177 | 177 | 0 | ⬜ |
| rotation_error (deg) | 20.04 | 20.04 | 0 | ⬜ |
| runtime (min) | 6 | 7 | 1 | ❌ |
| episode_runtime (sec) | 30 | 29 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| used_mlh (%) | 27 | 27 | 0 | ⬜ |
| match_steps | 166 | 166 | 0 | ⬜ |
| rotation_error (deg) | 16.89 | 16.89 | 0 | ⬜ |
| runtime (min) | 16 | 20 | 4 | ❌ |
| episode_runtime (sec) | 116 | 146 | 30 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 68 | 68 | 0 | ⬜ |
| used_mlh (%) | 68 | 68 | 0 | ⬜ |
| match_steps | 14 | 14 | 0 | ⬜ |
| rotation_error (deg) | 92.93 | 92.93 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 6 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10multi_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 48.57 | 48.57 | 0 | ⬜ |
| used_mlh (%) | 1.43 | 1.43 | 0 | ⬜ |
| match_steps | 32 | 32 | 0 | ⬜ |
| rotation_error (deg) | 37.74 | 37.74 | 0 | ⬜ |
| runtime (min) | 32 | 37 | 5 | ❌ |
| episode_runtime (sec) | 1 | 2 | 1 | ❌ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.27 | 98.27 | 0 | ⬜ |
| used_mlh (%) | 8.66 | 8.66 | 0 | ⬜ |
| match_steps | 75 | 75 | 0 | ⬜ |
| rotation_error (deg) | 13.68 | 13.68 | 0 | ⬜ |
| runtime (min) | 12 | 14 | 2 | ❌ |
| episode_runtime (sec) | 24 | 25 | 1 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 4.76 | 4.76 | 0 | ⬜ |
| match_steps | 43 | 43 | 0 | ⬜ |
| rotation_error (deg) | 2.27 | 2.27 | 0 | ⬜ |
| runtime (min) | 12 | 15 | 3 | ❌ |
| episode_runtime (sec) | 24 | 28 | 4 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96.97 | 96.97 | 0 | ⬜ |
| used_mlh (%) | 16.88 | 16.88 | 0 | ⬜ |
| match_steps | 123 | 123 | 0 | ⬜ |
| rotation_error (deg) | 24.63 | 24.63 | 0 | ⬜ |
| runtime (min) | 20 | 24 | 4 | ❌ |
| episode_runtime (sec) | 52 | 55 | 3 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99.57 | 99.57 | 0 | ⬜ |
| used_mlh (%) | 15.58 | 15.58 | 0 | ⬜ |
| match_steps | 93 | 93 | 0 | ⬜ |
| rotation_error (deg) | 21.91 | 21.91 | 0 | ⬜ |
| runtime (min) | 35 | 36 | 1 | ❌ |
| episode_runtime (sec) | 95 | 89 | -6 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 92.21 | 92.21 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 38 | 38 | 0 | ⬜ |
| rotation_error (deg) | 47.4 | 47.4 | 0 | ⬜ |
| runtime (min) | 10 | 12 | 2 | ❌ |
| episode_runtime (sec) | 99 | 97 | -2 | ✅ |
| num_episodes | 77 | 77 | 0 | ⬜ |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 10 | 12 | 2 | ❌ |
| episode_runtime (sec) | 4 | 5 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 23 | 23 | 0 | ⬜ |
| episode_runtime (sec) | 12 | 12 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 90 | 90 | 0 | ⬜ |
| used_mlh (%) | 85 | 85 | 0 | ⬜ |
| match_steps | 444 | 444 | 0 | ⬜ |
| runtime (min) | 27 | 27 | 0 | ⬜ |
| episode_runtime (sec) | 174 | 170 | -4 | ✅ |
| num_episodes | 120 | 120 | 0 | ⬜ |

### world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 66.67 | 66.67 | 0 | ⬜ |
| used_mlh (%) | 62.5 | 62.5 | 0 | ⬜ |
| match_steps | 374 | 374 | 0 | ⬜ |
| runtime (min) | 10 | 10 | 0 | ⬜ |
| episode_runtime (sec) | 11 | 11 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### dark_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 29.17 | 29.17 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 242 | 242 | 0 | ⬜ |
| runtime (min) | 8 | 8 | 0 | ⬜ |
| episode_runtime (sec) | 9 | 9 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### bright_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 37.5 | 37.5 | 0 | ⬜ |
| used_mlh (%) | 64.58 | 64.58 | 0 | ⬜ |
| match_steps | 413 | 413 | 0 | ⬜ |
| runtime (min) | 12 | 11 | -1 | ✅ |
| episode_runtime (sec) | 14 | 13 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### hand_intrusion_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 43.75 | 43.75 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 272 | 272 | 0 | ⬜ |
| runtime (min) | 9 | 9 | 0 | ⬜ |
| episode_runtime (sec) | 10 | 10 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### multi_object_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 25 | 25 | 0 | ⬜ |
| used_mlh (%) | 2.08 | 2.08 | 0 | ⬜ |
| match_steps | 158 | 158 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 6 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### base_infer_objects_with_stickers_monolithic_models

_...coming soon..._

### base_infer_objects_with_stickers_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 72 | 72 | 0 | ⬜ |
| used_mlh (%) | 42.57 | 42.57 | 0 | ⬜ |
| match_steps | 34 | 34 | 0 | ⬜ |
| rotation_error (deg) | 49.35 | 49.35 | 0 | ⬜ |
| avg_prediction_error | 0.3 | 0.3 | 0 | ⬜ |
| runtime (min) | 19 | 19 | 0 | ⬜ |
| num_episodes | 350 | 350 | 0 | ⬜ |
