### PR TITLE
refactor!: salience goals explicitly for motor system only

### DIFF
--- a/src/tbp/monty/frameworks/models/salience/sensor_module.py
+++ b/src/tbp/monty/frameworks/models/salience/sensor_module.py
@@ -116,7 +116,7 @@ class SalienceSM(SensorModule):
                 morphological_features=None,
                 non_morphological_features=None,
                 confidence=salience[i],
-                use_state=True,
+                use_state=False,  # SalienceSM goals are intended for the motor system
                 sender_id=self._sensor_module_id,
                 sender_type="SM",
                 goal_tolerances=None,

--- a/tests/unit/frameworks/models/salience/sensor_module_test.py
+++ b/tests/unit/frameworks/models/salience/sensor_module_test.py
@@ -137,7 +137,7 @@ class SalienceSMTest(unittest.TestCase):
             expected_goal = Goal(
                 location=locations[i],
                 confidence=salience[i],
-                use_state=True,
+                use_state=False,
                 morphological_features=None,
                 non_morphological_features=None,
                 goal_tolerances=None,


### PR DESCRIPTION
When `SalienceSM` was created in #511, we incorrectly set `use_state=True`. However, the goals generated by the `SalienceSM` are intended only for the motor system. ~~This is a latent bug, but it hasn't manifested~~ This has not been a problem because we haven't configured a `SalienceSM` to connect to any learning module, and the goals are saved on `self._goals` property and not returned from `SalienceSM.step(...)`.

This pull request correctly sets `use_state=True` on a goal originating from `SalienceSM`.

## Breaking Changes

- The `Goal`s produced by the `SalienceSM` are no longer routable to learning modules because now `use_state=False`.

## Why this is not a bug yet

Currently, goals are returned via `propose_goals()` method (which returns contents of `self._goals`), and these are only sent to the motor system:
```python
    def _pass_goals(self) -> None:
        """Pass goals between learning modules.

        Currently we just aggregate these for later passing to the (single) motor
        system.

        TODO M implement more complex, hierarchical passing of goals.
        """
        self._goals = []
        for lm in self.learning_modules:
            goals = lm.propose_goals()
            self._goals.extend(goals)
        for sm in self.sensor_modules:
            goals = sm.propose_goals()
            self._goals.extend(goals)

    def _step_motor_system(
        self,
        ctx: RuntimeContext,
        observations: Observations,
        proprioceptive_state: ProprioceptiveState,
    ) -> None:
        self._actions = self.motor_system(
            ctx,
            observations,
            proprioceptive_state,
            self.sensor_module_outputs[0],
            self._goals, # <-- goals
        )
```
However, note that `TODO`: "TODO M implement more complex, hierarchical passing of goals." When we implement the TODO, we could have a problem.

As far as connectivity goes...

The only time we use `SalienceSM`, we use it as a `"view_finder"`, which we do not connect to learning modules:
```
src/tbp/monty/conf/monty/sensor_module/5sm_camera_dist_noise.yaml:
  48  sensor_module_5:
  49:   _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  50    sensor_module_id: view_finder

src/tbp/monty/conf/monty/sensor_module/camera_dist_delta_salience.yaml:
  26  sensor_module_1:
  27:   _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  28    sensor_module_id: view_finder

src/tbp/monty/conf/monty/sensor_module/camera_dist_noise_raw1_salience.yaml:
  23  sensor_module_1:
  24:   _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  25    sensor_module_id: view_finder

src/tbp/monty/conf/monty/sensor_module/camera_dist_noise_vocus2.yaml:
  23  sensor_module_1:
  24:   _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  25    sensor_module_id: view_finder

src/tbp/monty/conf/monty/sensor_module/camera_dist_vocus2.yaml:
  26  sensor_module_1:
  27:   _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  28    sensor_module_id: view_finder

tests/conf/snapshots/base_77obj_dist_agent.yaml:
  87          sensor_module_1:
  88:           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  89            sensor_module_id: view_finder

tests/conf/snapshots/base_config_10distinctobj_dist_agent_mujoco.yaml:
  87          sensor_module_1:
  88:           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  89            sensor_module_id: view_finder

tests/conf/snapshots/base_config_10distinctobj_dist_agent.yaml:
  87          sensor_module_1:
  88:           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  89            sensor_module_id: view_finder

tests/conf/snapshots/randrot_noise_10distinctobj_5lms_dist_agent.yaml:
  232          sensor_module_5:
  233:           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  234            sensor_module_id: view_finder

tests/conf/snapshots/randrot_noise_10distinctobj_dist_agent.yaml:
  84          sensor_module_1:
  85:           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  86            sensor_module_id: view_finder

tests/conf/snapshots/randrot_noise_10distinctobj_dist_on_distm.yaml:
  84          sensor_module_1:
  85:           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  86            sensor_module_id: view_finder

tests/conf/snapshots/randrot_noise_10distinctobj_vocus_on_vocusm.yaml:
  84          sensor_module_1:
  85:           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  86            sensor_module_id: view_finder

tests/conf/snapshots/randrot_noise_10simobj_dist_agent.yaml:
  84          sensor_module_1:
  85:           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  86            sensor_module_id: view_finder

tests/conf/snapshots/randrot_noise_77obj_5lms_dist_agent.yaml:
  232          sensor_module_5:
  233:           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  234            sensor_module_id: view_finder

tests/conf/snapshots/randrot_noise_77obj_dist_agent.yaml:
  84          sensor_module_1:
  85:           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  86            sensor_module_id: view_finder

tests/conf/snapshots/supervised_pre_training_10distinctobj_vocus2.yaml:
  76          sensor_module_1:
  77:           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
  78            sensor_module_id: view_finder
```

Because these are not connected to learning modules, we never check `use_state` on the goals emitted, which means these sensor module outputs were never routed to learning modules before.

```python
# src/tbp/monty/frameworks/models/monty_base.py

    def _collect_inputs_to_lm(self, lm_id: int) -> list[Message]:
        # ...
        sensory_inputs_from_sms = [
            self.sensor_module_outputs[j] for j in self.sm_to_lm_matrix[lm_id]
        ]
        # ...
        return self._combine_inputs(sensory_inputs_from_sms, sensory_inputs_from_lms)

    def _combine_inputs(
        self, inputs_from_sms: Sequence[Message], inputs_from_lms: Sequence[Message]
    ) -> list[Message]:
        # ...
        combined_inputs = [
            inputs_from_sms[i]
            for i in range(len(inputs_from_sms))
            if inputs_from_sms[i].use_state
        ]
        # ...
        return combined_inputs
```

None of this will change. But if we ever mess up the routing or allow goals to reach learning modules, this pull request will ensure that `_combine_inputs` or future goal-routing logic will not pass these goals to the learning module.