### PR TITLE
chore: update sanity checks to fix one broken test when run locally on macs

### DIFF
--- a/tools/github_readme_sync/hierarchy.py
+++ b/tools/github_readme_sync/hierarchy.py
@@ -121,7 +121,7 @@ def check_hierarchy_file(folder: str):
                 link_check_errors.extend(errors)
 
             file_path = folder.joinpath(extract_file_path(line))
-            file_path_errors = sanity_check_file_path(file_path)
+            file_path_errors = sanity_check_file_path(file_path, folder)
             if file_path_errors:
                 link_check_errors.extend(file_path_errors)
 
@@ -161,7 +161,18 @@ def sanity_check_slugs(path, folder):
     return check_links(path)
 
 
-def sanity_check_file_path(path):
+def sanity_check_file_path(path, folder):
+    # Path casing is checked relative to the docs folder. Absolute prefixes
+    # (e.g. macOS tempfile /var/folders/.../T/) are outside our control and
+    # may contain uppercase segments even when all docs paths are lowercase.
+    relative_path = Path(path).relative_to(folder)
+    if str(relative_path) != str(relative_path).lower():
+        return [
+            f"File {path} does not exist based on capitalization - "
+            "check what's in the () in hierarchy.md "
+            "to make sure everything is lowercase"
+        ]
+        
     if not path.exists():
         return [
             f"File {path} does not exist based on file path - "

--- a/tools/github_readme_sync/hierarchy.py
+++ b/tools/github_readme_sync/hierarchy.py
@@ -172,7 +172,7 @@ def sanity_check_file_path(path, folder):
             "check what's in the () in hierarchy.md "
             "to make sure everything is lowercase"
         ]
-        
+
     if not path.exists():
         return [
             f"File {path} does not exist based on file path - "

--- a/tools/github_readme_sync/hierarchy.py
+++ b/tools/github_readme_sync/hierarchy.py
@@ -116,7 +116,7 @@ def check_hierarchy_file(folder: str):
             parent_stack.append(new_doc)
 
             slug_path = folder.joinpath(*[el["slug"] for el in parent_stack])
-            errors = sanity_check_slugs(slug_path.with_suffix(".md"))
+            errors = sanity_check_slugs(slug_path.with_suffix(".md"), folder)
             if errors:
                 link_check_errors.extend(errors)
 
@@ -140,8 +140,12 @@ def extract_slug(line: str):
     return match.group(1)
 
 
-def sanity_check_slugs(path):
-    if str(path) != str(path).lower():
+def sanity_check_slugs(path, folder):
+    # Path casing is checked relative to the docs folder. Absolute prefixes
+    # (e.g. macOS tempfile /var/folders/.../T/) are outside our control and
+    # may contain uppercase segments even when all docs paths are lowercase.
+    relative_path = Path(path).relative_to(folder)
+    if str(relative_path) != str(relative_path).lower():
         return [
             f"File {path} does not exist based on slugs capitalization - "
             "check what's in the [] in hierarchy.md "


### PR DESCRIPTION
Locally we would get an error (below) because on Macs, temp directories have that capital 'T' that fail our new checker for only lower case docs paths. So I updated our checker to only test for the relative path, which should always be lower case and ignores the temp directory path.




```
if link_check_errors:
            for error in link_check_errors:
                logger.error(error)
>           sys.exit(1)
E           SystemExit: 1

tools/github_readme_sync/hierarchy.py:131: SystemExit
-------------------------------------------------------- Captured log call --------------------------------------------------------
ERROR    tools.github_readme_sync.hierarchy:hierarchy.py:130 File /var/folders/sm/klbtjmn17vxfl10knt_t13480000gn/T/tmpimsmvk24/category-1/doc-1.md does not exist based on slugs capitalization - check what's in the [] in hierarchy.md to make sure everything is lowercase
===================================================== short test summary info =====================================================
FAILED tools/github_readme_sync/tests/hierarchy_test.py::TestHierarchyFile::test_check_hierarchy_file_success - SystemExit: 1
```