### PR TITLE
feat: make SaccadeOnImageEnvironment camera HFOV and depth clip configurable

### DIFF
--- a/src/tbp/monty/frameworks/environments/two_d_data.py
+++ b/src/tbp/monty/frameworks/environments/two_d_data.py
@@ -266,15 +266,31 @@ class SaccadeOnImageEnvironment(SimulatedEnvironment):
     Images should be stored in .png format for rgb and .data format for depth.
     """
 
-    def __init__(self, patch_size: int = 64, data_path: str | Path | None = None):
+    def __init__(
+        self,
+        patch_size: int = 64,
+        data_path: str | Path | None = None,
+        hfov: float = 54.201,
+        depth_clip_value: float = 1.1,
+    ):
         """Initialize environment.
 
         Args:
             patch_size: height and width of patch in pixels, defaults to 64
             data_path: path to the image dataset. If None, defaults to
                 ~/tbp/data/worldimages/labeled_scenes/
+            hfov: horizontal field of view (degrees) of the camera that captured
+                the images, used to unproject depth into 3D. Defaults to 54.201,
+                the iPad front camera; set it to your camera's HFOV for other
+                devices.
+            depth_clip_value: depth (meters) beyond which points are treated as
+                background when unprojecting. Defaults to 1.1, tuned for the
+                iPad-range Monty Meets World captures; raise it for cameras
+                imaging farther scenes.
         """
         self.patch_size = patch_size
+        self.hfov = hfov
+        self.depth_clip_value = depth_clip_value
         # Images are always presented upright so patch and agent rotation is always
         # the same. Since we don't use this, value doesn't matter much.
         self.rotation = qt.from_rotation_vector([np.pi / 2, 0.0, 0.0])
@@ -567,14 +583,14 @@ class SaccadeOnImageEnvironment(SimulatedEnvironment):
             resolutions=[self.current_depth_image.shape],
             world_coord=True,
             zooms=1,
-            # hfov of iPad front camera from
-            # https://developer.apple.com/library/archive/documentation/DeviceInformation/Reference/iOSDeviceCompatibility/Cameras/Cameras.html
-            # TODO: determine dynamically which device is sending data
-            hfov=54.201,
+            # Camera HFOV. Defaults to the iPad front camera (54.201 deg,
+            # https://developer.apple.com/library/archive/documentation/DeviceInformation/Reference/iOSDeviceCompatibility/Cameras/Cameras.html)
+            # but is configurable so images from other cameras unproject correctly.
+            hfov=self.hfov,
             get_all_points=True,
             use_semantic_sensor=False,
             depth_clip_sensors=[0],
-            clip_value=1.1,
+            clip_value=self.depth_clip_value,
         )
         obs_3d = transform.call(obs, state=state)
         current_scene_point_cloud = obs_3d[agent_id][sensor_id]["semantic_3d"]
@@ -688,16 +704,30 @@ class SaccadeOnImageEnvironment(SimulatedEnvironment):
 class SaccadeOnImageFromStreamEnvironment(SaccadeOnImageEnvironment):
     """Environment for moving over a 2D streamed image with depth channel."""
 
-    def __init__(self, patch_size: int = 64, data_path: str | Path | None = None):
+    def __init__(
+        self,
+        patch_size: int = 64,
+        data_path: str | Path | None = None,
+        hfov: float = 54.201,
+        depth_clip_value: float = 1.1,
+    ):
         """Initialize environment.
 
         Args:
             patch_size: height and width of patch in pixels, defaults to 64
             data_path: path to the image dataset. If None, defaults to
                 ~/tbp/data/worldimages/world_data_stream/
+            hfov: horizontal field of view (degrees) of the capturing camera,
+                used to unproject depth into 3D. Defaults to 54.201 (iPad front
+                camera); set it to your camera's HFOV for other devices.
+            depth_clip_value: depth (meters) beyond which points are treated as
+                background when unprojecting. Defaults to 1.1; raise it for
+                cameras imaging farther scenes.
         """
         # TODO: use super() to avoid repeating lines of code
         self.patch_size = patch_size
+        self.hfov = hfov
+        self.depth_clip_value = depth_clip_value
         # Letters are always presented upright
         self.rotation = qt.from_rotation_vector([np.pi / 2, 0.0, 0.0])
         self.state = 0

--- a/tests/integration/frameworks/environments/saccade_on_image_environment_test.py
+++ b/tests/integration/frameworks/environments/saccade_on_image_environment_test.py
@@ -43,6 +43,21 @@ class TwoDMovementTest(unittest.TestCase):
         self.current_state = self.env._state()
         self.prev_loc = self.current_state[AGENT_ID].sensors[SENSOR_ID].position
 
+    def test_configurable_camera_intrinsics(self):
+        """Camera HFOV and depth clip are configurable; defaults preserve iPad."""
+        # Defaults are backward-compatible (iPad front camera).
+        self.assertAlmostEqual(self.env.hfov, 54.201)
+        self.assertAlmostEqual(self.env.depth_clip_value, 1.1)
+        # Custom values flow through to the environment.
+        env = SaccadeOnImageEnvironment(
+            patch_size=48,
+            data_path=str(self.DATA_PATH) + "/",
+            hfov=90.0,
+            depth_clip_value=2.0,
+        )
+        self.assertAlmostEqual(env.hfov, 90.0)
+        self.assertAlmostEqual(env.depth_clip_value, 2.0)
+
     def test_move_forward(self):
         action = MoveForward(agent_id=AGENT_ID, distance=1)
         _ = self.env.step([action])


### PR DESCRIPTION
Following up on the forum thread [Recognition through movement on real RGB-D data](https://forum.thousandbrains.org/t/recognition-through-movement-on-real-rgb-d-data-what-one-moving-sensor-buys-and-the-failure-it-introduces/1158) — @vclay suggested opening a PR for the hard-coded `hfov` (thanks for the pointer!).

`SaccadeOnImageEnvironment.get_3d_scene_point_cloud` hard-coded the iPad front camera's HFOV (`54.201` deg) and a `1.1` m depth clip when unprojecting depth into 3D, so images from any other camera unproject with the wrong geometry. This is the in-code `TODO: determine dynamically which device is sending data`.

This PR exposes both as constructor arguments on `SaccadeOnImageEnvironment` and `SaccadeOnImageFromStreamEnvironment`:

- `hfov: float = 54.201`
- `depth_clip_value: float = 1.1`

Defaults preserve the existing iPad values, so current behavior is unchanged; images from other cameras can now unproject correctly by passing their own HFOV / clip.

## Testing
- Added `test_configurable_camera_intrinsics` (checks the defaults are backward-compatible and that custom values flow through).
- `pytest` on the saccade-on-image env: 7 passed.
- `ruff check` / `ruff format`: clean.
