### PR TITLE
refactor!: more complete snapshot/restore for `NoReset*` classes

### DIFF
--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -63,7 +63,7 @@ class MontyExperiment:
 
     _recreation_mode: bool
     _monty_cfg: DictConfig | None  # dehydrated Monty config
-    _monty_ltm: Memento
+    _monty_memo: Memento
     _step_hook: StepHook
 
     def __init__(self, config: DictConfig) -> None:
@@ -77,7 +77,7 @@ class MontyExperiment:
         # Feature flag for "recreation" episode/epoch strategy.
         self._recreation_mode = False
         self._monty_cfg = None
-        self._monty_ltm = {}
+        self._monty_memo = {}
 
         self.rng = np.random.RandomState(config["seed"])
 
@@ -457,14 +457,14 @@ class MontyExperiment:
 
     def _snapshot_monty(self) -> None:
         """Capture episodic state of Monty model."""
-        self._monty_ltm = self.model.snapshot_ltm()
+        self._monty_memo = self.model.snapshot()
 
     def _restore_monty(self) -> None:
         """Recreate episodic state of Monty model."""
         if self._recreation_mode:
             self._create_monty()
-            if self._monty_ltm:
-                self.model.restore_ltm(self._monty_ltm)
+            if self._monty_memo:
+                self.model.restore(self._monty_memo)
             self.logger_handler.model = self.model
         else:
             self.model.reset()

--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -129,12 +129,12 @@ class RuntimeMonty(Protocol):
         """
         ...
 
-    def snapshot_ltm(self) -> Memento:
-        """Return an opaque snapshot of long-term memory."""
+    def snapshot(self) -> Memento:
+        """Return an opaque snapshot of Monty state."""
         ...
 
-    def restore_ltm(self, memo: Memento) -> None:
-        """Restore long-term memory from an opaque snapshot."""
+    def restore(self, memo: Memento) -> None:
+        """Restore Monty state from an opaque snapshot."""
         ...
 
 
@@ -285,11 +285,11 @@ class Monty(ExperimentMonty, RuntimeMonty, Snapshotable, metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def snapshot_ltm(self) -> Memento:
+    def snapshot(self) -> Memento:
         pass
 
     @abc.abstractmethod
-    def restore_ltm(self, memo: Memento) -> None:
+    def restore(self, memo: Memento) -> None:
         pass
 
     @abc.abstractmethod

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -397,16 +397,21 @@ class MontyBase(Monty):
         self.motor_system.reset()
         self._goals = []
 
-    def snapshot_ltm(self) -> Memento:
-        return {"lms": [copy.deepcopy(lm.state_dict()) for lm in self.learning_modules]}
+    def snapshot(self) -> Memento:
+        lm_dict: dict[int, Memento] = {
+            idx: lm.state_dict() for idx, lm in enumerate(self.learning_modules)
+        }
+        return {
+            "lm_dict": copy.deepcopy(lm_dict),
+        }
 
-    def restore_ltm(self, memo: Memento) -> None:
-        memo_lms: list[Memento] = memo["lms"]
+    def restore(self, memo: Memento) -> None:
+        lm_dict: dict[int, Memento] = memo["lm_dict"]
         # TODO: this is a weak compatibility check, make it stronger.
-        if len(memo_lms) != len(self.learning_modules):
+        if len(lm_dict) != len(self.learning_modules):
             raise ValueError("Incompatible Memento (different number of LMs)")
         for idx, lm in enumerate(self.learning_modules):
-            m: Memento = memo_lms[idx]
+            m: Memento = lm_dict[idx]
             lm.load_state_dict(copy.deepcopy(m))
 
     def fixme_set_ground_truth(

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -398,20 +398,20 @@ class MontyBase(Monty):
         self._goals = []
 
     def snapshot(self) -> Memento:
-        lm_dict: dict[int, Memento] = {
-            idx: lm.state_dict() for idx, lm in enumerate(self.learning_modules)
+        lm_dict = {
+            lm.learning_module_id: lm.state_dict() for lm in self.learning_modules
         }
         return {
             "lm_dict": copy.deepcopy(lm_dict),
         }
 
     def restore(self, memo: Memento) -> None:
-        lm_dict: dict[int, Memento] = memo["lm_dict"]
+        lm_dict = memo["lm_dict"]
         # TODO: this is a weak compatibility check, make it stronger.
         if len(lm_dict) != len(self.learning_modules):
             raise ValueError("Incompatible Memento (different number of LMs)")
-        for idx, lm in enumerate(self.learning_modules):
-            m: Memento = lm_dict[idx]
+        for lm in self.learning_modules:
+            m: Memento = lm_dict[lm.learning_module_id]
             lm.load_state_dict(copy.deepcopy(m))
 
     def fixme_set_ground_truth(

--- a/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
@@ -148,15 +148,23 @@ class NoResetEvidenceGraphLM(TheoreticalLimitLMLoggingMixin, EvidenceGraphLM):
         self._init_NoResetEvidenceGraphLM()
 
     def state_dict(self) -> Memento:
-        memo = dict(super().state_dict())
-        memo["_hypotheses"] = self._hypotheses
-        return memo
+        return {
+            "graph_memory": self.graph_memory.state_dict(),
+            "target_to_graph_id": self.target_to_graph_id,
+            "graph_id_to_target": self.graph_id_to_target,
+            "_hypotheses": self._hypotheses,
+        }
 
     def load_state_dict(self, memento: Memento) -> None:
         memo = dict(memento)
         self._hypotheses = memo.pop("_hypotheses", {})
-        # IMPORTANT! call superclass last to complete initialization
-        super().load_state_dict(memo)
+        self.graph_memory.load_state_dict(memo.pop("graph_memory"))
+        self.target_to_graph_id = memo.pop("target_to_graph_id")
+        self.graph_id_to_target = memo.pop("graph_id_to_target")
+
+        # After loading the long-term memory, give the LM a chance to
+        # update any internal state based on the contents of memory.
+        self.init_from_ltm()
 
     def _add_displacements(self, percepts: list[Message]) -> list[Message]:
         """Add displacements to the current percept.

--- a/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
+++ b/src/tbp/monty/frameworks/models/no_reset_evidence_matching.py
@@ -8,6 +8,7 @@
 # https://opensource.org/licenses/MIT.
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 import numpy as np
@@ -26,6 +27,7 @@ from tbp.monty.frameworks.models.evidence_matching.model import (
 from tbp.monty.frameworks.models.mixins.no_reset_evidence import (
     TheoreticalLimitLMLoggingMixin,
 )
+from tbp.monty.memento import Memento
 
 __all__ = ["MontyForNoResetEvidenceGraphMatching", "NoResetEvidenceGraphLM"]
 
@@ -72,6 +74,13 @@ class MontyForNoResetEvidenceGraphMatching(MontyForEvidenceGraphMatching):
         # TODO: Remove initialization logic from `reset`
         self._super_reset_called = False
         self._super_set_ground_truth_called = False
+
+    def snapshot(self) -> Memento:
+        memo: Memento = self.state_dict()
+        return copy.deepcopy(memo)
+
+    def restore(self, memo: Memento) -> None:
+        self.load_state_dict(copy.deepcopy(memo))
 
     def reset(self) -> None:
         if not self._super_reset_called:
@@ -137,6 +146,17 @@ class NoResetEvidenceGraphLM(TheoreticalLimitLMLoggingMixin, EvidenceGraphLM):
     def reset_stm(self) -> None:
         super().reset_stm()
         self._init_NoResetEvidenceGraphLM()
+
+    def state_dict(self) -> Memento:
+        memo = dict(super().state_dict())
+        memo["_hypotheses"] = self._hypotheses
+        return memo
+
+    def load_state_dict(self, memento: Memento) -> None:
+        memo = dict(memento)
+        self._hypotheses = memo.pop("_hypotheses", {})
+        # IMPORTANT! call superclass last to complete initialization
+        super().load_state_dict(memo)
 
     def _add_displacements(self, percepts: list[Message]) -> list[Message]:
         """Add displacements to the current percept.

--- a/tests/integration/frameworks/models/no_reset_evidence_lm_test.py
+++ b/tests/integration/frameworks/models/no_reset_evidence_lm_test.py
@@ -91,6 +91,7 @@ class NoResetEvidenceLMTest(BaseGraphTest):
             # load the eval experiment with the pretrained models
             pretrained_models = train_exp.model.learning_modules[0].state_dict()
             eval_exp.model.learning_modules[0].load_state_dict(pretrained_models)
+            eval_exp._snapshot_monty()
 
             eval_exp.experiment_mode = ExperimentMode.EVAL
             eval_exp.model.set_experiment_mode(eval_exp.experiment_mode)

--- a/tests/integration/frameworks/models/no_reset_evidence_lm_test.py
+++ b/tests/integration/frameworks/models/no_reset_evidence_lm_test.py
@@ -91,6 +91,15 @@ class NoResetEvidenceLMTest(BaseGraphTest):
             # load the eval experiment with the pretrained models
             pretrained_models = train_exp.model.learning_modules[0].state_dict()
             eval_exp.model.learning_modules[0].load_state_dict(pretrained_models)
+
+            # This test assumes that the Monty instance, and the learning modules
+            # in particular, remain stable throughout the test, which is the case
+            # when using the "reset" strategy. However, with the "recreation" strategy
+            # we get a new instance each time `pre_episode()` is called, so we use
+            # the internal `_snapshot_monty()` method to prepare a Memento for use
+            # in re-creating Monty.
+            # TODO: redesign experiments to use Memento snapshots to set Monty to
+            # the state needed for the test and avoid using the "reset" mechanism.
             eval_exp._snapshot_monty()
 
             eval_exp.experiment_mode = ExperimentMode.EVAL


### PR DESCRIPTION
The equivalent of "no reset" between episodes is "remember (almost) everything". This PR overrides the `snapshot()` and `restore()` methods of `MontyForNoResetEvidenceGraphMatching`, and the `state_dict()` and `load_state_dict()` methods of `NoResetEvidenceGraphLM`, to capture and (after re-creation) restore more of Monty's episodic state.

## Breaking Changes
- `Monty.snapshot_ltm()` becomes `Monty.snapshot()`
- `Monty.restore_ltm()` becomes `Monty.restore()`
- The internal structure of the `Memento` is revised to match `Monty.state_dict()`

## Benchmarks

_**Note**: all benchmarks run with `Experiment._recreation_mode = False`._

<details>
<summary>No significant changes...</summary>

### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 10.29 | 10.29 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 3.64 | 3.64 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 11 | 13 | 2 | ❌ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99 | 99 | 0 | ⬜ |
| used_mlh (%) | 2 | 2 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 15.85 | 15.85 | 0 | ⬜ |
| runtime (min) | 2 | 3 | 1 | ❌ |
| episode_runtime (sec) | 6 | 7 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 9.82 | 9.82 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 7 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 30 | 30 | 0 | ⬜ |
| rotation_error (deg) | 12.85 | 12.85 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 21 | 19 | -2 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 5.22 | 5.22 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 13 | 11 | -2 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 53.2 | 53.2 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 21 | 20 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.57 | 98.57 | 0 | ⬜ |
| used_mlh (%) | 2.14 | 2.14 | 0 | ⬜ |
| match_steps | 49 | 49 | 0 | ⬜ |
| rotation_error (deg) | 2.39 | 2.39 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 16 | 17 | 1 | ❌ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 97 | 97 | 0 | ⬜ |
| used_mlh (%) | 26 | 26 | 0 | ⬜ |
| match_steps | 177 | 177 | 0 | ⬜ |
| rotation_error (deg) | 20.04 | 20.04 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 30 | 27 | -3 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| used_mlh (%) | 27 | 27 | 0 | ⬜ |
| match_steps | 166 | 166 | 0 | ⬜ |
| rotation_error (deg) | 16.89 | 16.89 | 0 | ⬜ |
| runtime (min) | 16 | 18 | 2 | ❌ |
| episode_runtime (sec) | 116 | 132 | 16 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 68 | 68 | 0 | ⬜ |
| used_mlh (%) | 68 | 68 | 0 | ⬜ |
| match_steps | 14 | 14 | 0 | ⬜ |
| rotation_error (deg) | 92.93 | 92.93 | 0 | ⬜ |
| runtime (min) | 5 | 5 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 7 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10multi_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 48.57 | 48.57 | 0 | ⬜ |
| used_mlh (%) | 1.43 | 1.43 | 0 | ⬜ |
| match_steps | 32 | 32 | 0 | ⬜ |
| rotation_error (deg) | 37.74 | 37.74 | 0 | ⬜ |
| runtime (min) | 32 | 34 | 2 | ❌ |
| episode_runtime (sec) | 1 | 1 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.27 | 98.27 | 0 | ⬜ |
| used_mlh (%) | 8.66 | 8.66 | 0 | ⬜ |
| match_steps | 75 | 75 | 0 | ⬜ |
| rotation_error (deg) | 13.68 | 13.68 | 0 | ⬜ |
| runtime (min) | 12 | 14 | 2 | ❌ |
| episode_runtime (sec) | 24 | 24 | 0 | ⬜ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 4.76 | 4.76 | 0 | ⬜ |
| match_steps | 43 | 43 | 0 | ⬜ |
| rotation_error (deg) | 2.27 | 2.27 | 0 | ⬜ |
| runtime (min) | 12 | 14 | 2 | ❌ |
| episode_runtime (sec) | 24 | 27 | 3 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96.97 | 96.97 | 0 | ⬜ |
| used_mlh (%) | 16.88 | 16.88 | 0 | ⬜ |
| match_steps | 123 | 123 | 0 | ⬜ |
| rotation_error (deg) | 24.63 | 24.63 | 0 | ⬜ |
| runtime (min) | 20 | 23 | 3 | ❌ |
| episode_runtime (sec) | 52 | 55 | 3 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 99.57 | 99.57 | 0 | ⬜ |
| used_mlh (%) | 15.58 | 15.58 | 0 | ⬜ |
| match_steps | 93 | 93 | 0 | ⬜ |
| rotation_error (deg) | 21.91 | 21.91 | 0 | ⬜ |
| runtime (min) | 35 | 37 | 2 | ❌ |
| episode_runtime (sec) | 95 | 91 | -4 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 92.21 | 92.21 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 38 | 38 | 0 | ⬜ |
| rotation_error (deg) | 47.4 | 47.4 | 0 | ⬜ |
| runtime (min) | 10 | 11 | 1 | ❌ |
| episode_runtime (sec) | 99 | 87 | -12 | ✅ |
| num_episodes | 77 | 77 | 0 | ⬜ |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 10 | 11 | 1 | ❌ |
| episode_runtime (sec) | 4 | 5 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| match_steps | 98 | 98 | 0 | ⬜ |
| runtime (min) | 23 | 22 | -1 | ✅ |
| episode_runtime (sec) | 12 | 12 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 90 | 90 | 0 | ⬜ |
| used_mlh (%) | 85 | 85 | 0 | ⬜ |
| match_steps | 444 | 444 | 0 | ⬜ |
| runtime (min) | 27 | 24 | -3 | ✅ |
| episode_runtime (sec) | 174 | 156 | -18 | ✅ |
| num_episodes | 120 | 120 | 0 | ⬜ |

### world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 66.67 | 66.67 | 0 | ⬜ |
| used_mlh (%) | 62.5 | 62.5 | 0 | ⬜ |
| match_steps | 374 | 374 | 0 | ⬜ |
| runtime (min) | 10 | 10 | 0 | ⬜ |
| episode_runtime (sec) | 11 | 11 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### dark_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 29.17 | 29.17 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 242 | 242 | 0 | ⬜ |
| runtime (min) | 8 | 7 | -1 | ✅ |
| episode_runtime (sec) | 9 | 8 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### bright_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 37.5 | 37.5 | 0 | ⬜ |
| used_mlh (%) | 64.58 | 64.58 | 0 | ⬜ |
| match_steps | 413 | 413 | 0 | ⬜ |
| runtime (min) | 12 | 11 | -1 | ✅ |
| episode_runtime (sec) | 14 | 13 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### hand_intrusion_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 43.75 | 43.75 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 272 | 272 | 0 | ⬜ |
| runtime (min) | 9 | 8 | -1 | ✅ |
| episode_runtime (sec) | 10 | 9 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### multi_object_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 25 | 25 | 0 | ⬜ |
| used_mlh (%) | 2.08 | 2.08 | 0 | ⬜ |
| match_steps | 158 | 158 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 6 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### base_infer_objects_with_stickers_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 78.86 | 78.86 | 0 | ⬜ |
| used_mlh (%) | 92.57 | 92.57 | 0 | ⬜ |
| match_steps | 97 | 97 | 0 | ⬜ |
| rotation_error (deg) | 39.88 | 39.88 | 0 | ⬜ |
| avg_prediction_error | 0.2 | 0.2 | 0 | ⬜ |
| runtime (min) | 60 | 56 | -4 | ✅ |
| num_episodes | 350 | 350 | 0 | ⬜ |

### base_infer_objects_with_stickers_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| correct_child_or_parent (%) | 70.86 | 70.86 | 0 | ⬜ |
| used_mlh (%) | 43.14 | 43.14 | 0 | ⬜ |
| match_steps | 32 | 32 | 0 | ⬜ |
| rotation_error (deg) | 49.49 | 49.49 | 0 | ⬜ |
| avg_prediction_error | 0.3 | 0.3 | 0 | ⬜ |
| runtime (min) | 16 | 18 | 2 | ❌ |
| num_episodes | 350 | 350 | 0 | ⬜ |

</details>