### PR TITLE
chore: update the readme sync tool for the v2 migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,8 @@ github_readme_sync_tool = [
     'colorama',
     'markdown2',
     'python-slugify',
-    'nh3'
+    'nh3',
+    'urllib3'
 ]
 future_work_widget_tool = [
     'nh3',

--- a/tools/github_readme_sync/export.py
+++ b/tools/github_readme_sync/export.py
@@ -11,9 +11,7 @@
 import logging
 import shutil
 from pathlib import Path
-
 from slugify import slugify
-
 from tools.github_readme_sync.colors import BLUE, CYAN, RESET
 from tools.github_readme_sync.hierarchy import INDENTATION_UNIT
 from tools.github_readme_sync.readme import ReadMe
@@ -32,30 +30,38 @@ def export(output_dir: str, rdme: ReadMe):
     output_dir.mkdir(exist_ok=True, parents=True)
 
     for i, category in enumerate(categories):
+        # API v2 categories no longer have server-side slugs.
+        # Generate a local slug from the category title for the folder
+        # name and hierarchy.md.
+        category_slug = slugify(category["title"])
+
         category_entry = {
             "title": category["title"],
-            "slug": slugify(category["title"]),
+            "slug": category_slug,
             "children": [],
         }
         hierarchy.append(category_entry)
 
-        logger.info(
-            "\n" if i > 0 else "" + f"{BLUE}{slugify(category['title']).upper()}{RESET}"
-        )
+        prefix = "\n" if i > 0 else ""
+        logger.info(f"{prefix}{BLUE}{category_slug.upper()}{RESET}")
 
-        category_folder_path = output_dir / slugify(category["title"])
+        category_folder_path = output_dir / category_slug
         category_folder_path.mkdir(exist_ok=True, parents=True)
 
-        docs_from_server = rdme.get_category_docs(category)
+        # API v2 returns category pages as a flat collection.
+        # Rebuild the hierarchy using each page's parent URI.
+        docs_from_server = rdme.get_category_doc_tree(category)
+
         for server_doc in docs_from_server:
             hierarchy_doc = {
                 "title": server_doc["title"],
-                "slug": slugify(server_doc["title"]),
+                # Preserve the actual ReadMe slug. Do not derive a slug
+                # from the page title.
+                "slug": server_doc["slug"],
                 "children": [],
             }
             category_entry["children"].append(hierarchy_doc)
 
-            # Call process_doc with named parameters
             process_doc(
                 server_doc=server_doc,
                 hierarchy_doc=hierarchy_doc,
@@ -67,15 +73,25 @@ def export(output_dir: str, rdme: ReadMe):
     return hierarchy
 
 
-def process_doc(*, server_doc, hierarchy_doc, folder_path, indent_level, rdme):
+def process_doc(
+    *,
+    server_doc,
+    hierarchy_doc,
+    folder_path,
+    indent_level,
+    rdme,
+):
     indent = INDENTATION_UNIT * indent_level
     logger.info(f"{indent}{CYAN}{hierarchy_doc['slug']}{RESET}")
 
     doc_path = folder_path / f"{hierarchy_doc['slug']}.md"
-    with doc_path.open("w") as f:
+
+    # Documentation may contain Unicode text.
+    with doc_path.open("w", encoding="utf-8") as f:
         f.write(rdme.get_doc_by_slug(server_doc["slug"]))
 
     children = server_doc.get("children", [])
+
     if children:
         child_folder_path = folder_path / hierarchy_doc["slug"]
         child_folder_path.mkdir(exist_ok=True, parents=True)
@@ -83,12 +99,12 @@ def process_doc(*, server_doc, hierarchy_doc, folder_path, indent_level, rdme):
     for child in children:
         child_entry = {
             "title": child["title"],
-            "slug": slugify(child["title"]),
+            # Preserve the child page's actual ReadMe slug.
+            "slug": child["slug"],
             "children": [],
         }
         hierarchy_doc["children"].append(child_entry)
 
-        # Process the child document recursively with increased indent level
         process_doc(
             server_doc=child,
             hierarchy_doc=child_entry,

--- a/tools/github_readme_sync/export.py
+++ b/tools/github_readme_sync/export.py
@@ -11,7 +11,9 @@
 import logging
 import shutil
 from pathlib import Path
+
 from slugify import slugify
+
 from tools.github_readme_sync.colors import BLUE, CYAN, RESET
 from tools.github_readme_sync.hierarchy import INDENTATION_UNIT
 from tools.github_readme_sync.readme import ReadMe

--- a/tools/github_readme_sync/export.py
+++ b/tools/github_readme_sync/export.py
@@ -32,7 +32,7 @@ def export(output_dir: str, rdme: ReadMe):
     output_dir.mkdir(exist_ok=True, parents=True)
 
     for i, category in enumerate(categories):
-        # API v2 categories no longer have server-side slugs.
+        # API categories do not have server-side slugs.
         # Generate a local slug from the category title for the folder
         # name and hierarchy.md.
         category_slug = slugify(category["title"])
@@ -50,7 +50,7 @@ def export(output_dir: str, rdme: ReadMe):
         category_folder_path = output_dir / category_slug
         category_folder_path.mkdir(exist_ok=True, parents=True)
 
-        # API v2 returns category pages as a flat collection.
+        # The API returns category pages as a flat collection.
         # Rebuild the hierarchy using each page's parent URI.
         docs_from_server = rdme.get_category_doc_tree(category)
 

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -38,8 +38,8 @@ from tools.github_readme_sync.req import delete, get, get_collection, patch, pos
 logger = logging.getLogger(__name__)
 
 API_PREFIX = "https://api.readme.com/v2"
-GUIDES_SECTION = "guides"  # v2 category paths are /categories/{section}/…
-GUIDES_SECTION_BODY = "guide"  # v2 POST body wants singular guide.
+GUIDES_SECTION = "guides"  # category paths are /categories/{section}/…
+GUIDES_SECTION_BODY = "guide"  # POST body wants a singular 'guide'.
 GITHUB_RAW = "https://raw.githubusercontent.com"
 
 regex_images = re.compile(r"!\[(.*?)\]\((.*?)\)")
@@ -77,7 +77,6 @@ class ReadMe:
         self.version = version
 
     def _is_hidden(self, resource: dict) -> bool:
-        # v1 bool hidden → v2 privacy.view == anyone_with_link
         return (resource.get("privacy") or {}).get("view") == "anyone_with_link"
 
     def branch_url(self, suffix: str = "") -> str:
@@ -94,8 +93,6 @@ class ReadMe:
 
     def get_category_docs(self, category: Any) -> list[Any]:
         """Return a category's pages as a flat v2 collection."""
-        # API v2 identifies categories by title rather than by the
-        # category slug or hexadecimal ID used in API v1.
         title = quote(category["title"], safe="")
 
         response = get_collection(
@@ -108,7 +105,7 @@ class ReadMe:
         return response
 
     def get_category_doc_tree(self, category: Any) -> list[Any]:
-        """Rebuild a nested page tree from API v2's flat page collection.
+        """Rebuild a nested page tree from the APIs flat page collection.
 
         Args:
             category: The ReadMe category whose pages should be retrieved.
@@ -129,7 +126,7 @@ class ReadMe:
         pages_by_uri = {}
 
         # First create independent page dictionaries with empty children lists.
-        # We use resource URIs because v2 uses URIs as resource identifiers.
+        # We use resource URIs as the API uses URIs as resource identifiers.
         for raw_page in pages:
             page = dict(raw_page)
             page["children"] = []
@@ -252,7 +249,7 @@ class ReadMe:
         patch(
             f"{API_PREFIX}/branches/{self.version}",
             {
-                # The live ReadMe v2 API and tested project behavior use
+                # The live ReadMe API and tested project behavior use
                 # privacy.view="default" to make this version stable/default.
                 # This differs from the public migration guide.
                 "privacy": {"view": "default"},
@@ -433,7 +430,6 @@ class ReadMe:
         if parent_id:
             update_doc_request["parent"] = {"uri": parent_id}
 
-        # ReadMe v2 stores the document description as the content excerpt.
         if "description" in doc:
             update_doc_request["content"]["excerpt"] = doc["description"]
 
@@ -592,8 +588,6 @@ class ReadMe:
             ValueError: If no stable branch exists or the stable branch response
                 does not contain a name.
         """
-        # ReadMe v2 supports "stable" as an alias for the current
-        # stable/default version.
         stable = get(f"{API_PREFIX}/branches/stable")
         if stable is None:
             raise ValueError("No stable version found")

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -108,8 +108,19 @@ class ReadMe:
         return response
 
     def get_category_doc_tree(self, category: Any) -> list[Any]:
-        """Rebuild a nested page tree from API v2's flat page collection."""
+        """Rebuild a nested page tree from API v2's flat page collection.
 
+        Args:
+            category: The ReadMe category whose pages should be retrieved.
+
+        Returns:
+            The category's pages organized as a nested tree. Each page contains
+            a ``children`` list containing its direct child pages.
+
+        Raises:
+            ValueError: If a page has no URI, a duplicate URI is returned, or a
+                page references a parent URI that is not present in the category.
+        """
         pages = self.get_category_docs(category)
 
         if not pages:
@@ -119,8 +130,8 @@ class ReadMe:
 
         # First create independent page dictionaries with empty children lists.
         # We use resource URIs because v2 uses URIs as resource identifiers.
-        for page in pages:
-            page = dict(page)
+        for raw_page in pages:
+            page = dict(raw_page)
             page["children"] = []
 
             uri = page.get("uri")
@@ -195,8 +206,18 @@ class ReadMe:
         return front_matter_str + body
 
     def get_doc(self, slug: str) -> dict | None:
-        """Return one guide and verify ReadMe resolved the requested slug."""
+        """Return one guide and verify its slug and URI.
 
+        Args:
+            slug: The guide slug to retrieve.
+
+        Returns:
+            The guide returned by ReadMe, or ``None`` if ReadMe returns a 404.
+
+        Raises:
+            ValueError: If ReadMe resolves the request to a different slug or
+                returns a guide without a URI.
+        """
         doc = get(self.branch_url(f"/guides/{slug}"))
 
         if doc is None:
@@ -221,7 +242,6 @@ class ReadMe:
 
     def make_version_stable(self):
         """Make a release version the project's stable/default version."""
-
         # Versions containing a suffix are preview versions, such as
         # 0.40-brothman-newtest3. Do not make those stable.
         if self.version_has_suffix():
@@ -563,8 +583,15 @@ class ReadMe:
         return body
 
     def get_stable_version(self) -> str:
-        """Return the name of the project's stable/default version."""
+        """Return the name of the project's stable/default version.
 
+        Returns:
+            The name of the branch currently identified by ReadMe as stable.
+
+        Raises:
+            ValueError: If no stable branch exists or the stable branch response
+                does not contain a name.
+        """
         # ReadMe v2 supports "stable" as an alias for the current
         # stable/default version.
         stable = get(f"{API_PREFIX}/branches/stable")

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -33,11 +33,13 @@ from tools.github_readme_sync.constants import (
     IGNORE_YOUTUBE,
     REGEX_CSV_TABLE,
 )
-from tools.github_readme_sync.req import delete, get, post, put
+from tools.github_readme_sync.req import delete, get, get_collection, patch, post
 
 logger = logging.getLogger(__name__)
 
-PREFIX = "https://dash.readme.com/api/v1"
+API_PREFIX = "https://api.readme.com/v2"
+GUIDES_SECTION = "guides"  # v2 category paths are /categories/{section}/…
+GUIDES_SECTION_BODY = "guide"  # v2 POST body wants singular guide.
 GITHUB_RAW = "https://raw.githubusercontent.com"
 
 regex_images = re.compile(r"!\[(.*?)\]\((.*?)\)")
@@ -74,51 +76,104 @@ class ReadMe:
     def __init__(self, version: str):
         self.version = version
 
-    def normalize_title_to_readme_slug(self, title: str) -> str:
-        # Normalize a ReadMe title into the slug format ReadMe generates.
+    def _is_hidden(self, resource: dict) -> bool:
+        # v1 bool hidden → v2 privacy.view == anyone_with_link
+        return (resource.get("privacy") or {}).get("view") == "anyone_with_link"
 
-        # ReadMe slugs are generally derived from titles by:
-        # - lowercasing
-        # - replacing whitespace with hyphens
-        # - stripping punctuation/symbols/non-alphanumeric characters
-        # - collapsing repeated hyphens
-
-        slug = title.lower()
-        slug = re.sub(r"\s+", "-", slug)
-        slug = re.sub(r"[^a-z0-9-]", "", slug)
-        slug = re.sub(r"-+", "-", slug)
-        # Strip leading/trailing hyphens that may have resulted from punctuation removal
-        return slug.strip("-")
+    def branch_url(self, suffix: str = "") -> str:
+        # Every version-scoped call becomes …/branches/{self.version}{suffix}
+        return f"{API_PREFIX}/branches/{self.version}{suffix}"
 
     def get_categories(self) -> list[Any]:
-        categories = get(f"{PREFIX}/categories", {"x-readme-version": self.version})
+        """Return guide categories in the order supplied by ReadMe."""
+        categories = get_collection(self.branch_url(f"/categories/{GUIDES_SECTION}"))
         if not categories:
             return []
-        return sorted(categories, key=lambda x: x["order"])
+
+        return categories
 
     def get_category_docs(self, category: Any) -> list[Any]:
-        response = get(
-            f"{PREFIX}/categories/{category['slug']}/docs",
-            {"x-readme-version": self.version},
+        """Return a category's pages as a flat v2 collection."""
+        # API v2 identifies categories by title rather than by the
+        # category slug or hexadecimal ID used in API v1.
+        title = quote(category["title"], safe="")
+
+        response = get_collection(
+            self.branch_url(f"/categories/{GUIDES_SECTION}/{title}/pages")
         )
+
         if not response:
             return []
-        return sorted(response, key=lambda x: x["order"])
+
+        return response
+
+    def get_category_doc_tree(self, category: Any) -> list[Any]:
+        """Rebuild a nested page tree from API v2's flat page collection."""
+
+        pages = self.get_category_docs(category)
+
+        if not pages:
+            return []
+
+        pages_by_uri = {}
+
+        # First create independent page dictionaries with empty children lists.
+        # We use resource URIs because v2 uses URIs as resource identifiers.
+        for page in pages:
+            page = dict(page)
+            page["children"] = []
+
+            uri = page.get("uri")
+            if not uri:
+                raise ValueError(f"ReadMe page {page.get('slug')!r} has no uri")
+
+            if uri in pages_by_uri:
+                raise ValueError(f"ReadMe returned duplicate page URI {uri!r}")
+
+            pages_by_uri[uri] = page
+
+        roots = []
+
+        # Iterate over the original API order so sibling ordering remains
+        # the same as the order returned by ReadMe.
+        for original_page in pages:
+            page = pages_by_uri[original_page["uri"]]
+            parent_uri = (page.get("parent") or {}).get("uri")
+
+            if not parent_uri:
+                # A page without a parent is a category-level root page.
+                roots.append(page)
+                continue
+
+            parent = pages_by_uri.get(parent_uri)
+            if parent is None:
+                # Continuing would silently flatten or corrupt the hierarchy.
+                raise ValueError(
+                    f"ReadMe page {page['slug']!r} refers to missing "
+                    f"parent URI {parent_uri!r}"
+                )
+
+            parent["children"].append(page)
+
+        return roots
 
     def get_doc_by_slug(self, slug: str) -> str:
-        response = get(f"{PREFIX}/docs/{slug}", {"x-readme-version": self.version})
+        doc = self.get_doc(slug)
 
-        if not response:
+        if doc is None:
             raise DocumentNotFound(f"Document {slug} not found")
 
         front_matter = OrderedDict()
-        front_matter["title"] = response.get("title")
+        front_matter["title"] = doc.get("title")
 
-        if response.get("hidden"):
+        if self._is_hidden(doc):
             front_matter["hidden"] = True
 
-        if response.get("excerpt"):
-            front_matter["description"] = response.get("excerpt")
+        # Include a fallback for the excerpt in case the content is None
+        # which can happen if the document has no content.
+        excerpt = (doc.get("content") or {}).get("excerpt")
+        if excerpt:
+            front_matter["description"] = excerpt
 
         front_matter_str = (
             f"---\n"
@@ -133,42 +188,73 @@ class ReadMe:
             f"---\n"
         )
 
-        doc_body = response.get("body")
+        # ReadMe may return null for a page that has no body.
+        # Use an empty string so front matter can still be exported.
+        body = (doc.get("content") or {}).get("body") or ""
 
-        return front_matter_str + doc_body
+        return front_matter_str + body
 
-    def get_doc_id(self, slug: str) -> str:
-        response = get(f"{PREFIX}/docs/{slug}", {"x-readme-version": self.version})
-        if response:
-            return response["_id"]
-        return None
+    def get_doc(self, slug: str) -> dict | None:
+        """Return one guide and verify ReadMe resolved the requested slug."""
+
+        doc = get(self.branch_url(f"/guides/{slug}"))
+
+        if doc is None:
+            # None can only mean an actual 404.
+            return None
+
+        returned_slug = doc.get("slug")
+        uri = doc.get("uri")
+
+        # Do not allow ReadMe to resolve an alias or another canonical slug
+        # without the sync tool noticing.
+        if returned_slug != slug:
+            raise ValueError(
+                f"ReadMe resolved requested slug {slug!r} to "
+                f"{returned_slug!r} ({uri!r})"
+            )
+
+        if not uri:
+            raise ValueError(f"ReadMe guide {slug!r} has no uri")
+
+        return doc
 
     def make_version_stable(self):
+        """Make a release version the project's stable/default version."""
+
+        # Versions containing a suffix are preview versions, such as
+        # 0.40-brothman-newtest3. Do not make those stable.
         if self.version_has_suffix():
             return
+
         logger.info(f"{GREEN}Setting version {self.version} to stable{RESET}")
-        if not put(
-            f"{PREFIX}/version/{self.version}", {"is_stable": True, "is_hidden": False}
-        ):
-            raise ValueError("Failed to make version stable")
+
+        patch(
+            f"{API_PREFIX}/branches/{self.version}",
+            {
+                # The live ReadMe v2 API and tested project behavior use
+                # privacy.view="default" to make this version stable/default.
+                # This differs from the public migration guide.
+                "privacy": {"view": "default"},
+            },
+        )
 
     def version_has_suffix(self) -> bool:
         return "-" in self.version
 
     def create_version_if_not_exists(self) -> bool:
-        if get(f"{PREFIX}/version/{self.version}") is None:
+        if get(f"{API_PREFIX}/branches/{self.version}") is None:
             stable_version = self.get_stable_version()
             logger.info(
                 f"{GRAY}Creating version: {self.version} "
                 f"forked from {stable_version}{RESET}"
             )
             if not post(
-                f"{PREFIX}/version",
+                f"{API_PREFIX}/branches",
                 {
-                    "version": self.version,
-                    "from": stable_version,
-                    "is_stable": False,
-                    "is_hidden": True,
+                    "name": self.version,
+                    "base": stable_version,
+                    "privacy": {"view": "hidden"},
                 },
             ):
                 raise ValueError("Failed to create a new version")
@@ -179,15 +265,15 @@ class ReadMe:
         logger.info(f"{GRAY}Deleting categories for version {self.version}{RESET}")
         categories = self.get_categories()
         for category in categories:
-            self.delete_category(category["slug"])
+            self.delete_category(category["title"])
 
-    def delete_category(self, slug: str):
-        logger.info(f"{GRAY}Deleting category {slug}{RESET}")
-        delete(f"{PREFIX}/categories/{slug}", {"x-readme-version": self.version})
+    def delete_category(self, title: str):
+        logger.info(f"{GRAY}Deleting category {title}{RESET}")
+        delete(self.branch_url(f"/categories/{GUIDES_SECTION}/{quote(title, safe='')}"))
 
     def delete_doc(self, slug: str):
         logger.info(f"{GRAY}Deleting doc {slug}{RESET}")
-        delete(f"{PREFIX}/docs/{slug}", {"x-readme-version": self.version})
+        delete(self.branch_url(f"/guides/{slug}"))
 
     def validate_csv_align_param(self, align_value: str) -> None:
         if align_value not in ["left", "right"]:
@@ -196,28 +282,19 @@ class ReadMe:
             )
 
     def create_category_if_not_exists(self, title: str) -> tuple[str, bool]:
-        # Unfortunately ReadMe's API does not allow us to create a category with a
-        # specific slug, so we have to check if the category exists by converting
-        # the title to readme's style of slug to check if it exists.
-        # http://docs.readme.com/main/reference/createcategory
-        readme_slug = self.normalize_title_to_readme_slug(title)
-
         category = get(
-            f"{PREFIX}/categories/{readme_slug}", {"x-readme-version": self.version}
+            self.branch_url(f"/categories/{GUIDES_SECTION}/{quote(title, safe='')}")
         )
         if category is None:
-            response = post(
-                f"{PREFIX}/categories",
-                {"title": title, "type": "guide"},
-                {"x-readme-version": self.version},
+            created = post(
+                self.branch_url("/categories"),
+                {"title": title, "section": GUIDES_SECTION_BODY},
             )
-            if response is None:
+            if created is None:
                 raise ValueError(f"Failed to create category {title}")
 
-            category = json.loads(response)
-            return category["_id"], True
-
-        return category["_id"], False
+            return created["uri"], True
+        return category["uri"], False
 
     def convert_csv_to_html_table(self, body: str, file_path: str) -> str:
         """Convert CSV table references to HTML tables.
@@ -303,43 +380,82 @@ class ReadMe:
         return REGEX_CSV_TABLE.sub(replace_match, body)
 
     def create_or_update_doc(
-        self, order: int, category_id: str, doc: dict, parent_id: str, file_path: str
+        self,
+        order: int,
+        category_id: str,
+        doc: dict,
+        parent_id: str,
+        file_path: str,
     ) -> tuple[str, bool]:
-        markdown = self.process_markdown(doc["body"], file_path, doc["slug"])
+        # Convert the document body into the format expected by ReadMe.
+        markdown = self.process_markdown(
+            doc["body"],
+            file_path,
+            doc["slug"],
+        )
 
-        create_doc_request = {
+        # This payload is used when updating an existing guide.
+        #
+        # We not include "slug" in this request as updating a doc
+        # uses its slug in the patch URL.
+        update_doc_request = {
             "title": doc["title"],
             "type": "basic",
-            "body": markdown,
-            "category": category_id,
-            "hidden": doc.get("hidden", False),
-            "order": order,
-            "parentDoc": parent_id,
-            "slug": doc["slug"],
+            "content": {"body": markdown},
+            "category": {"uri": category_id},
+            "privacy": {
+                "view": ("anyone_with_link" if doc.get("hidden", False) else "public")
+            },
+            "position": order,
         }
 
-        # Include description field as excerpt if it exists in the document
+        # Include the parent URI when this guide is nested under another guide.
+        if parent_id:
+            update_doc_request["parent"] = {"uri": parent_id}
+
+        # ReadMe v2 stores the document description as the content excerpt.
         if "description" in doc:
-            create_doc_request["excerpt"] = doc["description"]
+            update_doc_request["content"]["excerpt"] = doc["description"]
 
-        doc_id = self.get_doc_id(doc["slug"])
-        created = doc_id is None
-        if doc_id:
-            if not put(
-                f"{PREFIX}/docs/{doc['slug']}",
-                create_doc_request,
-                {"x-readme-version": self.version},
-            ):
-                raise ValueError(f"Failed to update doc {doc['title']}")
-        else:
-            response = post(
-                f"{PREFIX}/docs", create_doc_request, {"x-readme-version": self.version}
+        existing_doc = self.get_doc(doc["slug"])
+
+        if existing_doc is not None:
+            # The guide already exists, so update it without sending its slug.
+            patch(
+                self.branch_url(f"/guides/{doc['slug']}"),
+                update_doc_request,
             )
-            if response is None:
-                raise ValueError(f"Failed to create doc {doc['title']}")
-            doc_id = json.loads(response)["_id"]
 
-        return doc_id, created
+            # Return the existing guide URI for use as the parent of nested pages.
+            return existing_doc["uri"], False
+
+        # The guide does not exist, so create it using the requested slug.
+        create_doc_request = dict(update_doc_request)
+        create_doc_request["slug"] = doc["slug"]
+
+        created = post(
+            self.branch_url("/guides"),
+            create_doc_request,
+            # Prevent ReadMe from silently changing a duplicate slug into slug-1.
+            # A slug collision will instead cause the request to fail.
+            headers={"prefer": "handling=strict"},
+        )
+
+        actual_slug = created.get("slug")
+        created_uri = created.get("uri")
+
+        # Keep this protection even though strict handling should prevent
+        # ReadMe from assigning a different slug.
+        if actual_slug != doc["slug"]:
+            raise ValueError(
+                f"ReadMe created {doc['title']!r} with slug "
+                f"{actual_slug!r}; expected {doc['slug']!r}"
+            )
+
+        if not created_uri:
+            raise ValueError(f"Created doc {doc['title']!r} has no uri")
+
+        return created_uri, True
 
     def process_markdown(self, body: str, file_path: str, slug: str) -> str:
         body = self.insert_edit_this_page(body, slug, file_path)
@@ -447,15 +563,19 @@ class ReadMe:
         return body
 
     def get_stable_version(self) -> str:
-        versions = get(f"{PREFIX}/version")
-        if versions is None or not versions:
-            raise ValueError("Failed to retrieve versions or no versions found")
+        """Return the name of the project's stable/default version."""
 
-        for version in versions:
-            if version["is_stable"]:
-                return version["version_clean"]
+        # ReadMe v2 supports "stable" as an alias for the current
+        # stable/default version.
+        stable = get(f"{API_PREFIX}/branches/stable")
+        if stable is None:
+            raise ValueError("No stable version found")
 
-        raise ValueError("No stable version found")
+        name = stable.get("name")
+        if not name:
+            raise ValueError("Stable version response did not contain a name")
+
+        return name
 
     def parse_images(self, markdown_text: str) -> str:
         def replace_image(match):
@@ -504,7 +624,7 @@ class ReadMe:
         return regex_images.sub(replace_image, markdown_text)
 
     def delete_version(self):
-        delete(f"{PREFIX}/version/v{self.version}")
+        delete(f"{API_PREFIX}/branches/{self.version}")
         logger.info(f"{GREEN}Successfully deleted version {self.version}{RESET}")
 
     def _should_ignore_video(self, identifier: str, ignore_list: list[str]) -> bool:

--- a/tools/github_readme_sync/readme.py
+++ b/tools/github_readme_sync/readme.py
@@ -404,6 +404,31 @@ class ReadMe:
         parent_id: str,
         file_path: str,
     ) -> tuple[str, bool]:
+        """Create a new ReadMe guide or update an existing guide.
+
+        Process the guide's Markdown content and construct the request payload
+        expected by the ReadMe API. If a guide with the requested slug already
+        exists, update it. Otherwise, create a new guide using the requested slug.
+
+        Args:
+            order: Position of the guide within its category or parent guide.
+            category_id: URI of the ReadMe category containing the guide.
+            doc: Guide data, including its title, slug, body, and optional
+                description and hidden status.
+            parent_id: Optional URI of the parent guide. Only exists if it
+                is a nested resource.
+            file_path: Path to the source Markdown file, used when processing the
+                guide's content.
+
+        Returns:
+            A tuple containing the guide's URI and a boolean indicating whether the
+            guide was created. The boolean is ``False`` when an existing guide was
+            updated. The URI is used to set the parent of any nested guides.
+
+        Raises:
+            ValueError: If ReadMe creates the guide with a different slug than the
+                requested slug, or if the creation response does not contain a URI.
+        """
         # Convert the document body into the format expected by ReadMe.
         markdown = self.process_markdown(
             doc["body"],
@@ -413,8 +438,7 @@ class ReadMe:
 
         # This payload is used when updating an existing guide.
         #
-        # We not include "slug" in this request as updating a doc
-        # uses its slug in the patch URL.
+        # "slug" is omitted as updating a doc uses its slug in the patch URL.
         update_doc_request = {
             "title": doc["title"],
             "type": "basic",
@@ -436,13 +460,10 @@ class ReadMe:
         existing_doc = self.get_doc(doc["slug"])
 
         if existing_doc is not None:
-            # The guide already exists, so update it without sending its slug.
             patch(
                 self.branch_url(f"/guides/{doc['slug']}"),
                 update_doc_request,
             )
-
-            # Return the existing guide URI for use as the parent of nested pages.
             return existing_doc["uri"], False
 
         # The guide does not exist, so create it using the requested slug.

--- a/tools/github_readme_sync/req.py
+++ b/tools/github_readme_sync/req.py
@@ -10,6 +10,7 @@
 
 import logging
 import os
+from urllib.parse import urljoin
 
 import requests
 
@@ -17,48 +18,137 @@ REQUEST_TIMEOUT_SECONDS = 60
 logger = logging.getLogger(__name__)
 
 
+def _auth_headers(headers=None) -> dict:
+    # v2 uses Bearer tokens.
+    # Copy caller-provided headers so adding Authorization does not mutate them.
+    headers = dict(headers or {})
+    headers["Authorization"] = f"Bearer {os.getenv('README_API_KEY')}"
+    return headers
+
+
+def _unwrap_data(payload):
+    # Single-resource and collection responses nest the payload under "data" in v2.
+    # Return the inner value so callers never see the wrapper.
+    if isinstance(payload, dict) and "data" in payload:
+        return payload["data"]
+    return payload
+
+
 def get(url: str, headers=None):
-    headers = headers or {}
-    headers["Authorization"] = f"Basic {os.getenv('README_API_KEY')}"
+    headers = _auth_headers(headers)
     response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
     logger.debug("get %s %s", url, response.status_code)
     if response.status_code == 404:
         return None
     if response.status_code < 200 or response.status_code >= 300:
-        logger.error(f"Failed to get {url} {response.text}")
-        return None
-    return response.json()
+        # Only a 404 means "the resource does not exist."
+        #
+        # A 401, 403, 429, or 500 must stop the upload. Otherwise,
+        # create_or_update_doc() interprets the failure as a missing page
+        # and incorrectly creates a duplicate.
+        raise RuntimeError(
+            f"GET {url} failed with {response.status_code}: {response.text}"
+        )
+    return _unwrap_data(response.json())
+
+
+def get_collection(url: str, headers=None) -> list:
+    """Retrieve every page from a paginated v2 collection endpoint."""
+
+    headers = _auth_headers(headers)
+    items = []
+    next_url = url
+
+    while next_url:
+        response = requests.get(
+            next_url,
+            headers=headers,
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+
+        logger.debug(
+            "get_collection %s %s",
+            next_url,
+            response.status_code,
+        )
+
+        if response.status_code == 404:
+            return items
+
+        if response.status_code < 200 or response.status_code >= 300:
+            # Do not return a partial collection. Some callers (cleanup code) use this
+            # inventory to determine which documents should be deleted.
+            raise RuntimeError(
+                f"GET {next_url} failed with {response.status_code}: {response.text}"
+            )
+
+        payload = response.json()
+        data = _unwrap_data(payload)
+
+        # ReadMe v2 collection responses should always contain a list
+        # under "data".
+        if not isinstance(data, list):
+            raise RuntimeError(
+                f"Expected collection data from {next_url} to be a list, "
+                f"received {type(data).__name__}"
+            )
+
+        items.extend(data)
+
+        paging = payload.get("paging") if isinstance(payload, dict) else None
+        next_path = paging.get("next") if isinstance(paging, dict) else None
+
+        # Resolve the next-page link relative to the current response URL.
+        # This works whether ReadMe returns an absolute or relative URL.
+        next_url = urljoin(response.url, next_path) if next_path else None
+
+    return items
 
 
 def post(url: str, data: dict, headers=None):
-    headers = headers or {}
-    headers["Authorization"] = f"Basic {os.getenv('README_API_KEY')}"
+    headers = _auth_headers(headers)
     response = requests.post(
         url, json=data, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
     )
     logger.debug("post %s %s", url, response.status_code)
     if response.status_code < 200 or response.status_code >= 300:
-        logger.error(f"Failed to post {url} {response.text}")
-        return None
-    return response.text
+        # Preserve the API response, especially when strict slug handling
+        # produces a 409 Conflict.
+        raise RuntimeError(
+            f"POST {url} failed with {response.status_code}: {response.text}"
+        )
+
+    if not response.content:
+        return {}
+    return _unwrap_data(response.json())
 
 
-def put(url: str, data: dict, headers=None):
-    headers = headers or {}
-    headers["Authorization"] = f"Basic {os.getenv('README_API_KEY')}"
-    response = requests.put(
+def patch(url: str, data: dict, headers=None) -> bool:
+    # v2 updates use PATCH (replaces put for guides/branches).
+    headers = _auth_headers(headers)
+    response = requests.patch(
         url, json=data, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
     )
-    logger.debug("put %s %s", url, response.status_code)
+    logger.debug("patch %s %s", url, response.status_code)
     if response.status_code < 200 or response.status_code >= 300:
-        logger.error(f"Failed to put {url} {response.text}")
-        return False
+        raise RuntimeError(
+            f"PATCH {url} failed with {response.status_code}: {response.text}"
+        )
     return True
 
 
-def delete(url: str, headers=None):
-    headers = headers or {}
-    headers["Authorization"] = f"Basic {os.getenv('README_API_KEY')}"
-    response = requests.delete(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+def delete(url: str, headers=None) -> None:
+    headers = _auth_headers(headers)
+
+    response = requests.delete(
+        url,
+        headers=headers,
+        timeout=REQUEST_TIMEOUT_SECONDS,
+    )
+
     logger.debug("delete %s %s", url, response.status_code)
-    return 200 <= response.status_code < 300
+
+    if response.status_code < 200 or response.status_code >= 300:
+        raise RuntimeError(
+            f"DELETE {url} failed with {response.status_code}: {response.text}"
+        )

--- a/tools/github_readme_sync/req.py
+++ b/tools/github_readme_sync/req.py
@@ -53,8 +53,19 @@ def get(url: str, headers=None):
 
 
 def get_collection(url: str, headers=None) -> list:
-    """Retrieve every page from a paginated v2 collection endpoint."""
+    """Retrieve every page from a paginated v2 collection endpoint.
 
+    Args:
+        url: The initial collection endpoint URL.
+        headers: Optional additional HTTP request headers.
+
+    Returns:
+        A flat list containing the resources from every response page.
+
+    Raises:
+        RuntimeError: If ReadMe returns an unsuccessful HTTP response.
+        TypeError: If the response's ``data`` field is not a list.
+    """
     headers = _auth_headers(headers)
     items = []
     next_url = url
@@ -88,7 +99,7 @@ def get_collection(url: str, headers=None) -> list:
         # ReadMe v2 collection responses should always contain a list
         # under "data".
         if not isinstance(data, list):
-            raise RuntimeError(
+            raise TypeError(
                 f"Expected collection data from {next_url} to be a list, "
                 f"received {type(data).__name__}"
             )

--- a/tools/github_readme_sync/req.py
+++ b/tools/github_readme_sync/req.py
@@ -7,9 +7,12 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
+from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
+from typing import Any
 from urllib.parse import urljoin
 
 import requests
@@ -18,23 +21,48 @@ REQUEST_TIMEOUT_SECONDS = 60
 logger = logging.getLogger(__name__)
 
 
-def _auth_headers(headers=None) -> dict:
-    # v2 uses Bearer tokens.
-    # Copy caller-provided headers so adding Authorization does not mutate them.
-    headers = dict(headers or {})
-    headers["Authorization"] = f"Bearer {os.getenv('README_API_KEY')}"
-    return headers
+def _auth_headers(
+    headers: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Build authenticated request headers without modifying the input.
+
+    Args:
+        headers: Optional request headers supplied by the caller.
+
+    Returns:
+        A new dictionary containing the caller's headers and authorization.
+    """
+    request_headers = dict(headers or {})
+    request_headers["Authorization"] = (
+        f"Bearer {os.getenv('README_API_KEY')}"
+    )
+    return request_headers
 
 
-def _unwrap_data(payload):
-    # Single-resource and collection responses nest the payload under "data" in v2.
-    # Return the inner value so callers never see the wrapper.
-    if isinstance(payload, dict) and "data" in payload:
-        return payload["data"]
-    return payload
+def _unwrap_data(payload: Mapping[str, Any]) -> Any:
+    """Return the resource stored in a response envelope.
+
+    Args:
+        payload: The decoded JSON response object.
+
+    Returns:
+        The value stored under the response's ``data`` field.
+
+    Raises:
+        ValueError: If the response does not contain a ``data`` field.
+    """
+    if "data" not in payload:
+        raise ValueError(
+            "ReadMe response is missing the required 'data' field"
+        )
+
+    return payload["data"]
 
 
-def get(url: str, headers=None):
+def get(
+    url: str,
+    headers: Mapping[str, str] | None = None,
+) -> Any | None:
     headers = _auth_headers(headers)
     response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
     logger.debug("get %s %s", url, response.status_code)
@@ -52,8 +80,11 @@ def get(url: str, headers=None):
     return _unwrap_data(response.json())
 
 
-def get_collection(url: str, headers=None) -> list:
-    """Retrieve every page from a paginated v2 collection endpoint.
+def get_collection(
+    url: str,
+    headers: Mapping[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Retrieve every page from a paginated collection endpoint.
 
     Args:
         url: The initial collection endpoint URL.
@@ -96,7 +127,7 @@ def get_collection(url: str, headers=None) -> list:
         payload = response.json()
         data = _unwrap_data(payload)
 
-        # ReadMe v2 collection responses should always contain a list
+        # ReadMe collection responses should always contain a list
         # under "data".
         if not isinstance(data, list):
             raise TypeError(
@@ -116,7 +147,11 @@ def get_collection(url: str, headers=None) -> list:
     return items
 
 
-def post(url: str, data: dict, headers=None):
+def post(
+    url: str,
+    data: Mapping[str, Any],
+    headers: Mapping[str, str] | None = None,
+) -> Any:
     headers = _auth_headers(headers)
     response = requests.post(
         url, json=data, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
@@ -134,8 +169,12 @@ def post(url: str, data: dict, headers=None):
     return _unwrap_data(response.json())
 
 
-def patch(url: str, data: dict, headers=None) -> bool:
-    # v2 updates use PATCH (replaces put for guides/branches).
+def patch(
+    url: str,
+    data: Mapping[str, Any],
+    headers: Mapping[str, str] | None = None,
+) -> bool:
+    """Update a resource."""
     headers = _auth_headers(headers)
     response = requests.patch(
         url, json=data, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
@@ -148,7 +187,10 @@ def patch(url: str, data: dict, headers=None) -> bool:
     return True
 
 
-def delete(url: str, headers=None) -> None:
+def delete(
+    url: str,
+    headers: Mapping[str, str] | None = None,
+) -> None:
     headers = _auth_headers(headers)
 
     response = requests.delete(

--- a/tools/github_readme_sync/req.py
+++ b/tools/github_readme_sync/req.py
@@ -11,11 +11,13 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Mapping
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 import requests
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 REQUEST_TIMEOUT_SECONDS = 60
 logger = logging.getLogger(__name__)
@@ -33,9 +35,7 @@ def _auth_headers(
         A new dictionary containing the caller's headers and authorization.
     """
     request_headers = dict(headers or {})
-    request_headers["Authorization"] = (
-        f"Bearer {os.getenv('README_API_KEY')}"
-    )
+    request_headers["Authorization"] = f"Bearer {os.getenv('README_API_KEY')}"
     return request_headers
 
 
@@ -52,9 +52,7 @@ def _unwrap_data(payload: Mapping[str, Any]) -> Any:
         ValueError: If the response does not contain a ``data`` field.
     """
     if "data" not in payload:
-        raise ValueError(
-            "ReadMe response is missing the required 'data' field"
-        )
+        raise ValueError("ReadMe response is missing the required 'data' field")
 
     return payload["data"]
 
@@ -76,8 +74,7 @@ def get(
         # create_or_update_doc() interprets the failure as a missing page
         # and incorrectly creates a duplicate.
         raise RuntimeError(
-            f"GET {url} failed with "
-            f"{response.status_code}: {response.text}"
+            f"GET {url} failed with {response.status_code}: {response.text}"
         )
 
     return _unwrap_data(response.json())
@@ -177,7 +174,19 @@ def patch(
     data: Mapping[str, Any],
     headers: Mapping[str, str] | None = None,
 ) -> bool:
-    """Update a resource."""
+    """Update a resource.
+
+    Args:
+        url: The URL of the resource to update.
+        data: The request body to send as JSON.
+        headers: Optional additional request headers.
+
+    Returns:
+        ``True`` when the resource is updated successfully.
+
+    Raises:
+        RuntimeError: If the request returns a client or server error.
+    """
     headers = _auth_headers(headers)
     response = requests.patch(
         url, json=data, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS

--- a/tools/github_readme_sync/req.py
+++ b/tools/github_readme_sync/req.py
@@ -68,15 +68,18 @@ def get(
     logger.debug("get %s %s", url, response.status_code)
     if response.status_code == 404:
         return None
-    if response.status_code < 200 or response.status_code >= 300:
+
+    if response.status_code >= 400:
         # Only a 404 means "the resource does not exist."
         #
-        # A 401, 403, 429, or 500 must stop the upload. Otherwise,
+        # Other failures must stop the upload. Otherwise,
         # create_or_update_doc() interprets the failure as a missing page
         # and incorrectly creates a duplicate.
         raise RuntimeError(
-            f"GET {url} failed with {response.status_code}: {response.text}"
+            f"GET {url} failed with "
+            f"{response.status_code}: {response.text}"
         )
+
     return _unwrap_data(response.json())
 
 
@@ -117,7 +120,7 @@ def get_collection(
         if response.status_code == 404:
             return items
 
-        if response.status_code < 200 or response.status_code >= 300:
+        if response.status_code >= 400:
             # Do not return a partial collection. Some callers (cleanup code) use this
             # inventory to determine which documents should be deleted.
             raise RuntimeError(
@@ -157,7 +160,7 @@ def post(
         url, json=data, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
     )
     logger.debug("post %s %s", url, response.status_code)
-    if response.status_code < 200 or response.status_code >= 300:
+    if response.status_code >= 400:
         # Preserve the API response, especially when strict slug handling
         # produces a 409 Conflict.
         raise RuntimeError(
@@ -180,7 +183,7 @@ def patch(
         url, json=data, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
     )
     logger.debug("patch %s %s", url, response.status_code)
-    if response.status_code < 200 or response.status_code >= 300:
+    if response.status_code >= 400:
         raise RuntimeError(
             f"PATCH {url} failed with {response.status_code}: {response.text}"
         )
@@ -201,7 +204,7 @@ def delete(
 
     logger.debug("delete %s %s", url, response.status_code)
 
-    if response.status_code < 200 or response.status_code >= 300:
+    if response.status_code >= 400:
         raise RuntimeError(
             f"DELETE {url} failed with {response.status_code}: {response.text}"
         )

--- a/tools/github_readme_sync/req.py
+++ b/tools/github_readme_sync/req.py
@@ -11,58 +11,162 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 from urllib.parse import urljoin
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
 REQUEST_TIMEOUT_SECONDS = 60
+
+# Retry a request up to three times after the initial attempt.
+MAX_RETRIES = 3
+
+# Wait progressively longer between retries so temporary API or network
+# problems have time to recover.
+RETRY_BACKOFF_FACTOR = 3
+
+# Retry rate limiting and temporary server failures.
+#
+# Other client errors, such as 400, 401, 403, 404, and 409, normally mean
+# the request must be corrected and should not be automatically retried.
+RETRY_STATUS_CODES = (429, 500, 502, 503, 504)
+
 logger = logging.getLogger(__name__)
 
 
-def _auth_headers(
-    headers: Mapping[str, str] | None = None,
-) -> dict[str, str]:
-    """Build authenticated request headers without modifying the input.
+class ReadMeResponse(TypedDict):
+    """Expected structure shared by ReadMe API responses."""
 
-    Args:
-        headers: Optional request headers supplied by the caller.
+    data: object
+
+
+def _create_retry_session() -> requests.Session:
+    """Create an HTTP session configured to retry failures.
 
     Returns:
-        A new dictionary containing the caller's headers and authorization.
+        A session that retries requests after failures.
     """
-    request_headers = dict(headers or {})
-    request_headers["Authorization"] = f"Bearer {os.getenv('README_API_KEY')}"
-    return request_headers
+    retry = Retry(
+        # Retry up to three times after the initial request.
+        total=MAX_RETRIES,
+        # Increase the delay between retries instead of repeatedly sending
+        # requests to an API that may be temporarily unavailable.
+        backoff_factor=RETRY_BACKOFF_FACTOR,
+        # Retry rate limiting and temporary server failures.
+        status_forcelist=RETRY_STATUS_CODES,
+        # Retry every HTTP method used by this module.
+        allowed_methods=frozenset({"DELETE", "GET", "PATCH", "POST"}),
+        # Follow ReadMe's Retry-After header when it tells us how long to
+        # wait before sending another request.
+        respect_retry_after_header=True,
+        # Return the final unsuccessful response after all retries fail.
+        #
+        # This lets the existing code below raise its detailed RuntimeError
+        # containing the response status code and body.
+        raise_on_status=False,
+    )
+
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+
+    # Install the retry behavior for both HTTP and HTTPS URLs.
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    return session
 
 
-def _unwrap_data(payload: Mapping[str, Any]) -> Any:
-    """Return the resource stored in a response envelope.
+# Reuse one session for every request so all request functions have the same
+# retry behavior. A session also reuses its underlying HTTP connections.
+_SESSION = _create_retry_session()
+
+
+def _auth_headers(
+    headers: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Add authorization to the supplied request headers.
+
+    Args:
+        headers: Optional mutable request headers supplied by the caller.
+
+    Returns:
+        The supplied headers with authorization added, or a new dictionary
+        when no headers are supplied.
+    """
+    if headers is None:
+        headers = {}
+
+    headers["Authorization"] = f"Bearer {os.getenv('README_API_KEY')}"
+    return headers
+
+
+def _unwrap_object(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return an object stored in a response envelope.
 
     Args:
         payload: The decoded JSON response object.
 
     Returns:
-        The value stored under the response's ``data`` field.
+        The object stored under the response's ``data`` field.
 
     Raises:
         ValueError: If the response does not contain a ``data`` field.
+        TypeError: If the response's ``data`` field is not an object.
     """
     if "data" not in payload:
         raise ValueError("ReadMe response is missing the required 'data' field")
 
-    return payload["data"]
+    data = payload["data"]
+
+    # JSON objects are decoded into Python dictionaries.
+    if not isinstance(data, dict):
+        raise TypeError(
+            "Expected ReadMe response data to be an object, "
+            f"received {type(data).__name__}"
+        )
+
+    return data
+
+
+def _unwrap_list(payload: Mapping[str, Any]) -> list[Any]:
+    """Return a list stored in a response envelope.
+
+    Args:
+        payload: The decoded JSON response object.
+
+    Returns:
+        The list stored under the response's ``data`` field.
+
+    Raises:
+        ValueError: If the response does not contain a ``data`` field.
+        TypeError: If the response's ``data`` field is not a list.
+    """
+    if "data" not in payload:
+        raise ValueError("ReadMe response is missing the required 'data' field")
+
+    data = payload["data"]
+
+    # JSON arrays are decoded into Python lists.
+    if not isinstance(data, list):
+        raise TypeError(
+            "Expected ReadMe response data to be a list, "
+            f"received {type(data).__name__}"
+        )
+
+    return data
 
 
 def get(
     url: str,
-    headers: Mapping[str, str] | None = None,
-) -> Any | None:
+    headers: dict[str, str] | None = None,
+) -> dict[str, Any] | None:
     headers = _auth_headers(headers)
-    response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+    response = _SESSION.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
     logger.debug("get %s %s", url, response.status_code)
     if response.status_code == 404:
         return None
@@ -76,13 +180,13 @@ def get(
         raise RuntimeError(
             f"GET {url} failed with {response.status_code}: {response.text}"
         )
-
-    return _unwrap_data(response.json())
+    payload: ReadMeResponse = response.json()
+    return _unwrap_object(payload)
 
 
 def get_collection(
     url: str,
-    headers: Mapping[str, str] | None = None,
+    headers: dict[str, str] | None = None,
 ) -> list[dict[str, Any]]:
     """Retrieve every page from a paginated collection endpoint.
 
@@ -95,14 +199,13 @@ def get_collection(
 
     Raises:
         RuntimeError: If ReadMe returns an unsuccessful HTTP response.
-        TypeError: If the response's ``data`` field is not a list.
     """
     headers = _auth_headers(headers)
     items = []
     next_url = url
 
     while next_url:
-        response = requests.get(
+        response = _SESSION.get(
             next_url,
             headers=headers,
             timeout=REQUEST_TIMEOUT_SECONDS,
@@ -125,15 +228,7 @@ def get_collection(
             )
 
         payload = response.json()
-        data = _unwrap_data(payload)
-
-        # ReadMe collection responses should always contain a list
-        # under "data".
-        if not isinstance(data, list):
-            raise TypeError(
-                f"Expected collection data from {next_url} to be a list, "
-                f"received {type(data).__name__}"
-            )
+        data = _unwrap_list(payload)
 
         items.extend(data)
 
@@ -150,10 +245,10 @@ def get_collection(
 def post(
     url: str,
     data: Mapping[str, Any],
-    headers: Mapping[str, str] | None = None,
-) -> Any:
+    headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
     headers = _auth_headers(headers)
-    response = requests.post(
+    response = _SESSION.post(
         url, json=data, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
     )
     logger.debug("post %s %s", url, response.status_code)
@@ -166,13 +261,15 @@ def post(
 
     if not response.content:
         return {}
-    return _unwrap_data(response.json())
+
+    payload: ReadMeResponse = response.json()
+    return _unwrap_object(payload)
 
 
 def patch(
     url: str,
     data: Mapping[str, Any],
-    headers: Mapping[str, str] | None = None,
+    headers: dict[str, str] | None = None,
 ) -> bool:
     """Update a resource.
 
@@ -188,7 +285,7 @@ def patch(
         RuntimeError: If the request returns a client or server error.
     """
     headers = _auth_headers(headers)
-    response = requests.patch(
+    response = _SESSION.patch(
         url, json=data, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS
     )
     logger.debug("patch %s %s", url, response.status_code)
@@ -201,11 +298,11 @@ def patch(
 
 def delete(
     url: str,
-    headers: Mapping[str, str] | None = None,
+    headers: dict[str, str] | None = None,
 ) -> None:
     headers = _auth_headers(headers)
 
-    response = requests.delete(
+    response = _SESSION.delete(
         url,
         headers=headers,
         timeout=REQUEST_TIMEOUT_SECONDS,

--- a/tools/github_readme_sync/tests/export_test.py
+++ b/tools/github_readme_sync/tests/export_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Thousand Brains Project
+# Copyright 2025-2026 Thousand Brains Project
 # Copyright 2024 Numenta Inc.
 #
 # Copyright may exist in Contributors' modifications
@@ -11,7 +11,7 @@
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from tools.github_readme_sync.export import export
 from tools.github_readme_sync.readme import ReadMe
@@ -19,65 +19,116 @@ from tools.github_readme_sync.readme import ReadMe
 
 class TestExport(unittest.TestCase):
     def setUp(self):
-        # Create a temporary directory for the test
         self.test_dir = tempfile.TemporaryDirectory()
-        self.test_output_dir = Path(self.test_dir.name)
+        self.output_dir = Path(self.test_dir.name) / "exported-docs"
 
     def tearDown(self):
-        # Clean up the temporary directory after the test
         self.test_dir.cleanup()
 
-    def test_export(self):
-        # Create a mock instance of the ReadMe class
-        mock_readme = MagicMock(spec=ReadMe)
+    def test_export_rebuilds_nested_v2_pages_and_preserves_page_slugs(self):
+        rdme = MagicMock(spec=ReadMe)
 
-        # Inline mock return values for clarity
-        mock_readme.get_categories.return_value = [
-            {"title": "Category 1", "slug": "category-1"},
-            {"title": "Category 2", "slug": "category-2"},
+        # API v2 categories have titles but no category slug. export.py creates
+        # a local folder slug from the title.
+        category = {"title": "How to Use Monty"}
+        rdme.get_categories.return_value = [category]
+
+        # get_category_doc_tree() has already reconstructed the flat v2 page
+        # collection using parent URIs. Deliberately use titles that do not
+        # match the slugs to ensure export preserves server-provided slugs.
+        rdme.get_category_doc_tree.return_value = [
+            {
+                "title": "Getting Started with Monty",
+                "slug": "getting-started",
+                "uri": "/branches/0.40/guides/getting-started",
+                "children": [
+                    {
+                        "title": "Windows Setup via WSL",
+                        "slug": "getting-started-on-windows-via-wsl",
+                        "uri": (
+                            "/branches/0.40/guides/getting-started-on-windows-via-wsl"
+                        ),
+                        "parent": {"uri": "/branches/0.40/guides/getting-started"},
+                        "children": [],
+                    }
+                ],
+            }
         ]
 
-        # Explicitly differentiate the documents for each category
-        mock_readme.get_category_docs.side_effect = lambda category: (
-            [{"title": "Doc 1", "slug": "doc-1"}]
-            if category["slug"] == "category-1"
-            else [{"title": "Doc 2", "slug": "doc-2"}]
+        rdme.get_doc_by_slug.side_effect = lambda slug: {
+            "getting-started": "---\ntitle: Getting Started with Monty\n---\nRoot",
+            "getting-started-on-windows-via-wsl": (
+                "---\ntitle: Windows Setup via WSL\n---\nChild"
+            ),
+        }[slug]
+
+        hierarchy = export(self.output_dir, rdme)
+
+        self.assertEqual(
+            hierarchy,
+            [
+                {
+                    "title": "How to Use Monty",
+                    "slug": "how-to-use-monty",
+                    "children": [
+                        {
+                            "title": "Getting Started with Monty",
+                            "slug": "getting-started",
+                            "children": [
+                                {
+                                    "title": "Windows Setup via WSL",
+                                    "slug": ("getting-started-on-windows-via-wsl"),
+                                    "children": [],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
         )
 
-        # Explicitly differentiate the document content by slug
-        mock_readme.get_doc_by_slug.side_effect = lambda slug: (
-            "Content of Doc 1" if slug == "doc-1" else "Content of Doc 2"
+        root_file = self.output_dir / "how-to-use-monty" / "getting-started.md"
+        child_file = (
+            self.output_dir
+            / "how-to-use-monty"
+            / "getting-started"
+            / "getting-started-on-windows-via-wsl.md"
         )
 
-        # Call the function under test
-        hierarchy = export(self.test_output_dir, mock_readme)
+        self.assertTrue(root_file.is_file())
+        self.assertTrue(child_file.is_file())
+        self.assertEqual(
+            root_file.read_text(encoding="utf-8"),
+            "---\ntitle: Getting Started with Monty\n---\nRoot",
+        )
+        self.assertEqual(
+            child_file.read_text(encoding="utf-8"),
+            "---\ntitle: Windows Setup via WSL\n---\nChild",
+        )
 
-        # Assert the hierarchy is constructed correctly
-        expected_hierarchy = [
-            {
-                "title": "Category 1",
-                "slug": "category-1",
-                "children": [{"title": "Doc 1", "slug": "doc-1", "children": []}],
-            },
-            {
-                "title": "Category 2",
-                "slug": "category-2",
-                "children": [{"title": "Doc 2", "slug": "doc-2", "children": []}],
-            },
-        ]
-        self.assertEqual(hierarchy, expected_hierarchy)
+        rdme.get_category_doc_tree.assert_called_once_with(category)
+        self.assertEqual(
+            rdme.get_doc_by_slug.call_args_list,
+            [
+                call("getting-started"),
+                call("getting-started-on-windows-via-wsl"),
+            ],
+        )
 
-        # Assert that the directory structure is created as expected
-        self.assertTrue((self.test_output_dir / "category-1").is_dir())
-        self.assertTrue((self.test_output_dir / "category-2").is_dir())
+    def test_export_replaces_an_existing_output_directory(self):
+        rdme = MagicMock(spec=ReadMe)
+        rdme.get_categories.return_value = []
 
-        # Assert that the document files are created as expected
-        self.assertTrue((self.test_output_dir / "category-1" / "doc-1.md").is_file())
-        self.assertTrue((self.test_output_dir / "category-2" / "doc-2.md").is_file())
+        self.output_dir.mkdir(parents=True)
+        stale_file = self.output_dir / "stale.md"
+        stale_file.write_text("old export", encoding="utf-8")
 
-        # Assert the content of the files is correct
-        with (self.test_output_dir / "category-1" / "doc-1.md").open() as f:
-            self.assertEqual(f.read(), "Content of Doc 1")
+        hierarchy = export(self.output_dir, rdme)
 
-        with (self.test_output_dir / "category-2" / "doc-2.md").open() as f:
-            self.assertEqual(f.read(), "Content of Doc 2")
+        self.assertEqual(hierarchy, [])
+        self.assertTrue(self.output_dir.is_dir())
+        self.assertFalse(stale_file.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/github_readme_sync/tests/readme_test.py
+++ b/tools/github_readme_sync/tests/readme_test.py
@@ -14,7 +14,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import MagicMock, call, patch
 
 from tools.github_readme_sync.readme import (
     API_PREFIX,
@@ -485,10 +485,13 @@ class TestReadme(unittest.TestCase):
     @patch("tools.github_readme_sync.readme.post")
     @patch("tools.github_readme_sync.readme.patch")
     @patch.object(ReadMe, "get_doc")
-    @patch.object(ReadMe, "process_markdown", return_value="Updated body")
+    @patch.object(
+        ReadMe,
+        "process_markdown",
+        new=MagicMock(return_value="Updated body"),
+    )
     def test_create_or_update_doc_updates_without_sending_slug(
         self,
-        mock_process_markdown,
         mock_get_doc,
         mock_patch,
         mock_post,
@@ -530,12 +533,18 @@ class TestReadme(unittest.TestCase):
         mock_post.assert_not_called()
 
     @patch("tools.github_readme_sync.readme.post")
-    @patch.object(ReadMe, "get_doc", return_value=None)
-    @patch.object(ReadMe, "process_markdown", return_value="Body")
+    @patch.object(
+        ReadMe,
+        "get_doc",
+        new=MagicMock(return_value=None),
+    )
+    @patch.object(
+        ReadMe,
+        "process_markdown",
+        new=MagicMock(return_value="Body"),
+    )
     def test_create_or_update_doc_rejects_changed_created_slug(
         self,
-        mock_process_markdown,
-        mock_get_doc,
         mock_post,
     ):
         mock_post.return_value = {
@@ -553,12 +562,18 @@ class TestReadme(unittest.TestCase):
             )
 
     @patch("tools.github_readme_sync.readme.post")
-    @patch.object(ReadMe, "get_doc", return_value=None)
-    @patch.object(ReadMe, "process_markdown", return_value="Body")
+    @patch.object(
+        ReadMe,
+        "get_doc",
+        new=MagicMock(return_value=None),
+    )
+    @patch.object(
+        ReadMe,
+        "process_markdown",
+        new=MagicMock(return_value="Body"),
+    )
     def test_create_or_update_doc_requires_created_uri(
         self,
-        mock_process_markdown,
-        mock_get_doc,
         mock_post,
     ):
         mock_post.return_value = {"slug": "new-doc"}

--- a/tools/github_readme_sync/tests/readme_test.py
+++ b/tools/github_readme_sync/tests/readme_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Thousand Brains Project
+# Copyright 2025-2026 Thousand Brains Project
 # Copyright 2024 Numenta Inc.
 #
 # Copyright may exist in Contributors' modifications
@@ -14,9 +14,14 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import call, patch
 
-from tools.github_readme_sync.readme import GITHUB_RAW, ReadMe
+from tools.github_readme_sync.readme import (
+    API_PREFIX,
+    GITHUB_RAW,
+    DocumentNotFound,
+    ReadMe,
+)
 
 
 class TestReadme(unittest.TestCase):
@@ -25,337 +30,547 @@ class TestReadme(unittest.TestCase):
         self.readme = ReadMe(self.version)
 
     @patch("tools.github_readme_sync.readme.get")
-    def test_get_stable_version(self, mock_get):
-        mock_get.return_value = [
-            {
-                "version": "0.0-dry-run",
-                "version_clean": "0.0.0-dry-run",
-                "codename": "",
-                "is_stable": False,
-                "is_beta": False,
-                "is_hidden": True,
-                "is_deprecated": False,
-                "pdfStatus": "",
-                "_id": "66f2da3113724c00253aa01c",
-                "createdAt": "2024-09-24T15:26:41.131Z",
-            },
-            {
-                "version": "1.0.0",
-                "version_clean": "1.0.0",
-                "codename": "",
-                "is_stable": True,
-                "is_beta": False,
-                "is_hidden": False,
-                "is_deprecated": False,
-                "pdfStatus": "",
-                "_id": "6669fcac47cf690019d6192d",
-                "createdAt": "2024-06-12T19:53:16.502Z",
-            },
-        ]
+    def test_get_stable_version_uses_v2_stable_alias(self, mock_get):
+        mock_get.return_value = {
+            "name": "0.40",
+            "privacy": {"view": "default"},
+        }
+
         stable_version = self.readme.get_stable_version()
-        self.assertEqual(stable_version, "1.0.0")
-        mock_get.assert_called_once_with(
-            "https://dash.readme.com/api/v1/version",
-        )
+
+        self.assertEqual(stable_version, "0.40")
+        mock_get.assert_called_once_with(f"{API_PREFIX}/branches/stable")
 
     @patch("tools.github_readme_sync.readme.get")
-    def test_get_stable_version_none(self, mock_get):
-        # Simulate None being returned by the API
+    def test_get_stable_version_raises_when_alias_is_missing(self, mock_get):
         mock_get.return_value = None
 
-        # Assert that ValueError is raised when no versions are returned
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaisesRegex(ValueError, "No stable version found"):
             self.readme.get_stable_version()
 
+    @patch("tools.github_readme_sync.readme.get")
+    def test_get_stable_version_requires_name(self, mock_get):
+        mock_get.return_value = {"privacy": {"view": "default"}}
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Stable version response did not contain a name",
+        ):
+            self.readme.get_stable_version()
+
+    @patch("tools.github_readme_sync.readme.get_collection")
+    def test_get_categories_uses_branch_scoped_v2_endpoint(
+        self,
+        mock_get_collection,
+    ):
+        categories = [
+            {"title": "Category 2", "uri": "/categories/Category%202"},
+            {"title": "Category 1", "uri": "/categories/Category%201"},
+        ]
+        mock_get_collection.return_value = categories
+
+        result = self.readme.get_categories()
+
+        # The API response order is preserved; v2 does not return the old
+        # category order property that the v1 tests sorted on.
+        self.assertEqual(result, categories)
+        mock_get_collection.assert_called_once_with(
+            f"{API_PREFIX}/branches/{self.version}/categories/guides"
+        )
+
+    @patch("tools.github_readme_sync.readme.get_collection")
+    def test_get_categories_empty_collection(self, mock_get_collection):
+        mock_get_collection.return_value = []
+
+        self.assertEqual(self.readme.get_categories(), [])
+
+    @patch("tools.github_readme_sync.readme.get_collection")
+    def test_get_category_docs_uses_quoted_category_title(
+        self,
+        mock_get_collection,
+    ):
+        pages = [
+            {
+                "title": "Doc 1",
+                "slug": "doc-1",
+                "uri": "/branches/1.0.0/guides/doc-1",
+            }
+        ]
+        mock_get_collection.return_value = pages
+
+        result = self.readme.get_category_docs({"title": "How to Use Monty & More"})
+
+        self.assertEqual(result, pages)
+        mock_get_collection.assert_called_once_with(
+            f"{API_PREFIX}/branches/{self.version}/categories/"
+            "guides/How%20to%20Use%20Monty%20%26%20More/pages"
+        )
+
+    @patch.object(ReadMe, "get_category_docs")
+    def test_get_category_doc_tree_rebuilds_nested_pages(
+        self,
+        mock_get_category_docs,
+    ):
+        parent_uri = "/branches/1.0.0/guides/parent"
+        mock_get_category_docs.return_value = [
+            {
+                "title": "Parent",
+                "slug": "parent",
+                "uri": parent_uri,
+                "parent": None,
+            },
+            {
+                "title": "First Child",
+                "slug": "first-child",
+                "uri": "/branches/1.0.0/guides/first-child",
+                "parent": {"uri": parent_uri},
+            },
+            {
+                "title": "Second Child",
+                "slug": "second-child",
+                "uri": "/branches/1.0.0/guides/second-child",
+                "parent": {"uri": parent_uri},
+            },
+            {
+                "title": "Other Root",
+                "slug": "other-root",
+                "uri": "/branches/1.0.0/guides/other-root",
+                "parent": None,
+            },
+        ]
+
+        roots = self.readme.get_category_doc_tree({"title": "Category"})
+
         self.assertEqual(
-            str(context.exception), "Failed to retrieve versions or no versions found"
+            [page["slug"] for page in roots],
+            ["parent", "other-root"],
         )
-        mock_get.assert_called_once_with(
-            "https://dash.readme.com/api/v1/version",
+        self.assertEqual(
+            [child["slug"] for child in roots[0]["children"]],
+            ["first-child", "second-child"],
         )
+        self.assertEqual(roots[1]["children"], [])
 
-    @patch("tools.github_readme_sync.readme.get")
-    def test_get_categories(self, mock_get):
-        mock_get.return_value = [
-            {"order": 2, "name": "Category 2"},
-            {"order": 1, "name": "Category 1"},
+    @patch.object(ReadMe, "get_category_docs")
+    def test_get_category_doc_tree_rejects_page_without_uri(
+        self,
+        mock_get_category_docs,
+    ):
+        mock_get_category_docs.return_value = [
+            {"title": "Missing URI", "slug": "missing-uri"}
         ]
-        categories = self.readme.get_categories()
-        self.assertEqual(len(categories), 2)
-        self.assertEqual(categories[0]["name"], "Category 1")
-        mock_get.assert_called_once_with(
-            "https://dash.readme.com/api/v1/categories",
-            {"x-readme-version": self.version},
-        )
 
-    @patch("tools.github_readme_sync.readme.get")
-    def test_get_categories_none(self, mock_get):
-        mock_get.return_value = None
-        categories = self.readme.get_categories()
-        # assert empty list
-        self.assertEqual(categories, [])
-        mock_get.assert_called_once_with(
-            "https://dash.readme.com/api/v1/categories",
-            {"x-readme-version": self.version},
-        )
+        with self.assertRaisesRegex(ValueError, "has no uri"):
+            self.readme.get_category_doc_tree({"title": "Category"})
 
-    @patch("tools.github_readme_sync.readme.get")
-    def test_get_categories_raises_error(self, mock_get):
-        mock_get.side_effect = ValueError("Failed to get categories")
-        with self.assertRaises(ValueError) as context:
-            self.readme.get_categories()
-        self.assertEqual(str(context.exception), "Failed to get categories")
-
-    @patch("tools.github_readme_sync.readme.get")
-    def test_get_category_docs(self, mock_get):
-        mock_get.return_value = [
-            {"order": 2, "name": "Doc 2"},
-            {"order": 1, "name": "Doc 1"},
+    @patch.object(ReadMe, "get_category_docs")
+    def test_get_category_doc_tree_rejects_duplicate_uri(
+        self,
+        mock_get_category_docs,
+    ):
+        duplicate_uri = "/branches/1.0.0/guides/duplicate"
+        mock_get_category_docs.return_value = [
+            {"title": "One", "slug": "one", "uri": duplicate_uri},
+            {"title": "Two", "slug": "two", "uri": duplicate_uri},
         ]
-        docs = self.readme.get_category_docs({"slug": "example-category"})
-        self.assertEqual(len(docs), 2)
-        self.assertEqual(docs[0]["name"], "Doc 1")
-        mock_get.assert_called_once_with(
-            "https://dash.readme.com/api/v1/categories/example-category/docs",
-            {"x-readme-version": self.version},
-        )
+
+        with self.assertRaisesRegex(ValueError, "duplicate page URI"):
+            self.readme.get_category_doc_tree({"title": "Category"})
+
+    @patch.object(ReadMe, "get_category_docs")
+    def test_get_category_doc_tree_rejects_missing_parent(
+        self,
+        mock_get_category_docs,
+    ):
+        mock_get_category_docs.return_value = [
+            {
+                "title": "Orphan",
+                "slug": "orphan",
+                "uri": "/branches/1.0.0/guides/orphan",
+                "parent": {"uri": "/branches/1.0.0/guides/missing"},
+            }
+        ]
+
+        with self.assertRaisesRegex(ValueError, "refers to missing parent URI"):
+            self.readme.get_category_doc_tree({"title": "Category"})
 
     @patch("tools.github_readme_sync.readme.get")
-    def test_get_category_docs_raises_error(self, mock_get):
-        mock_get.side_effect = ValueError("Failed to get category docs")
-        with self.assertRaises(ValueError) as context:
-            self.readme.get_category_docs({"slug": "example-category"})
-        self.assertEqual(str(context.exception), "Failed to get category docs")
-
-    @patch("tools.github_readme_sync.readme.get")
-    def test_get_doc_by_slug(self, mock_get):
+    def test_get_doc_by_slug_exports_v2_content_and_frontmatter(self, mock_get):
         mock_get.return_value = {
             "title": "Test Document",
-            "body": "This is a test document.",
-            "hidden": False,
+            "slug": "test-doc",
+            "uri": "/branches/1.0.0/guides/test-doc",
+            "privacy": {"view": "public"},
+            "content": {
+                "body": "This is a test document.",
+                "excerpt": "A description",
+            },
         }
+
         doc = self.readme.get_doc_by_slug("test-doc")
+
         self.assertIn("title: Test Document", doc)
+        self.assertIn("description: A description", doc)
         self.assertIn("This is a test document.", doc)
         mock_get.assert_called_once_with(
-            "https://dash.readme.com/api/v1/docs/test-doc",
-            {"x-readme-version": self.version},
+            f"{API_PREFIX}/branches/{self.version}/guides/test-doc"
         )
 
     @patch("tools.github_readme_sync.readme.get")
-    def test_get_doc_by_slug_escaped(self, mock_get):
+    def test_get_doc_by_slug_exports_hidden_page_and_empty_body(self, mock_get):
         mock_get.return_value = {
             "title": "[Test] Document",
-            "body": "This is a test document.",
-            "hidden": True,
+            "slug": "test-doc",
+            "uri": "/branches/1.0.0/guides/test-doc",
+            "privacy": {"view": "anyone_with_link"},
+            "content": {"body": None, "excerpt": None},
         }
+
         doc = self.readme.get_doc_by_slug("test-doc")
+
         self.assertEqual(
             doc,
-            """---
-title: '[Test] Document'
-hidden: true
----
-This is a test document.""",
-        )
-        mock_get.assert_called_once_with(
-            "https://dash.readme.com/api/v1/docs/test-doc",
-            {"x-readme-version": self.version},
+            "---\ntitle: '[Test] Document'\nhidden: true\n---\n",
         )
 
     @patch("tools.github_readme_sync.readme.get")
-    def test_get_doc_by_slug_raises_error(self, mock_get):
-        mock_get.side_effect = ValueError("Failed to get doc")
-        with self.assertRaises(ValueError) as context:
-            self.readme.get_doc_by_slug("test-doc")
-        self.assertEqual(str(context.exception), "Failed to get doc")
+    def test_get_doc_by_slug_raises_document_not_found(self, mock_get):
+        mock_get.return_value = None
+
+        with self.assertRaisesRegex(DocumentNotFound, "Document missing not found"):
+            self.readme.get_doc_by_slug("missing")
 
     @patch("tools.github_readme_sync.readme.get")
-    def test_get_doc_id(self, mock_get):
-        mock_get.return_value = {"_id": "123"}
-        doc_id = self.readme.get_doc_id("test-doc")
-        self.assertEqual(doc_id, "123")
-        mock_get.assert_called_once_with(
-            "https://dash.readme.com/api/v1/docs/test-doc",
-            {"x-readme-version": self.version},
-        )
+    def test_get_doc_rejects_alias_or_changed_slug(self, mock_get):
+        mock_get.return_value = {
+            "title": "Document",
+            "slug": "canonical-slug",
+            "uri": "/branches/1.0.0/guides/canonical-slug",
+        }
 
-    @patch("tools.github_readme_sync.readme.put")
-    def test_make_version_stable(self, mock_put):
-        mock_put.return_value = True
+        with self.assertRaisesRegex(
+            ValueError,
+            "resolved requested slug 'requested-slug' to 'canonical-slug'",
+        ):
+            self.readme.get_doc("requested-slug")
+
+    @patch("tools.github_readme_sync.readme.get")
+    def test_get_doc_requires_resource_uri(self, mock_get):
+        mock_get.return_value = {"title": "Document", "slug": "test-doc"}
+
+        with self.assertRaisesRegex(ValueError, "has no uri"):
+            self.readme.get_doc("test-doc")
+
+    @patch("tools.github_readme_sync.readme.patch")
+    def test_make_version_stable_uses_live_v2_privacy_behavior(self, mock_patch):
         self.readme.make_version_stable()
-        mock_put.assert_called_once_with(
-            f"https://dash.readme.com/api/v1/version/{self.version}",
-            {"is_stable": True, "is_hidden": False},
+
+        mock_patch.assert_called_once_with(
+            f"{API_PREFIX}/branches/{self.version}",
+            {"privacy": {"view": "default"}},
         )
 
-    @patch("tools.github_readme_sync.readme.put")
-    def test_make_version_stable_with_suffix(self, mock_put):
+    @patch("tools.github_readme_sync.readme.patch")
+    def test_make_version_stable_skips_preview_version(self, mock_patch):
         self.readme.version = "1.0.0-beta"
+
         self.readme.make_version_stable()
-        mock_put.assert_not_called()
 
-    @patch("tools.github_readme_sync.readme.get")
+        mock_patch.assert_not_called()
+
+    @patch.object(ReadMe, "get_stable_version", return_value="0.39")
     @patch("tools.github_readme_sync.readme.post")
-    def test_create_version_if_not_exists(self, mock_post, mock_get):
-        # Mock the first get call to check if the version exists (returns None)
-        mock_get.side_effect = [
-            None,  # First get call for checking if the version exists
-            [
-                {
-                    "version": "0.0.0-base",
-                    "version_clean": "0.0.0-base",
-                    "is_stable": True,
-                    "is_beta": False,
-                    "is_hidden": False,
-                    "is_deprecated": False,
-                    "pdfStatus": "",
-                    "_id": "66f2da3113724c00253aa01c",
-                    "createdAt": "2024-09-24T15:26:41.131Z",
-                }
-            ],  # Second get call to retrieve stable versions
-        ]
+    @patch("tools.github_readme_sync.readme.get")
+    def test_create_version_if_not_exists_uses_v2_branch_payload(
+        self,
+        mock_get,
+        mock_post,
+        mock_get_stable_version,
+    ):
+        mock_get.return_value = None
+        mock_post.return_value = {
+            "name": self.version,
+            "uri": f"/branches/{self.version}",
+        }
 
-        # Mock the post call to create the new version
-        mock_post.return_value = True
-
-        # Call the method to test
         created = self.readme.create_version_if_not_exists()
 
-        # Assert the version was created
         self.assertTrue(created)
-
-        # Check if the right API calls were made
-        mock_get.assert_any_call(
-            f"https://dash.readme.com/api/v1/version/{self.version}"
-        )
-
-        mock_get.assert_any_call("https://dash.readme.com/api/v1/version")
-
+        mock_get.assert_called_once_with(f"{API_PREFIX}/branches/{self.version}")
+        mock_get_stable_version.assert_called_once_with()
         mock_post.assert_called_once_with(
-            "https://dash.readme.com/api/v1/version",
+            f"{API_PREFIX}/branches",
             {
-                "version": self.version,
-                "from": "0.0.0-base",
-                "is_stable": False,
-                "is_hidden": True,
+                "name": self.version,
+                "base": "0.39",
+                "privacy": {"view": "hidden"},
             },
         )
+
+    @patch("tools.github_readme_sync.readme.post")
+    @patch("tools.github_readme_sync.readme.get")
+    def test_create_version_if_not_exists_returns_false_when_branch_exists(
+        self,
+        mock_get,
+        mock_post,
+    ):
+        mock_get.return_value = {"name": self.version}
+
+        created = self.readme.create_version_if_not_exists()
+
+        self.assertFalse(created)
+        mock_post.assert_not_called()
 
     @patch.object(ReadMe, "get_categories")
     @patch("tools.github_readme_sync.readme.delete")
-    def test_delete_categories(self, mock_delete, mock_get_categories):
+    def test_delete_categories_uses_category_titles(
+        self,
+        mock_delete,
+        mock_get_categories,
+    ):
         mock_get_categories.return_value = [
-            {"slug": "category-1"},
-            {"slug": "category-2"},
+            {"title": "Category 1"},
+            {"title": "Category 2"},
         ]
+
         self.readme.delete_categories()
-        mock_get_categories.assert_called_once_with()
-        self.assertEqual(mock_delete.call_count, 2)
 
-    @patch("tools.github_readme_sync.readme.delete")
-    def test_delete_category(self, mock_delete):
-        self.readme.delete_category("category-1")
-        mock_delete.assert_called_once_with(
-            "https://dash.readme.com/api/v1/categories/category-1",
-            {"x-readme-version": self.version},
+        self.assertEqual(
+            mock_delete.call_args_list,
+            [
+                call(
+                    f"{API_PREFIX}/branches/{self.version}/"
+                    "categories/guides/Category%201"
+                ),
+                call(
+                    f"{API_PREFIX}/branches/{self.version}/"
+                    "categories/guides/Category%202"
+                ),
+            ],
         )
 
     @patch("tools.github_readme_sync.readme.delete")
-    def test_delete_doc(self, mock_delete):
+    def test_delete_category_quotes_title(self, mock_delete):
+        self.readme.delete_category("How to Use Monty & More")
+
+        mock_delete.assert_called_once_with(
+            f"{API_PREFIX}/branches/{self.version}/categories/"
+            "guides/How%20to%20Use%20Monty%20%26%20More"
+        )
+
+    @patch("tools.github_readme_sync.readme.delete")
+    def test_delete_doc_uses_branch_scoped_v2_endpoint(self, mock_delete):
         self.readme.delete_doc("doc-1")
+
         mock_delete.assert_called_once_with(
-            "https://dash.readme.com/api/v1/docs/doc-1",
-            {"x-readme-version": self.version},
+            f"{API_PREFIX}/branches/{self.version}/guides/doc-1"
         )
 
-    @patch("tools.github_readme_sync.readme.get")
+    @patch("tools.github_readme_sync.readme.delete")
+    def test_delete_version_uses_v2_branch_endpoint(self, mock_delete):
+        self.readme.delete_version()
+
+        mock_delete.assert_called_once_with(f"{API_PREFIX}/branches/{self.version}")
+
     @patch("tools.github_readme_sync.readme.post")
-    def test_create_category_if_not_exists(self, mock_post, mock_get):
+    @patch("tools.github_readme_sync.readme.get")
+    def test_create_category_if_not_exists_uses_title_and_resource_uri(
+        self,
+        mock_get,
+        mock_post,
+    ):
         mock_get.return_value = None
-        mock_post.return_value = json.dumps({"_id": "new-category-id"})
-        category_id, created = self.readme.create_category_if_not_exists("New Category")
+        mock_post.return_value = {
+            "title": "New Category",
+            "uri": "/branches/1.0.0/categories/guides/New%20Category",
+        }
+
+        category_uri, created = self.readme.create_category_if_not_exists(
+            "New Category"
+        )
+
         self.assertTrue(created)
-        self.assertEqual(category_id, "new-category-id")
+        self.assertEqual(
+            category_uri,
+            "/branches/1.0.0/categories/guides/New%20Category",
+        )
         mock_get.assert_called_once_with(
-            "https://dash.readme.com/api/v1/categories/new-category",
-            {"x-readme-version": self.version},
+            f"{API_PREFIX}/branches/{self.version}/categories/guides/New%20Category"
         )
         mock_post.assert_called_once_with(
-            "https://dash.readme.com/api/v1/categories",
-            {"title": "New Category", "type": "guide"},
-            {"x-readme-version": self.version},
+            f"{API_PREFIX}/branches/{self.version}/categories",
+            {"title": "New Category", "section": "guide"},
         )
 
-    @patch("tools.github_readme_sync.readme.get")
-    @patch("tools.github_readme_sync.readme.put")
     @patch("tools.github_readme_sync.readme.post")
-    @patch.dict(os.environ, {"IMAGE_PATH": "user/repo"})
-    def test_create_or_update_doc(self, mock_post, mock_put, mock_get):
-        mock_get.return_value = None  # Doc does not exist
-        mock_post.return_value = json.dumps({"_id": "new-doc-id"})
-        doc_id, created = self.readme.create_or_update_doc(
-            order=1,
-            category_id="category-id",
-            doc={"title": "New Doc", "body": "This is a new doc.", "slug": "new-doc"},
-            parent_id="parent-doc-id",
-            file_path="docs/new-doc.md",
-        )
-        self.assertTrue(created)
-        self.assertEqual(doc_id, "new-doc-id")
-        # Get the actual body from the call arguments
-        actual_body = mock_post.call_args[0][1]["body"]
-        self.assertTrue(actual_body.startswith("This is a new doc."))
+    @patch("tools.github_readme_sync.readme.get")
+    def test_create_category_if_not_exists_returns_existing_uri(
+        self,
+        mock_get,
+        mock_post,
+    ):
+        mock_get.return_value = {
+            "title": "Existing Category",
+            "uri": "/branches/1.0.0/categories/guides/Existing%20Category",
+        }
 
+        category_uri, created = self.readme.create_category_if_not_exists(
+            "Existing Category"
+        )
+
+        self.assertFalse(created)
+        self.assertEqual(
+            category_uri,
+            "/branches/1.0.0/categories/guides/Existing%20Category",
+        )
+        mock_post.assert_not_called()
+
+    @patch("tools.github_readme_sync.readme.post")
+    @patch("tools.github_readme_sync.readme.patch")
+    @patch.object(ReadMe, "get_doc")
+    @patch.object(ReadMe, "process_markdown", return_value="Processed body")
+    def test_create_or_update_doc_creates_v2_guide(
+        self,
+        mock_process_markdown,
+        mock_get_doc,
+        mock_patch,
+        mock_post,
+    ):
+        mock_get_doc.return_value = None
+        mock_post.return_value = {
+            "slug": "new-doc",
+            "uri": "/branches/1.0.0/guides/new-doc",
+        }
+        doc = {
+            "title": "New Doc",
+            "body": "This is a new doc.",
+            "slug": "new-doc",
+            "description": "A description",
+        }
+
+        doc_uri, created = self.readme.create_or_update_doc(
+            order=1,
+            category_id="/branches/1.0.0/categories/guides/Category",
+            doc=doc,
+            parent_id="/branches/1.0.0/guides/parent-doc",
+            file_path="docs/category",
+        )
+
+        self.assertTrue(created)
+        self.assertEqual(doc_uri, "/branches/1.0.0/guides/new-doc")
+        mock_process_markdown.assert_called_once_with(
+            "This is a new doc.",
+            "docs/category",
+            "new-doc",
+        )
         mock_post.assert_called_once_with(
-            "https://dash.readme.com/api/v1/docs",
+            f"{API_PREFIX}/branches/{self.version}/guides",
             {
                 "title": "New Doc",
                 "type": "basic",
-                "body": mock_post.call_args[0][1]["body"],  # Use actual body
-                "category": "category-id",
-                "hidden": False,
-                "order": 1,
-                "parentDoc": "parent-doc-id",
+                "content": {
+                    "body": "Processed body",
+                    "excerpt": "A description",
+                },
+                "category": {"uri": "/branches/1.0.0/categories/guides/Category"},
+                "privacy": {"view": "public"},
+                "position": 1,
+                "parent": {"uri": "/branches/1.0.0/guides/parent-doc"},
                 "slug": "new-doc",
             },
-            {"x-readme-version": self.version},
+            headers={"prefer": "handling=strict"},
         )
-        mock_put.assert_not_called()
+        mock_patch.assert_not_called()
 
-    @patch("tools.github_readme_sync.readme.get")
     @patch("tools.github_readme_sync.readme.post")
-    @patch.dict(os.environ, {"IMAGE_PATH": "user/repo"})
-    def test_description_field_is_sent_to_readme_as_excerpt(self, mock_post, mock_get):
-        mock_get.return_value = None  # Doc does not exist
-        mock_post.return_value = json.dumps({"_id": "glossary-id"})
-
-        # Create a document with a description field
-        doc_with_description = {
-            "title": "Glossary",
-            "body": "Glossary content",
-            "slug": "glossary",
-            "description": "A collection of terms",
+    @patch("tools.github_readme_sync.readme.patch")
+    @patch.object(ReadMe, "get_doc")
+    @patch.object(ReadMe, "process_markdown", return_value="Updated body")
+    def test_create_or_update_doc_updates_without_sending_slug(
+        self,
+        mock_process_markdown,
+        mock_get_doc,
+        mock_patch,
+        mock_post,
+    ):
+        mock_get_doc.return_value = {
+            "slug": "existing-doc",
+            "uri": "/branches/1.0.0/guides/existing-doc",
+        }
+        doc = {
+            "title": "Existing Doc",
+            "body": "Updated source",
+            "slug": "existing-doc",
+            "hidden": True,
         }
 
-        self.readme.create_or_update_doc(
-            order=1,
-            category_id="category-id",
-            doc=doc_with_description,
-            parent_id="parent-doc-id",
-            file_path="docs/glossary.md",
+        doc_uri, created = self.readme.create_or_update_doc(
+            order=2,
+            category_id="/branches/1.0.0/categories/guides/Category",
+            doc=doc,
+            parent_id=None,
+            file_path="docs/category",
         )
 
-        self.assertIn(
-            "excerpt",
-            mock_post.call_args[0][1],
-            "Excerpt field is missing",
+        self.assertFalse(created)
+        self.assertEqual(doc_uri, "/branches/1.0.0/guides/existing-doc")
+        expected_payload = {
+            "title": "Existing Doc",
+            "type": "basic",
+            "content": {"body": "Updated body"},
+            "category": {"uri": "/branches/1.0.0/categories/guides/Category"},
+            "privacy": {"view": "anyone_with_link"},
+            "position": 2,
+        }
+        mock_patch.assert_called_once_with(
+            f"{API_PREFIX}/branches/{self.version}/guides/existing-doc",
+            expected_payload,
         )
-        self.assertEqual(
-            mock_post.call_args[0][1]["excerpt"],
-            "A collection of terms",
-            "Excerpt field value is incorrect",
-        )
+        self.assertNotIn("slug", expected_payload)
+        mock_post.assert_not_called()
+
+    @patch("tools.github_readme_sync.readme.post")
+    @patch.object(ReadMe, "get_doc", return_value=None)
+    @patch.object(ReadMe, "process_markdown", return_value="Body")
+    def test_create_or_update_doc_rejects_changed_created_slug(
+        self,
+        mock_process_markdown,
+        mock_get_doc,
+        mock_post,
+    ):
+        mock_post.return_value = {
+            "slug": "new-doc-1",
+            "uri": "/branches/1.0.0/guides/new-doc-1",
+        }
+
+        with self.assertRaisesRegex(ValueError, "expected 'new-doc'"):
+            self.readme.create_or_update_doc(
+                order=0,
+                category_id="/branches/1.0.0/categories/guides/Category",
+                doc={"title": "New Doc", "body": "Body", "slug": "new-doc"},
+                parent_id=None,
+                file_path="docs/category",
+            )
+
+    @patch("tools.github_readme_sync.readme.post")
+    @patch.object(ReadMe, "get_doc", return_value=None)
+    @patch.object(ReadMe, "process_markdown", return_value="Body")
+    def test_create_or_update_doc_requires_created_uri(
+        self,
+        mock_process_markdown,
+        mock_get_doc,
+        mock_post,
+    ):
+        mock_post.return_value = {"slug": "new-doc"}
+
+        with self.assertRaisesRegex(ValueError, "has no uri"):
+            self.readme.create_or_update_doc(
+                order=0,
+                category_id="/branches/1.0.0/categories/guides/Category",
+                doc={"title": "New Doc", "body": "Body", "slug": "new-doc"},
+                parent_id=None,
+                file_path="docs/category",
+            )
 
     @patch.dict(os.environ, {"IMAGE_PATH": "user/repo/refs/head/main/docs/figures"})
     def test_correct_image_locations_markdown(self):
@@ -864,3 +1079,7 @@ This is a test document.""",
         self.assertIn("<h1>Test Content</h1>", sanitized_html)
         self.assertIn("<p>This is a test paragraph</p>", sanitized_html)
         self.assertIn("<p>More content after the script</p>", sanitized_html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/github_readme_sync/tests/req_test.py
+++ b/tools/github_readme_sync/tests/req_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Thousand Brains Project
+# Copyright 2025-2026 Thousand Brains Project
 # Copyright 2024 Numenta Inc.
 #
 # Copyright may exist in Contributors' modifications
@@ -10,192 +10,265 @@
 
 import os
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
-from tools.github_readme_sync.readme import ReadMe
-from tools.github_readme_sync.req import REQUEST_TIMEOUT_SECONDS, delete, get, post, put
+from tools.github_readme_sync.req import (
+    REQUEST_TIMEOUT_SECONDS,
+    delete,
+    get,
+    get_collection,
+    patch as patch_request,
+    post,
+)
 
 
 @patch.dict(os.environ, {"README_API_KEY": "test_api_key"})
 class TestReq(unittest.TestCase):
-    @patch("requests.get")
-    def test_get_success(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {"key": "value"}
-        mock_get.return_value = mock_response
+    """Tests for the shared ReadMe API v2 request helpers."""
 
-        url = "https://api.example.com/data"
-        result = get(url)
+    @patch("tools.github_readme_sync.req.requests.get")
+    def test_get_success_unwraps_v2_data(self, mock_get):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"data": {"slug": "test-doc"}}
+        mock_get.return_value = response
 
-        self.assertEqual(result, {"key": "value"})
+        result = get("https://api.example.com/data")
+
+        self.assertEqual(result, {"slug": "test-doc"})
         mock_get.assert_called_once_with(
-            url,
-            headers={"Authorization": "Basic test_api_key"},
+            "https://api.example.com/data",
+            headers={"Authorization": "Bearer test_api_key"},
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
-    @patch("requests.get")
-    def test_get_404(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.status_code = 404
-        mock_get.return_value = mock_response
+    @patch("tools.github_readme_sync.req.requests.get")
+    def test_get_preserves_caller_headers(self, mock_get):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"data": {"name": "0.40"}}
+        mock_get.return_value = response
 
-        url = "https://api.example.com/data"
-        result = get(url)
+        caller_headers = {"prefer": "handling=strict"}
+        result = get("https://api.example.com/data", caller_headers)
+
+        self.assertEqual(result, {"name": "0.40"})
+        # The helper adds Bearer authentication without mutating the input.
+        self.assertEqual(caller_headers, {"prefer": "handling=strict"})
+        mock_get.assert_called_once_with(
+            "https://api.example.com/data",
+            headers={
+                "prefer": "handling=strict",
+                "Authorization": "Bearer test_api_key",
+            },
+            timeout=REQUEST_TIMEOUT_SECONDS,
+        )
+
+    @patch("tools.github_readme_sync.req.requests.get")
+    def test_get_404_returns_none(self, mock_get):
+        response = MagicMock()
+        response.status_code = 404
+        mock_get.return_value = response
+
+        result = get("https://api.example.com/missing")
 
         self.assertIsNone(result)
-        mock_get.assert_called_once_with(
-            url,
-            headers={"Authorization": "Basic test_api_key"},
-            timeout=REQUEST_TIMEOUT_SECONDS,
+
+    @patch("tools.github_readme_sync.req.requests.get")
+    def test_get_non_404_failure_raises(self, mock_get):
+        response = MagicMock()
+        response.status_code = 500
+        response.text = "Internal Server Error"
+        mock_get.return_value = response
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            r"GET https://api\.example\.com/data failed with 500",
+        ):
+            get("https://api.example.com/data")
+
+    @patch("tools.github_readme_sync.req.requests.get")
+    def test_get_collection_follows_v2_pagination(self, mock_get):
+        first_response = MagicMock()
+        first_response.status_code = 200
+        first_response.url = "https://api.readme.com/v2/branches/0.40/guides"
+        first_response.json.return_value = {
+            "data": [{"slug": "doc-1"}],
+            "paging": {"next": "/v2/branches/0.40/guides?page=2"},
+        }
+
+        second_response = MagicMock()
+        second_response.status_code = 200
+        second_response.url = "https://api.readme.com/v2/branches/0.40/guides?page=2"
+        second_response.json.return_value = {
+            "data": [{"slug": "doc-2"}],
+            "paging": {"next": None},
+        }
+
+        mock_get.side_effect = [first_response, second_response]
+
+        result = get_collection("https://api.readme.com/v2/branches/0.40/guides")
+
+        self.assertEqual(result, [{"slug": "doc-1"}, {"slug": "doc-2"}])
+        self.assertEqual(
+            mock_get.call_args_list,
+            [
+                call(
+                    "https://api.readme.com/v2/branches/0.40/guides",
+                    headers={"Authorization": "Bearer test_api_key"},
+                    timeout=REQUEST_TIMEOUT_SECONDS,
+                ),
+                call(
+                    "https://api.readme.com/v2/branches/0.40/guides?page=2",
+                    headers={"Authorization": "Bearer test_api_key"},
+                    timeout=REQUEST_TIMEOUT_SECONDS,
+                ),
+            ],
         )
 
-    @patch("requests.get")
-    def test_get_failure(self, mock_get):
-        mock_response = MagicMock()
-        mock_response.status_code = 500
-        mock_response.text = "Internal Server Error"
-        mock_get.return_value = mock_response
+    @patch("tools.github_readme_sync.req.requests.get")
+    def test_get_collection_404_returns_items_already_collected(self, mock_get):
+        first_response = MagicMock()
+        first_response.status_code = 200
+        first_response.url = "https://api.readme.com/v2/items"
+        first_response.json.return_value = {
+            "data": [{"slug": "doc-1"}],
+            "paging": {"next": "/v2/items?page=2"},
+        }
 
-        url = "https://api.example.com/data"
-        with self.assertLogs(level="ERROR") as log:
-            result = get(url)
+        second_response = MagicMock()
+        second_response.status_code = 404
+        mock_get.side_effect = [first_response, second_response]
 
-        self.assertIsNone(result)
-        self.assertIn("Failed to get https://api.example.com/data", log.output[0])
-        mock_get.assert_called_once_with(
-            url,
-            headers={"Authorization": "Basic test_api_key"},
-            timeout=REQUEST_TIMEOUT_SECONDS,
+        result = get_collection("https://api.readme.com/v2/items")
+
+        self.assertEqual(result, [{"slug": "doc-1"}])
+
+    @patch("tools.github_readme_sync.req.requests.get")
+    def test_get_collection_rejects_non_list_data(self, mock_get):
+        response = MagicMock()
+        response.status_code = 200
+        response.url = "https://api.readme.com/v2/items"
+        response.json.return_value = {"data": {"slug": "not-a-list"}}
+        mock_get.return_value = response
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Expected collection data .* to be a list",
+        ):
+            get_collection("https://api.readme.com/v2/items")
+
+    @patch("tools.github_readme_sync.req.requests.get")
+    def test_get_collection_failure_raises_instead_of_returning_partial_data(
+        self, mock_get
+    ):
+        response = MagicMock()
+        response.status_code = 429
+        response.text = "Rate limited"
+        mock_get.return_value = response
+
+        with self.assertRaisesRegex(RuntimeError, "failed with 429"):
+            get_collection("https://api.readme.com/v2/items")
+
+    @patch("tools.github_readme_sync.req.requests.post")
+    def test_post_success_unwraps_v2_data(self, mock_post):
+        response = MagicMock()
+        response.status_code = 201
+        response.content = b'{"data": {"uri": "/guides/doc"}}'
+        response.json.return_value = {"data": {"uri": "/guides/doc"}}
+        mock_post.return_value = response
+
+        result = post(
+            "https://api.example.com/data",
+            {"slug": "doc"},
+            {"prefer": "handling=strict"},
         )
 
-    @patch("requests.post")
-    def test_post_success(self, mock_post):
-        mock_response = MagicMock()
-        mock_response.status_code = 201
-        mock_response.text = "Created"
-        mock_post.return_value = mock_response
-
-        url = "https://api.example.com/data"
-        data = {"key": "value"}
-        result = post(url, data, {"version": "1.0"})
-
-        self.assertEqual(result, "Created")
+        self.assertEqual(result, {"uri": "/guides/doc"})
         mock_post.assert_called_once_with(
-            url,
-            json=data,
-            headers={"Authorization": "Basic test_api_key", "version": "1.0"},
+            "https://api.example.com/data",
+            json={"slug": "doc"},
+            headers={
+                "prefer": "handling=strict",
+                "Authorization": "Bearer test_api_key",
+            },
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
-    @patch("requests.post")
-    def test_post_failure(self, mock_post):
-        mock_response = MagicMock()
-        mock_response.status_code = 400
-        mock_response.text = "Bad Request"
-        mock_post.return_value = mock_response
+    @patch("tools.github_readme_sync.req.requests.post")
+    def test_post_success_without_body_returns_empty_dict(self, mock_post):
+        response = MagicMock()
+        response.status_code = 204
+        response.content = b""
+        mock_post.return_value = response
 
-        url = "https://api.example.com/data"
-        data = {"key": "value"}
-        with self.assertLogs(level="ERROR") as log:
-            result = post(url, data)
+        self.assertEqual(post("https://api.example.com/data", {}), {})
 
-        self.assertIsNone(result)
-        self.assertIn("Failed to post https://api.example.com/data", log.output[0])
-        mock_post.assert_called_once_with(
-            url,
-            json=data,
-            headers={"Authorization": "Basic test_api_key"},
-            timeout=REQUEST_TIMEOUT_SECONDS,
+    @patch("tools.github_readme_sync.req.requests.post")
+    def test_post_failure_raises_with_api_response(self, mock_post):
+        response = MagicMock()
+        response.status_code = 409
+        response.text = "Slug already exists"
+        mock_post.return_value = response
+
+        with self.assertRaisesRegex(RuntimeError, "failed with 409"):
+            post("https://api.example.com/data", {"slug": "doc"})
+
+    @patch("tools.github_readme_sync.req.requests.patch")
+    def test_patch_success(self, mock_patch):
+        response = MagicMock()
+        response.status_code = 200
+        mock_patch.return_value = response
+
+        result = patch_request(
+            "https://api.example.com/data",
+            {"title": "Updated"},
         )
-
-    @patch("requests.put")
-    def test_put_success(self, mock_put):
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_put.return_value = mock_response
-
-        url = "https://api.example.com/data"
-        data = {"key": "value"}
-        result = put(url, data)
 
         self.assertTrue(result)
-        mock_put.assert_called_once_with(
-            url,
-            json=data,
-            headers={"Authorization": "Basic test_api_key"},
+        mock_patch.assert_called_once_with(
+            "https://api.example.com/data",
+            json={"title": "Updated"},
+            headers={"Authorization": "Bearer test_api_key"},
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
-    @patch("requests.put")
-    def test_put_failure(self, mock_put):
-        mock_response = MagicMock()
-        mock_response.status_code = 400
-        mock_response.text = "Bad Request"
-        mock_put.return_value = mock_response
+    @patch("tools.github_readme_sync.req.requests.patch")
+    def test_patch_failure_raises(self, mock_patch):
+        response = MagicMock()
+        response.status_code = 400
+        response.text = "Bad Request"
+        mock_patch.return_value = response
 
-        url = "https://api.example.com/data"
-        data = {"key": "value"}
-        with self.assertLogs(level="ERROR") as log:
-            result = put(url, data)
+        with self.assertRaisesRegex(RuntimeError, "failed with 400"):
+            patch_request("https://api.example.com/data", {})
 
-        self.assertFalse(result)
-        self.assertIn("Failed to put https://api.example.com/data", log.output[0])
-        mock_put.assert_called_once_with(
-            url,
-            json=data,
-            headers={"Authorization": "Basic test_api_key"},
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
+    @patch("tools.github_readme_sync.req.requests.delete")
+    def test_delete_success_returns_none(self, mock_delete):
+        response = MagicMock()
+        response.status_code = 204
+        mock_delete.return_value = response
 
-    @patch("requests.delete")
-    def test_delete_success(self, mock_delete):
-        mock_response = MagicMock()
-        mock_response.status_code = 204
-        mock_delete.return_value = mock_response
+        result = delete("https://api.example.com/data")
 
-        url = "https://api.example.com/data"
-        result = delete(url)
-
-        self.assertTrue(result)
+        # Successful DELETE calls now complete normally instead of returning True.
+        self.assertIsNone(result)
         mock_delete.assert_called_once_with(
-            url,
-            headers={"Authorization": "Basic test_api_key"},
+            "https://api.example.com/data",
+            headers={"Authorization": "Bearer test_api_key"},
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
-    @patch("requests.delete")
-    def test_delete_failure(self, mock_delete):
-        mock_response = MagicMock()
-        mock_response.status_code = 400
-        mock_delete.return_value = mock_response
+    @patch("tools.github_readme_sync.req.requests.delete")
+    def test_delete_failure_raises(self, mock_delete):
+        response = MagicMock()
+        response.status_code = 400
+        response.text = "Bad Request"
+        mock_delete.return_value = response
 
-        url = "https://api.example.com/data"
-        result = delete(url)
+        with self.assertRaisesRegex(RuntimeError, "failed with 400"):
+            delete("https://api.example.com/data")
 
-        self.assertFalse(result)
-        mock_delete.assert_called_once_with(
-            url,
-            headers={"Authorization": "Basic test_api_key"},
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
 
-    @patch("requests.delete")
-    def test_delete_version(self, mock_delete):
-        mock_response = MagicMock()
-        mock_response.status_code = 204
-        mock_delete.return_value = mock_response
-
-        url = "https://dash.readme.com/api/v1/version/v1.0.0"
-
-        rdme = ReadMe("1.0.0")
-        with self.assertLogs() as log:
-            rdme.delete_version()
-
-        self.assertIn("Successfully deleted version 1.0.0", log.output[0])
-        mock_delete.assert_called_once_with(
-            url,
-            headers={"Authorization": "Basic test_api_key"},
-            timeout=REQUEST_TIMEOUT_SECONDS,
-        )
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/github_readme_sync/tests/req_test.py
+++ b/tools/github_readme_sync/tests/req_test.py
@@ -17,8 +17,10 @@ from tools.github_readme_sync.req import (
     delete,
     get,
     get_collection,
-    patch as patch_request,
     post,
+)
+from tools.github_readme_sync.req import (
+    patch as patch_request,
 )
 
 
@@ -153,7 +155,7 @@ class TestReq(unittest.TestCase):
         mock_get.return_value = response
 
         with self.assertRaisesRegex(
-            RuntimeError,
+            TypeError,
             "Expected collection data .* to be a list",
         ):
             get_collection("https://api.readme.com/v2/items")

--- a/tools/github_readme_sync/tests/req_test.py
+++ b/tools/github_readme_sync/tests/req_test.py
@@ -28,7 +28,7 @@ from tools.github_readme_sync.req import (
 class TestReq(unittest.TestCase):
     """Tests for the shared ReadMe API v2 request helpers."""
 
-    @patch("tools.github_readme_sync.req.requests.get")
+    @patch("tools.github_readme_sync.req._SESSION.get")
     def test_get_success_unwraps_v2_data(self, mock_get):
         response = MagicMock()
         response.status_code = 200
@@ -44,8 +44,8 @@ class TestReq(unittest.TestCase):
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
-    @patch("tools.github_readme_sync.req.requests.get")
-    def test_get_preserves_caller_headers(self, mock_get):
+    @patch("tools.github_readme_sync.req._SESSION.get")
+    def test_get_adds_authentication_to_caller_headers(self, mock_get):
         response = MagicMock()
         response.status_code = 200
         response.json.return_value = {"data": {"name": "0.40"}}
@@ -55,8 +55,13 @@ class TestReq(unittest.TestCase):
         result = get("https://api.example.com/data", caller_headers)
 
         self.assertEqual(result, {"name": "0.40"})
-        # The helper adds Bearer authentication without mutating the input.
-        self.assertEqual(caller_headers, {"prefer": "handling=strict"})
+        self.assertEqual(
+            caller_headers,
+            {
+                "prefer": "handling=strict",
+                "Authorization": "Bearer test_api_key",
+            },
+        )
         mock_get.assert_called_once_with(
             "https://api.example.com/data",
             headers={
@@ -66,7 +71,7 @@ class TestReq(unittest.TestCase):
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
-    @patch("tools.github_readme_sync.req.requests.get")
+    @patch("tools.github_readme_sync.req._SESSION.get")
     def test_get_404_returns_none(self, mock_get):
         response = MagicMock()
         response.status_code = 404
@@ -76,7 +81,7 @@ class TestReq(unittest.TestCase):
 
         self.assertIsNone(result)
 
-    @patch("tools.github_readme_sync.req.requests.get")
+    @patch("tools.github_readme_sync.req._SESSION.get")
     def test_get_non_404_failure_raises(self, mock_get):
         response = MagicMock()
         response.status_code = 500
@@ -89,7 +94,7 @@ class TestReq(unittest.TestCase):
         ):
             get("https://api.example.com/data")
 
-    @patch("tools.github_readme_sync.req.requests.get")
+    @patch("tools.github_readme_sync.req._SESSION.get")
     def test_get_collection_follows_v2_pagination(self, mock_get):
         first_response = MagicMock()
         first_response.status_code = 200
@@ -128,7 +133,7 @@ class TestReq(unittest.TestCase):
             ],
         )
 
-    @patch("tools.github_readme_sync.req.requests.get")
+    @patch("tools.github_readme_sync.req._SESSION.get")
     def test_get_collection_404_returns_items_already_collected(self, mock_get):
         first_response = MagicMock()
         first_response.status_code = 200
@@ -146,7 +151,7 @@ class TestReq(unittest.TestCase):
 
         self.assertEqual(result, [{"slug": "doc-1"}])
 
-    @patch("tools.github_readme_sync.req.requests.get")
+    @patch("tools.github_readme_sync.req._SESSION.get")
     def test_get_collection_rejects_non_list_data(self, mock_get):
         response = MagicMock()
         response.status_code = 200
@@ -156,11 +161,11 @@ class TestReq(unittest.TestCase):
 
         with self.assertRaisesRegex(
             TypeError,
-            "Expected collection data .* to be a list",
+            r"Expected ReadMe response data to be a list, received dict",
         ):
             get_collection("https://api.readme.com/v2/items")
 
-    @patch("tools.github_readme_sync.req.requests.get")
+    @patch("tools.github_readme_sync.req._SESSION.get")
     def test_get_collection_failure_raises_instead_of_returning_partial_data(
         self, mock_get
     ):
@@ -172,7 +177,7 @@ class TestReq(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "failed with 429"):
             get_collection("https://api.readme.com/v2/items")
 
-    @patch("tools.github_readme_sync.req.requests.post")
+    @patch("tools.github_readme_sync.req._SESSION.post")
     def test_post_success_unwraps_v2_data(self, mock_post):
         response = MagicMock()
         response.status_code = 201
@@ -197,7 +202,7 @@ class TestReq(unittest.TestCase):
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
-    @patch("tools.github_readme_sync.req.requests.post")
+    @patch("tools.github_readme_sync.req._SESSION.post")
     def test_post_success_without_body_returns_empty_dict(self, mock_post):
         response = MagicMock()
         response.status_code = 204
@@ -206,7 +211,7 @@ class TestReq(unittest.TestCase):
 
         self.assertEqual(post("https://api.example.com/data", {}), {})
 
-    @patch("tools.github_readme_sync.req.requests.post")
+    @patch("tools.github_readme_sync.req._SESSION.post")
     def test_post_failure_raises_with_api_response(self, mock_post):
         response = MagicMock()
         response.status_code = 409
@@ -216,7 +221,7 @@ class TestReq(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "failed with 409"):
             post("https://api.example.com/data", {"slug": "doc"})
 
-    @patch("tools.github_readme_sync.req.requests.patch")
+    @patch("tools.github_readme_sync.req._SESSION.patch")
     def test_patch_success(self, mock_patch):
         response = MagicMock()
         response.status_code = 200
@@ -235,7 +240,7 @@ class TestReq(unittest.TestCase):
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
-    @patch("tools.github_readme_sync.req.requests.patch")
+    @patch("tools.github_readme_sync.req._SESSION.patch")
     def test_patch_failure_raises(self, mock_patch):
         response = MagicMock()
         response.status_code = 400
@@ -245,7 +250,7 @@ class TestReq(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "failed with 400"):
             patch_request("https://api.example.com/data", {})
 
-    @patch("tools.github_readme_sync.req.requests.delete")
+    @patch("tools.github_readme_sync.req._SESSION.delete")
     def test_delete_success_returns_none(self, mock_delete):
         response = MagicMock()
         response.status_code = 204
@@ -261,7 +266,7 @@ class TestReq(unittest.TestCase):
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
 
-    @patch("tools.github_readme_sync.req.requests.delete")
+    @patch("tools.github_readme_sync.req._SESSION.delete")
     def test_delete_failure_raises(self, mock_delete):
         response = MagicMock()
         response.status_code = 400

--- a/tools/github_readme_sync/tests/upload_test.py
+++ b/tools/github_readme_sync/tests/upload_test.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Thousand Brains Project
+# Copyright 2025-2026 Thousand Brains Project
 # Copyright 2024 Numenta Inc.
 #
 # Copyright may exist in Contributors' modifications
@@ -9,7 +9,7 @@
 # https://opensource.org/licenses/MIT.
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from tools.github_readme_sync.upload import (
     get_all_categories_docs,
@@ -22,65 +22,180 @@ from tools.github_readme_sync.upload import (
 class TestUpload(unittest.TestCase):
     @patch("tools.github_readme_sync.upload.get_all_categories_docs")
     @patch("tools.github_readme_sync.upload.process_children")
-    def test_upload(self, mock_process_children, mock_get_all_categories_docs):
-        mock_rdme_instance = MagicMock()
-        mock_get_all_categories_docs.return_value = [{"slug": "test", "type": "doc"}]
-
-        new_hierarchy = [{"slug": "cat1", "title": "Category 1", "children": []}]
-        file_path = "/path/to/files"
-
-        mock_rdme_instance.create_category_if_not_exists.return_value = ("cat_id", True)
-
-        upload(new_hierarchy, file_path, mock_rdme_instance)
-
-        mock_rdme_instance.create_version_if_not_exists.assert_called_once()
-        mock_rdme_instance.create_category_if_not_exists.assert_called_once_with(
-            "Category 1"
+    def test_upload_cleans_up_before_making_version_stable(
+        self,
+        mock_process_children,
+        mock_get_all_categories_docs,
+    ):
+        rdme = MagicMock()
+        rdme.create_category_if_not_exists.return_value = (
+            "/branches/0.40/categories/guides/Category%201",
+            True,
         )
-        mock_process_children.assert_called_once()
 
+        # The inventory is category-first. upload() reverses it so pages are
+        # deleted before their categories, then makes the version stable.
+        mock_get_all_categories_docs.return_value = [
+            {"title": "Old Category", "type": "category"},
+            {"slug": "old-doc", "type": "doc"},
+        ]
+
+        hierarchy = [
+            {
+                "slug": "category-1",
+                "title": "Category 1",
+                "children": [],
+            }
+        ]
+
+        upload(hierarchy, "/path/to/files", rdme)
+
+        rdme.create_version_if_not_exists.assert_called_once_with()
+        rdme.create_category_if_not_exists.assert_called_once_with("Category 1")
+        mock_process_children.assert_called_once_with(
+            parent=hierarchy[0],
+            cat_id="/branches/0.40/categories/guides/Category%201",
+            file_path="/path/to/files",
+            rdme=rdme,
+            to_be_deleted=[
+                {"title": "Old Category", "type": "category"},
+                {"slug": "old-doc", "type": "doc"},
+            ],
+        )
+
+        # This call order protects the newly stable version from partial cleanup.
+        self.assertLess(
+            rdme.method_calls.index(call.delete_doc("old-doc")),
+            rdme.method_calls.index(call.delete_category("Old Category")),
+        )
+        self.assertLess(
+            rdme.method_calls.index(call.delete_category("Old Category")),
+            rdme.method_calls.index(call.make_version_stable()),
+        )
+
+    @patch("tools.github_readme_sync.upload.print_child")
     @patch("tools.github_readme_sync.upload.load_doc")
-    def test_process_children(self, mock_load_doc):
-        mock_rdme_instance = MagicMock()
-        mock_load_doc.return_value = {"title": "Document", "slug": "doc1"}
+    def test_process_children_uses_v2_resource_uris(
+        self,
+        mock_load_doc,
+        mock_print_child,
+    ):
+        rdme = MagicMock()
+        mock_load_doc.return_value = {
+            "title": "Document",
+            "slug": "child-1",
+            "body": "Document body",
+        }
+        rdme.create_or_update_doc.return_value = (
+            "/branches/0.40/guides/child-1",
+            True,
+        )
 
-        # Mock create_or_update_doc to return a tuple
-        mock_rdme_instance.create_or_update_doc.return_value = ("doc_id", True)
-
-        parent = {"slug": "parent", "children": [{"slug": "child1", "children": []}]}
-        to_be_deleted = []
+        parent = {
+            "slug": "parent",
+            "children": [{"slug": "child-1", "children": []}],
+        }
+        to_be_deleted = [{"slug": "child-1", "type": "doc"}]
 
         process_children(
             parent=parent,
-            cat_id="cat_id",
+            cat_id="/branches/0.40/categories/guides/Category",
             file_path="/path/to/files",
-            rdme=mock_rdme_instance,
+            rdme=rdme,
             to_be_deleted=to_be_deleted,
+            parent_doc_id="/branches/0.40/guides/parent-doc",
         )
 
-        mock_load_doc.assert_called_once()
-        mock_rdme_instance.create_or_update_doc.assert_called_once()
+        mock_load_doc.assert_called_once_with(
+            "/path/to/files",
+            "parent",
+            {"slug": "child-1", "children": []},
+        )
+        rdme.create_or_update_doc.assert_called_once_with(
+            order=0,
+            category_id="/branches/0.40/categories/guides/Category",
+            doc=mock_load_doc.return_value,
+            parent_id="/branches/0.40/guides/parent-doc",
+            file_path="/path/to/files/parent",
+        )
+        mock_print_child.assert_called_once_with(
+            0,
+            mock_load_doc.return_value,
+            True,
+        )
+        self.assertEqual(to_be_deleted, [])
 
-    def test_set_do_not_delete(self):
+    def test_set_do_not_delete_removes_document_by_slug(self):
         to_be_deleted = [
             {"slug": "test-doc", "type": "doc"},
-            {"slug": "test-cat", "type": "category"},
+            {"title": "Test Category", "type": "category"},
         ]
+
         set_do_not_delete(to_be_deleted, "test-doc")
-        self.assertEqual(len(to_be_deleted), 1)
-        self.assertEqual(to_be_deleted[0]["slug"], "test-cat")
 
-    def test_get_all_categories_docs(self):
-        mock_rdme_instance = MagicMock()
-        mock_rdme_instance.get_categories.return_value = [{"slug": "cat1"}]
-        mock_rdme_instance.get_category_docs.return_value = [
-            {"slug": "doc1", "children": []}
+        self.assertEqual(
+            to_be_deleted,
+            [{"title": "Test Category", "type": "category"}],
+        )
+
+    def test_set_do_not_delete_removes_category_by_title(self):
+        to_be_deleted = [
+            {"slug": "test-doc", "type": "doc"},
+            {"title": "Test Category", "type": "category"},
         ]
 
-        result = get_all_categories_docs(mock_rdme_instance)
-        expected = [
-            {"slug": "cat1", "type": "category"},
-            {"slug": "doc1", "type": "doc"},
+        # API v2 categories are identified by title, not by category slug.
+        set_do_not_delete(to_be_deleted, "Test Category")
+
+        self.assertEqual(
+            to_be_deleted,
+            [{"slug": "test-doc", "type": "doc"}],
+        )
+
+    def test_get_all_categories_docs_uses_flat_v2_page_collection(self):
+        rdme = MagicMock()
+        rdme.get_categories.return_value = [
+            {"title": "Category 1"},
+            {"title": "Category 2"},
+        ]
+        rdme.get_category_docs.side_effect = [
+            [
+                {
+                    "slug": "parent-doc",
+                    "uri": "/branches/0.40/guides/parent-doc",
+                    "parent": None,
+                },
+                {
+                    "slug": "child-doc",
+                    "uri": "/branches/0.40/guides/child-doc",
+                    "parent": {"uri": "/branches/0.40/guides/parent-doc"},
+                },
+            ],
+            [{"slug": "other-doc"}],
         ]
 
-        self.assertEqual(result, expected)
+        result = get_all_categories_docs(rdme)
+
+        # Cleanup only needs category titles and page slugs. Parent nesting is
+        # irrelevant because pages are returned as one flat v2 collection.
+        self.assertEqual(
+            result,
+            [
+                {"title": "Category 1", "type": "category"},
+                {"slug": "parent-doc", "type": "doc"},
+                {"slug": "child-doc", "type": "doc"},
+                {"title": "Category 2", "type": "category"},
+                {"slug": "other-doc", "type": "doc"},
+            ],
+        )
+        self.assertEqual(
+            rdme.get_category_docs.call_args_list,
+            [
+                call({"title": "Category 1"}),
+                call({"title": "Category 2"}),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/github_readme_sync/tests/upload_test.py
+++ b/tools/github_readme_sync/tests/upload_test.py
@@ -119,9 +119,9 @@ class TestUpload(unittest.TestCase):
             file_path="/path/to/files/parent",
         )
         mock_print_child.assert_called_once_with(
-            0,
-            mock_load_doc.return_value,
-            True,
+            level=0,
+            doc=mock_load_doc.return_value,
+            created=True,
         )
         self.assertEqual(to_be_deleted, [])
 

--- a/tools/github_readme_sync/upload.py
+++ b/tools/github_readme_sync/upload.py
@@ -80,9 +80,9 @@ def process_children(
         )
 
         print_child(
-            path_prefix.count("/"),
-            doc,
-            created,
+            level=path_prefix.count("/"),
+            doc=doc,
+            created=created,
         )
         set_do_not_delete(to_be_deleted, child["slug"])
 

--- a/tools/github_readme_sync/upload.py
+++ b/tools/github_readme_sync/upload.py
@@ -119,7 +119,7 @@ def get_all_categories_docs(rdme: ReadMe):
             }
         )
 
-        # API v2 returns the category's pages as a flat collection.
+        # The API returns the category's pages as a flat collection.
         for doc in rdme.get_category_docs(category):
             all_categories_and_docs.append(
                 {

--- a/tools/github_readme_sync/upload.py
+++ b/tools/github_readme_sync/upload.py
@@ -23,6 +23,7 @@ def upload(new_hierarchy, file_path: str, rdme: ReadMe):
     logger.info(f"Uploading export folder: {file_path}")
     logger.info(f"URL: https://docs.thousandbrains.org/v{rdme.version}/docs")
     rdme.create_version_if_not_exists()
+
     to_be_deleted = get_all_categories_docs(rdme)
 
     for category in new_hierarchy:
@@ -31,10 +32,8 @@ def upload(new_hierarchy, file_path: str, rdme: ReadMe):
             f"\n{BLUE}{category['title'].upper()}{GRAY}{created * ' [created]'}{RESET}"
         )
 
-        # Use the normalized title to slug to match ReadMe's slug generation
-        # for categories, since we can't create a category with a specific slug
-        readme_slug = rdme.normalize_title_to_readme_slug(category["title"])
-        set_do_not_delete(to_be_deleted, readme_slug)
+        # Exact title match (case-sensitive)
+        set_do_not_delete(to_be_deleted, category["title"])
 
         # Recursively process the hierarchy of children
         process_children(
@@ -46,15 +45,18 @@ def upload(new_hierarchy, file_path: str, rdme: ReadMe):
         )
 
     logger.info("")
-    rdme.make_version_stable()
 
     if len(to_be_deleted) > 0:
         # Delete all docs and categories in reverse order
-        for doc in reversed(to_be_deleted):
-            if doc["type"] == "doc":
-                rdme.delete_doc(doc["slug"])
-            elif doc["type"] == "category":
-                rdme.delete_category(doc["slug"])
+        for item in reversed(to_be_deleted):
+            if item["type"] == "doc":
+                rdme.delete_doc(item["slug"])
+            elif item["type"] == "category":
+                rdme.delete_category(item["title"])
+
+    # Only expose a stable release after every create, update, and delete
+    # operation has completed successfully.
+    rdme.make_version_stable()
 
 
 def process_children(
@@ -76,7 +78,12 @@ def process_children(
             parent_id=parent_doc_id,
             file_path=f"{file_path}/{path_prefix}{parent['slug']}",
         )
-        print_child(path_prefix.count("/"), doc, created)
+
+        print_child(
+            path_prefix.count("/"),
+            doc,
+            created,
+        )
         set_do_not_delete(to_be_deleted, child["slug"])
 
         # If this child has children, call the function recursively
@@ -92,27 +99,35 @@ def process_children(
             )
 
 
-def set_do_not_delete(to_be_deleted: list, slug: str):
-    for doc in to_be_deleted:
-        if doc["slug"] == slug:
+def set_do_not_delete(to_be_deleted: list, identifier: str):
+    for item in to_be_deleted:
+        key = "title" if item["type"] == "category" else "slug"
+        if item.get(key) == identifier:
             # remove the item from the list
-            to_be_deleted.remove(doc)
+            to_be_deleted.remove(item)
+            return
 
 
 def get_all_categories_docs(rdme: ReadMe):
-    categories = rdme.get_categories()
     all_categories_and_docs = []
-    for category in categories:
-        all_categories_and_docs.append({"slug": category["slug"], "type": "category"})
-        docs = rdme.get_category_docs(category)
-        for doc in docs:
-            all_categories_and_docs.append({"slug": doc["slug"], "type": "doc"})
-            for child in doc["children"]:
-                all_categories_and_docs.append({"slug": child["slug"], "type": "doc"})
-                for sub_child in child["children"]:
-                    all_categories_and_docs.append(
-                        {"slug": sub_child["slug"], "type": "doc"}
-                    )
+
+    for category in rdme.get_categories():
+        all_categories_and_docs.append(
+            {
+                "title": category["title"],
+                "type": "category",
+            }
+        )
+
+        # API v2 returns the category's pages as a flat collection.
+        for doc in rdme.get_category_docs(category):
+            all_categories_and_docs.append(
+                {
+                    "slug": doc["slug"],
+                    "type": "doc",
+                }
+            )
+
     return all_categories_and_docs
 
 
@@ -120,6 +135,7 @@ def print_child(level: int, doc: dict, created: bool):
     color = CYAN if level else BLUE
     indent = INDENTATION_UNIT * level
     suffix = f"{GRAY}[created]{RESET}" if created else f"{GRAY}[updated]{RESET}"
+
     logger.info(
         f"{color}{indent}{doc['title']} {WHITE}/{doc['slug']} {GRAY}{suffix}{RESET}"
     )


### PR DESCRIPTION
## Summary

This PR migrates the GitHub-ReadMe synchronization tool from ReadMe API v1 to API v2: https://docs.readme.com/main/reference/api-upgrade-guide

The migration updates authentication, branch-scoped endpoints, response parsing, pagination, category and page identifiers, document creation and updates, export hierarchy reconstruction, cleanup behavior, and the associated tests.

The tool continues to support **ReadMe Guides only**. It does not add support for API reference documentation or other ReadMe content types.

## See the live docs on a test project
You can find the docs this tool created here: https://test-project-jnqi.readme.io/docs/welcome-to-the-thousand-brains-project-documentation

I tested it to ensure no duplicates were created, that stable branches work properly and are visible, and that preview branches are hidden.

## Why this change was needed

ReadMe API v2 differs from v1 in several important ways:

- Authentication now uses Bearer tokens.
- Versions are represented as branches and included directly in endpoint URLs.
- API responses are wrapped under a top-level `data` field.
- Collection responses are paginated using `paging.next`.
- Categories are identified by title instead of slug or ID.
- Pages, categories, and parents are connected using resource URIs.
- Category page responses are flat rather than recursively nested.
- Document content is stored under `content.body`.
- Descriptions are stored under `content.excerpt`.
- Visibility is represented through `privacy.view`.
- Updates use `PATCH` instead of `PUT`.

This PR updates the tool with the minimal changes needed to satisfy the migration requirements.

## Code changes

### `req.py`

Updated the shared HTTP request helpers for ReadMe API v2.

Key changes:

- Replaced Basic authentication with:

  ```text
  Authorization: Bearer <README_API_KEY>
  ```

- Added `_unwrap_data()` so callers receive the contents of the v2 `data` wrapper rather than the entire response envelope.
- Added support for paginated collection responses through `paging.next`.
- Resolves relative and absolute pagination URLs against the current response URL.
- Replaced the old `put()` helper with `patch()`.
- Changed error handling so only an actual `404` is treated as a missing resource.
- Authentication errors, rate limits, server errors, and other unsuccessful responses now raise `RuntimeError`.
- `POST`, `PATCH`, and `DELETE` errors now include the status code and API response body.
- `DELETE` no longer returns an ignored Boolean. It completes successfully or raises an exception.

This prevents API failures such as `401`, `429`, or `500` from being mistaken for missing documents and accidentally triggering duplicate creation.

### `readme.py`

Migrated the ReadMe API wrapper to v2 branch, category, and guide endpoints.

#### Branch handling

- Changed the API base URL to:

  ```text
  https://api.readme.com/v2
  ```

- Added `branch_url()` so version-scoped endpoints use:

  ```text
  /v2/branches/{branch}/...
  ```

- Changed stable-version lookup to use ReadMe's stable branch alias.
- Updated branch creation to send:

  ```json
  {
    "name": "version",
    "base": "stable_version",
    "privacy": {
      "view": "hidden"
    }
  }
  ```

- Updated stable-version promotion to use:

  ```json
  {
    "privacy": {
      "view": "default"
    }
  }
  ```

  This differs from the public migration documentation, but it matches the live ReadMe OpenAPI behavior and has been verified against the project.

#### Category handling

- Changed category collection endpoints to:

  ```text
  /branches/{branch}/categories/guides
  ```

- Categories are now looked up and deleted by URL-encoded title rather than slug or hexadecimal ID.
- Category creation now uses:

  ```json
  {
    "title": "title",
    "section": "guide"
  }
  ```

#### Export hierarchy reconstruction

ReadMe API v2 returns all pages in a category as a flat collection. Nested pages identify their parent using `parent.uri`.

Added `get_category_doc_tree()` to:

- index pages by resource URI;
- create empty `children` collections;
- connect each page to its parent;
- preserve the order returned by the API;
- fail clearly when a page has a missing or duplicate URI;
- fail rather than silently flatten the hierarchy when a parent cannot be found.

#### Guide retrieval and export

- Guide lookup now uses:

  ```text
  /branches/{branch}/guides/{slug}
  ```

- Added validation that ReadMe returned the requested slug and a valid URI.
- Updated exported front matter to read:
  - body from `content.body`;
  - description from `content.excerpt`;
  - hidden state from `privacy.view`.

#### Guide creation and updates

- Page category and parent relationships now use resource URIs:

  ```json
  {
    "category": {
      "uri": "category_uri"
    },
    "parent": {
      "uri": "parent_uri"
    }
  }
  ```

- Page content is sent through:

  ```json
  {
    "content": {
      "body": "markdown",
      "excerpt": "description"
    }
  }
  ```

- Visibility now uses either:

  ```json
  {
    "privacy": {
      "view": "public"
    }
  }
  ```

  or:

  ```json
  {
    "privacy": {
      "view": "anyone_with_link"
    }
  }
  ```

- Page ordering now uses `position`.
- Existing pages are updated using `PATCH`.
- The slug is deliberately omitted from `PATCH` requests.
- New pages include their requested slug.
- New-page creation uses:

  ```python
  headers={"prefer": "handling=strict"}
  ```

  This prevents ReadMe from silently resolving a collision by creating the duplicate `slug-1`.

- The returned slug is validated against the requested slug.
- Created and updated page URIs are returned for use when recursively creating nested pages.

### `upload.py`

Updated the upload and cleanup process for v2's resource shapes.

Key changes:

- Categories are protected from deletion by using their exact title.
- Pages are protected from deletion by using their actual slug.
- The cleanup inventory reads all pages directly from the flat v2 category-page collection instead of looking for nested `children` arrays.
- Parent pages pass their returned resource URI to child-page uploads.
- Document creation now returns the URI needed to create nested relationships.
- Obsolete documents and categories are deleted in reverse inventory order so pages are removed before their categories.
- The version is only made stable after all create, update, and delete operations finish successfully.

This ordering prevents a partially synchronized release from being exposed as the stable version if cleanup fails.

### `export.py`

Updated export to correctly reconstruct a local documentation tree from ReadMe API v2.

Key changes:

- Categories no longer receive a server-side slug from ReadMe.
- A local category slug is generated from the category title using `slugify()`.
- Document slugs are preserved directly from ReadMe rather than regenerated from document titles.
- Export now calls `get_category_doc_tree()` instead of using the flat category-page collection directly.
- Parent, child, and grandchild pages are recursively written into corresponding nested directories.
- Exported hierarchy entries preserve each page's actual ReadMe slug.
- Markdown files are written using UTF-8 encoding.

## Test changes

### `req_test.py`

Rewrote request-helper tests for the v2 transport behavior.

Added coverage for:

- Bearer authentication;
- preservation of caller-provided headers;
- v2 `data` response unwrapping;
- actual `404` handling;
- exceptions for non-`404` failures;
- collection pagination;
- relative pagination URL resolution;
- malformed collection responses;
- avoiding partial results when a later page fails;
- `POST` response parsing;
- empty successful `POST` responses;
- `PATCH` instead of `PUT`;
- `DELETE` success and failure behavior.

These tests specifically verify that API errors cannot be mistaken for missing resources.

### `readme_test.py`

Replaced the v1 URL, payload, ID, and response assumptions with v2 behavior.

Added or updated coverage for:

- stable branch lookup;
- missing or malformed stable branch responses;
- branch-scoped category and guide endpoints;
- URL-encoded category titles;
- flat category page responses;
- parent/child tree reconstruction;
- duplicate and missing resource URIs;
- v2 `content.body` and `content.excerpt`;
- v2 `privacy.view`;
- empty document bodies;
- returned slug and URI validation;
- branch creation;
- the project's tested stable-version payload;
- category creation using `section: "guide"`;
- category and parent resource URIs;
- `PATCH` updates without a slug field;
- strict guide creation;
- rejection of automatically altered slugs;
- create responses without a URI;
- v2 deletion endpoints.

Existing Markdown, image, video, CSV, and HTML sanitization tests were retained.

### `upload_test.py`

Updated tests to reflect the v2 cleanup inventory and resource relationships.

Added coverage for:

- categories being identified by title;
- pages being identified by slug;
- flat category-page inventory handling;
- category and parent resource URIs;
- recursive child processing;
- obsolete page deletion;
- obsolete category deletion;
- cleanup occurring before stable-version promotion;
- avoiding stable-version promotion when an earlier operation fails.

### `export_test.py`

Updated export tests for raw v2 category responses and reconstructed page trees.

Added coverage for:

- generating a local category slug from its title;
- calling `get_category_doc_tree()`;
- preserving actual ReadMe page slugs;
- handling titles that intentionally differ from slugs;
- exporting nested parent and child directories;
- writing UTF-8 document content;
- replacing an existing export directory with a fresh snapshot.