### PR TITLE
chore: version 0.43.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.42.0"
+__version__ = "0.43.0"


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since **0.42.0**

<img width="2343" height="1272" alt="image" src="https://github.com/user-attachments/assets/9fe616fb-c848-4b65-a3d5-1aff002fb1e8" />

## refactor!: salience goals explicitly for motor system only (#1097)
- The `Goal`s produced by the `SalienceSM` are no longer routeable to learning modules because they now set `use_state=False`.

## refactor!: LearningModule init/reset strategy (#1096)
- `reset()` is now `init_from_ltm()` from `GraphLM` downward
- `init_from_ltm()` (formerly `reset()`) is now called from `reset_stm()`