### PR TITLE
feat: simple overall stats logging in run_parallel

### DIFF
--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -468,7 +468,7 @@ def print_benchmark_stats(overall_stats: dict) -> None:
         "overall/num_episodes",
     ]
     benchmark_stats = [overall_stats[k] for k in benchmark_keys]
-    comma_keys = ",".join([k[8:] for k in benchmark_keys])
+    comma_keys = ",".join([k[len("overall/"):] for k in benchmark_keys])
     comma_stats = ",".join([str(s) for s in benchmark_stats])
     print(f"Benchmark Stats\n{comma_keys}\n{comma_stats}")
 

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -468,7 +468,7 @@ def print_benchmark_stats(overall_stats: dict) -> None:
         "overall/num_episodes",
     ]
     benchmark_stats = [overall_stats[k] for k in benchmark_keys]
-    comma_keys = ",".join([k[len("overall/"):] for k in benchmark_keys])
+    comma_keys = ",".join([k[len("overall/") :] for k in benchmark_keys])
     comma_stats = ",".join([str(s) for s in benchmark_stats])
     print(f"Benchmark Stats\n{comma_keys}\n{comma_stats}")
 

--- a/src/tbp/monty/frameworks/run_parallel.py
+++ b/src/tbp/monty/frameworks/run_parallel.py
@@ -456,6 +456,23 @@ def get_overall_stats(stats):
     return overall_stats
 
 
+def print_benchmark_stats(overall_stats: dict) -> None:
+    benchmark_keys = [
+        "overall/percent_correct",
+        "overall/percent_correct_child_or_parent",
+        "overall/avg_rotation_error",
+        "overall/avg_num_monty_matching_steps",
+        "overall/run_time",
+        "overall/avg_episode_run_time",
+        "overall/percent_used_mlh_after_timeout",
+        "overall/num_episodes",
+    ]
+    benchmark_stats = [overall_stats[k] for k in benchmark_keys]
+    comma_keys = ",".join([k[8:] for k in benchmark_keys])
+    comma_stats = ",".join([str(s) for s in benchmark_stats])
+    print(f"Benchmark Stats\n{comma_keys}\n{comma_stats}")
+
+
 def collect_detailed_episodes_names(parallel_dirs: Iterable[Path]) -> list[Path]:
     filenames = []
     for pdir in parallel_dirs:
@@ -617,15 +634,16 @@ def run_episodes_parallel(
     )
     start_time = time.time()
     log_parallel_wandb = experiments[0]["config"]["logging"]["log_parallel_wandb"]
+    wandb_run = None
     if log_parallel_wandb:
-        run = wandb.init(
+        wandb_run = wandb.init(
             name=experiment_name,
             group=experiments[0]["config"]["logging"]["wandb_group"],
             project="Monty",
             config=experiments[0],
             id=hydra.utils.instantiate(experiments[0]["config"]["logging"]["wandb_id"]),
         )
-    print(f"Wandb setup took {time.time() - start_time} seconds")
+        print(f"Wandb setup took {time.time() - start_time} seconds")
     start_time = time.time()
 
     # Create a multiprocessing Context so that we can set the start method to "spawn".
@@ -641,7 +659,8 @@ def run_episodes_parallel(
         elif log_parallel_wandb:
             all_episode_stats: dict[str, list[Any]] = {}
             for result in p.imap(single_evaluate, experiments):
-                run.log(result)
+                if wandb_run:
+                    wandb_run.log(result)
                 if not all_episode_stats:  # first episode
                     for key in list(result.keys()):
                         all_episode_stats[key] = [result[key]]
@@ -654,7 +673,9 @@ def run_episodes_parallel(
             # log this here additionally.
             overall_stats["overall/parallel_run_time"] = time.time() - start_time
             overall_stats["overall/num_processes"] = num_parallel
-            run.log(overall_stats)
+            if wandb_run:
+                wandb_run.log(overall_stats)
+            print_benchmark_stats(overall_stats)
         else:
             p.map(single_evaluate, experiments)
     end_time = time.time()
@@ -669,8 +690,8 @@ def run_episodes_parallel(
             if csv_path.exists():
                 train_stats = pd.read_csv(csv_path)
                 train_table = wandb.Table(dataframe=train_stats)
-                if run is not None:
-                    run.log({"train_stats": train_table})
+                if wandb_run:
+                    wandb_run.log({"train_stats": train_table})
             else:
                 print(f"No csv table found at {csv_path} to log to wandb")
     else:
@@ -680,7 +701,8 @@ def run_episodes_parallel(
             if csv_path.exists():
                 eval_stats = pd.read_csv(csv_path)
                 eval_table = wandb.Table(dataframe=eval_stats)
-                run.log({"eval_stats": eval_table})
+                if wandb_run:
+                    wandb_run.log({"eval_stats": eval_table})
             else:
                 print(f"No csv table found at {csv_path} to log to wandb")
 
@@ -688,8 +710,8 @@ def run_episodes_parallel(
         f"Total time for {len(experiments)} running {num_parallel} episodes in "
         f"parallel: {total_time}"
     )
-    if log_parallel_wandb:
-        run.finish()
+    if wandb_run:
+        wandb_run.finish()
 
     print(f"Done running parallel experiments in {end_time - start_time} seconds")
 


### PR DESCRIPTION
There's nothing fancy here. It's just the simplest thing that works.

There _is_ a bug fix here as well for a situation in which `log_parallel_wandb` is `False`. In that case `wandb_run` is never defined. I also renamed it to be clear that it was WandB related.