### PR TITLE
fix: normalize eigenvectors in principal_curvatures()

### DIFF
--- a/src/tbp/monty/frameworks/utils/sensor_processing.py
+++ b/src/tbp/monty/frameworks/utils/sensor_processing.py
@@ -709,6 +709,8 @@ def principal_curvatures(
             # definite, so the generalized spectral theorem guarantees real
             # eigenvalues and a complete basis of real eigenvectors.
             eigval, eigvec = scipy.linalg.eigh(buv, guv)
+            eigvec[:, 0] = normalize(eigvec[:, 0])
+            eigvec[:, 1] = normalize(eigvec[:, 1])
 
             # `eigh` returns eigenvalues in ascending order. Preserve the existing
             # convention of ordering principal curvatures from largest to smallest.


### PR DESCRIPTION
Hi Jeremy, I just realized that I forgot to add normalization after we updated to `scipy.linalg.eigh(buv, guv)` in #1099. 

`scipy.linalg.eigh(buv, guv)` returns guv-normalized eigenvector*, unlike the Euclidean-unit eigenvectors previously returned by `np.linalg.eig(m)`. The fix normalizes each eigenvector to Euclidean unit length. Otherwise I get `ValueError("The pc1_dir and pc2_dir must be unit vectors.")` in some compositional training experiment that uses `TwoDSensroModule`. Thank goodness we added this check back then. 😂

Note on *: By `guv` (G)-normalized, I mean satisfying this equation: $v^T Gv = 1$ instead of $v^T v = 1$, where the latter is the usual Euclidean norm. 