### PR TITLE
chore: version 0.44.0

### DIFF
--- a/src/tbp/monty/__init__.py
+++ b/src/tbp/monty/__init__.py
@@ -8,4 +8,4 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-__version__ = "0.43.0"
+__version__ = "0.44.0"


### PR DESCRIPTION
Minor release version due to 0 Major version and breaking changes since 0.43.0.

<img width="1311" height="650" alt="Screenshot 2026-07-23 at 12 55 57" src="https://github.com/user-attachments/assets/764c35a1-e66c-4365-b78f-631473b853d0" />

## refactor!: more complete snapshot/restore for NoReset* classes (#1101)

- `Monty.snapshot_ltm()` becomes `Monty.snapshot()`
- `Monty.restore_ltm()` becomes `Monty.restore()`
- The internal structure of the `Memento` is revised to match `Monty.state_dict()`