### PR TITLE
chore: create MuJoCo versions of ycb_10objs benchmarks

### DIFF
--- a/src/tbp/monty/conf/environment/mujoco_surf_rawnoise_agent.yaml
+++ b/src/tbp/monty/conf/environment/mujoco_surf_rawnoise_agent.yaml
@@ -1,0 +1,34 @@
+# @package experiment.config.environment
+
+env_init_args:
+  data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
+  agents:
+    - _target_: tbp.monty.simulators.mujoco.agents.SurfaceAgent
+      _partial_: true
+      agent_id: agent_id_0
+      sensor_configs:
+        patch:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          position:
+            - 0.0
+            - 0.0
+            - 0.0
+          zoom: 10.0
+        view_finder:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          position:
+            - 0.0
+            - 0.0
+            - 0.03
+          zoom: 1.0
+      position:
+        - 0.0
+        - 1.5
+        - 0.1
+env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}

--- a/src/tbp/monty/conf/environment/mujoco_ycb_dist_agent_256.yaml
+++ b/src/tbp/monty/conf/environment/mujoco_ycb_dist_agent_256.yaml
@@ -1,0 +1,27 @@
+# @package experiment.config.environment
+
+env_init_args:
+  data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
+  agents:
+    - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+      _partial_: true
+      agent_id: agent_id_0
+      sensor_configs:
+        patch:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 64
+            height: 64
+          zoom: 10.0
+        view_finder:
+          _target_: tbp.monty.frameworks.sensors.SensorConfig
+          resolution:
+            width: 256
+            height: 256
+          zoom: 1.0
+      position:
+        - 0.0
+        - 1.5
+        - 0.2
+  raise_actuate_missing: false
+env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}

--- a/src/tbp/monty/conf/experiment/base_10simobj_surf_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/base_10simobj_surf_agent_mujoco.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp1000_emin_t3_tot2500
+  - /monty/motor_system_config: surface_curvature_informed_goal1
+  - /monty/learning_module: evidence_1lm_nn5_dod0025
+  - /monty/sensor_module: camera_surf_delta
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_ycb_surf_agent
+  - /env_interface: eval_simobj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0_clip
+  - /logging: basic_warning_wandb_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 5000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10similarobj/pretrained/
+    n_eval_epochs: ${constants.rotations_all_count}
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+    logging:
+      run_name: base_10simobj_surf_agent_mujoco

--- a/src/tbp/monty/conf/experiment/randomrot_rawnoise_10distinctobj_surf_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randomrot_rawnoise_10distinctobj_surf_agent_mujoco.yaml
@@ -2,14 +2,13 @@
 
 defaults:
   - /monty: evidencegraph_exp1000_emin_t3_tot2500
-  - /monty/motor_system_config: distant_5
-  - /monty/learning_module: evidence_1lm_nn5_dod003
-  - /monty/sensor_module: camera_dist_delta_salience
+  - /monty/motor_system_config: surface_curvature_informed_goal1
+  - /monty/learning_module: evidence_1lm_nn10_dod0025
+  - /monty/sensor_module: camera_surf_noise_raw1
   - /monty/connectivity: 1lm_1sm
-  - /environment: mujoco_ycb_dist_agent
-  - /env_interface: eval_distinctobj_predefined
-  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
-  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /environment: mujoco_surf_rawnoise_agent
+  - /env_interface: eval_distinctobj_random
+  - /env_interface/transform: missing_noise_depthto3d_sensor2_semantic0_clip
   - /logging: basic_warning_wandb_monty_runs
 
 experiment:
@@ -18,13 +17,13 @@ experiment:
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
-    max_total_steps: 6000
+    max_total_steps: 5000
     n_train_epochs: 3
     model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []
     python_log_level: DEBUG
     logging:
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randomrot_rawnoise_10distinctobj_surf_agent_mujoco

--- a/src/tbp/monty/conf/experiment/randrot_10distinctobj_surf_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_10distinctobj_surf_agent_mujoco.yaml
@@ -2,14 +2,13 @@
 
 defaults:
   - /monty: evidencegraph_exp1000_emin_t3_tot2500
-  - /monty/motor_system_config: distant_5
-  - /monty/learning_module: evidence_1lm_nn5_dod003
-  - /monty/sensor_module: camera_dist_delta_salience
+  - /monty/motor_system_config: surface_curvature_informed_goal1
+  - /monty/learning_module: evidence_1lm_nn5_dod0025
+  - /monty/sensor_module: camera_surf_delta
   - /monty/connectivity: 1lm_1sm
-  - /environment: mujoco_ycb_dist_agent
-  - /env_interface: eval_distinctobj_predefined
-  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
-  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /environment: mujoco_ycb_surf_agent
+  - /env_interface: eval_distinctobj_random
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0_clip
   - /logging: basic_warning_wandb_monty_runs
 
 experiment:
@@ -18,13 +17,13 @@ experiment:
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
-    max_total_steps: 6000
+    max_total_steps: 5000
     n_train_epochs: 3
     model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []
     python_log_level: DEBUG
     logging:
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_10distinctobj_surf_agent_mujoco

--- a/src/tbp/monty/conf/experiment/randrot_noise_10distinctobj_5lms_dist_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_noise_10distinctobj_5lms_dist_agent_mujoco.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp1000_emin_t3_tot2500
+  - /monty/motor_system_config: distant_5
+  - /monty/learning_module: evidence_5lm_nn10_dod003
+  - /monty/sensor_module: 5sm_camera_dist_noise
+  - /monty/connectivity: 5lm_5sm
+  - /environment: mujoco_dist_agent_sensors5
+  - /env_interface: eval_distinctobj_random
+  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch0
+  - /env_interface/transform: missing_depthto3d_sensor6
+  - /logging: basic_warning_wandb_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/supervised_pre_training_5lms/pretrained/
+    n_eval_epochs: 10
+    min_lms_match: 3
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+    logging:
+      run_name: randrot_noise_10distinctobj_5lms_dist_agent

--- a/src/tbp/monty/conf/experiment/randrot_noise_10distinctobj_dist_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_noise_10distinctobj_dist_agent_mujoco.yaml
@@ -3,11 +3,11 @@
 defaults:
   - /monty: evidencegraph_exp1000_emin_t3_tot2500
   - /monty/motor_system_config: distant_5
-  - /monty/learning_module: evidence_1lm_nn5_dod003
-  - /monty/sensor_module: camera_dist_delta_salience
+  - /monty/learning_module: evidence_1lm_nn10_dod003
+  - /monty/sensor_module: camera_dist_noise_raw1_salience
   - /monty/connectivity: 1lm_1sm
   - /environment: mujoco_ycb_dist_agent
-  - /env_interface: eval_distinctobj_predefined
+  - /env_interface: eval_distinctobj_random
   - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
   - /env_interface/transform: missing_depthto3d_sensor2_semantic0
   - /logging: basic_warning_wandb_monty_runs
@@ -21,10 +21,10 @@ experiment:
     max_total_steps: 6000
     n_train_epochs: 3
     model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []
     python_log_level: DEBUG
     logging:
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_noise_10distinctobj_dist_agent_mujoco

--- a/src/tbp/monty/conf/experiment/randrot_noise_10distinctobj_dist_on_distm_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_noise_10distinctobj_dist_on_distm_mujoco.yaml
@@ -3,11 +3,11 @@
 defaults:
   - /monty: evidencegraph_exp1000_emin_t3_tot2500
   - /monty/motor_system_config: distant_5
-  - /monty/learning_module: evidence_1lm_nn5_dod003
-  - /monty/sensor_module: camera_dist_delta_salience
+  - /monty/learning_module: evidence_1lm_nn10_dod003
+  - /monty/sensor_module: camera_dist_noise_raw1_salience
   - /monty/connectivity: 1lm_1sm
   - /environment: mujoco_ycb_dist_agent
-  - /env_interface: eval_distinctobj_predefined
+  - /env_interface: eval_distinctobj_random
   - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
   - /env_interface/transform: missing_depthto3d_sensor2_semantic0
   - /logging: basic_warning_wandb_monty_runs
@@ -20,11 +20,11 @@ experiment:
     max_eval_steps: 500
     max_total_steps: 6000
     n_train_epochs: 3
-    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    model_name_or_path: ${constants.pretrained_dir}/supervised_pre_training_base/pretrained/
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []
     python_log_level: DEBUG
     logging:
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_noise_10distinctobj_dist_on_distm_mujoco

--- a/src/tbp/monty/conf/experiment/randrot_noise_10distinctobj_surf_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_noise_10distinctobj_surf_agent_mujoco.yaml
@@ -2,14 +2,13 @@
 
 defaults:
   - /monty: evidencegraph_exp1000_emin_t3_tot2500
-  - /monty/motor_system_config: distant_5
-  - /monty/learning_module: evidence_1lm_nn5_dod003
-  - /monty/sensor_module: camera_dist_delta_salience
+  - /monty/motor_system_config: surface_curvature_informed_goal1
+  - /monty/learning_module: evidence_1lm_nn10_dod0025
+  - /monty/sensor_module: camera_surf_noise_raw1
   - /monty/connectivity: 1lm_1sm
-  - /environment: mujoco_ycb_dist_agent
-  - /env_interface: eval_distinctobj_predefined
-  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
-  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /environment: mujoco_ycb_surf_agent
+  - /env_interface: eval_distinctobj_random
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0_clip
   - /logging: basic_warning_wandb_monty_runs
 
 experiment:
@@ -18,13 +17,13 @@ experiment:
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
-    max_total_steps: 6000
+    max_total_steps: 5000
     n_train_epochs: 3
     model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []
     python_log_level: DEBUG
     logging:
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_noise_10distinctobj_surf_agent_mujoco

--- a/src/tbp/monty/conf/experiment/randrot_noise_10distinctobj_vocus_on_vocusm_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_noise_10distinctobj_vocus_on_vocusm_mujoco.yaml
@@ -3,13 +3,13 @@
 defaults:
   - /monty: evidencegraph_exp1000_emin_t3_tot2500
   - /monty/motor_system_config: distant_5
-  - /monty/learning_module: evidence_1lm_nn5_dod003
-  - /monty/sensor_module: camera_dist_delta_salience
+  - /monty/learning_module: evidence_1lm_nn10_dod003
+  - /monty/sensor_module: camera_dist_noise_vocus2
   - /monty/connectivity: 1lm_1sm
-  - /environment: mujoco_ycb_dist_agent
-  - /env_interface: eval_distinctobj_predefined
+  - /environment: mujoco_ycb_dist_agent_256
+  - /env_interface: eval_distinctobj_random
   - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
-  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0_256
   - /logging: basic_warning_wandb_monty_runs
 
 experiment:
@@ -20,11 +20,11 @@ experiment:
     max_eval_steps: 500
     max_total_steps: 6000
     n_train_epochs: 3
-    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    model_name_or_path: ${constants.pretrained_dir}/supervised_pre_training_10distinctobj_vocus2/pretrained/
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []
     python_log_level: DEBUG
     logging:
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_noise_10distinctobj_vocus_on_vocusm_mujoco

--- a/src/tbp/monty/conf/experiment/randrot_noise_10simobj_dist_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_noise_10simobj_dist_agent_mujoco.yaml
@@ -3,11 +3,11 @@
 defaults:
   - /monty: evidencegraph_exp1000_emin_t3_tot2500
   - /monty/motor_system_config: distant_5
-  - /monty/learning_module: evidence_1lm_nn5_dod003
-  - /monty/sensor_module: camera_dist_delta_salience
+  - /monty/learning_module: evidence_1lm_nn10_dod003
+  - /monty/sensor_module: camera_dist_noise_raw1_salience
   - /monty/connectivity: 1lm_1sm
   - /environment: mujoco_ycb_dist_agent
-  - /env_interface: eval_distinctobj_predefined
+  - /env_interface: eval_simobj_random
   - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
   - /env_interface/transform: missing_depthto3d_sensor2_semantic0
   - /logging: basic_warning_wandb_monty_runs
@@ -20,11 +20,11 @@ experiment:
     max_eval_steps: 500
     max_total_steps: 6000
     n_train_epochs: 3
-    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10similarobj/pretrained/
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []
     python_log_level: DEBUG
     logging:
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_noise_10simobj_dist_agent_mujoco

--- a/src/tbp/monty/conf/experiment/randrot_noise_10simobj_surf_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_noise_10simobj_surf_agent_mujoco.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp1000_emin_t3_tot2500
+  - /monty/motor_system_config: surface_curvature_informed_goal1
+  - /monty/learning_module: evidence_1lm_nn10_dod0025
+  - /monty/sensor_module: camera_surf_noise_raw1
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_ycb_surf_agent
+  - /env_interface: eval_simobj_random
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0_clip
+  - /logging: basic_warning_wandb_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10similarobj/pretrained/
+    n_eval_epochs: 10
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+    logging:
+      run_name: randrot_noise_10simobj_surf_agent_mujoco

--- a/tests/conf/snapshots/base_10simobj_surf_agent_mujoco.yaml
+++ b/tests/conf/snapshots/base_10simobj_surf_agent_mujoco.yaml
@@ -10,28 +10,26 @@ experiment:
         min_train_steps: 3
         max_total_steps: 2500
       motor_system_config:
-        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
         policy_selector:
-          _target_: tbp.monty.frameworks.models.motor_policy_selectors.DistantPolicySelector
-          jump_to_goal:
-            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.JumpToGoal}
-            agent_id: agent_id_0
-            sensor_id: view_finder
-          look_at_goal:
-            _target_: ${monty.class:tbp.monty.frameworks.models.salience.motor_policy.LookAtGoal}
-            agent_id: agent_id_0
-            sensor_id: view_finder
-          default:
-            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicyRandomWalk}
-            agent_id: agent_id_0
+          policy:
             action_sampler:
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               actions:
-              - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.LookDown}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
-              rotation_degrees: 5.0
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveForward}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveTangentially}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
+            use_goal_driven_actions: true
+            agent_id: agent_id_0
+            desired_object_distance: 0.025
+            alpha: 0.1
+            pc_alpha: 0.5
+            max_pc_bias_steps: 32
+            min_general_steps: 8
+            min_heading_steps: 12
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.SinglePolicySelector
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
       learning_modules:
         learning_module_0:
           hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
@@ -59,17 +57,21 @@ experiment:
             elapsed_steps_factor: 10
             min_post_goal_success_steps: 5
             x_percent_scale_factor: 0.75
-            desired_object_distance: 0.03
+            desired_object_distance: 0.025
       sensor_modules:
         sensor_module_0:
           _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          is_surface_sm: true
           sensor_module_id: patch
           features:
           - pose_vectors
           - pose_fully_defined
           - on_object
           - object_coverage
+          - min_depth
+          - mean_depth
           - hsv
+          - principal_curvatures
           - principal_curvatures_log
           delta_thresholds:
             on_object: 0
@@ -85,7 +87,7 @@ experiment:
             distance: 0.01
           save_raw_obs: false
         sensor_module_1:
-          _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:
@@ -99,18 +101,26 @@ experiment:
       env_init_args:
         data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
         agents:
-        - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+        - _target_: tbp.monty.simulators.mujoco.agents.SurfaceAgent
           _partial_: true
           agent_id: agent_id_0
           sensor_configs:
             patch:
               _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.0
               resolution:
                 width: 64
                 height: 64
               zoom: 10.0
             view_finder:
               _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.03
               resolution:
                 width: 64
                 height: 64
@@ -118,7 +128,7 @@ experiment:
           position:
           - 0.0
           - 1.5
-          - 0.2
+          - 0.1
         raise_actuate_missing: false
       env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}
       transform:
@@ -141,31 +151,25 @@ experiment:
         - 1.0
         get_all_points: true
         use_semantic_sensor: false
+        depth_clip_sensors:
+        - 0
+        clip_value: 0.05
     eval_env_interface_args:
       parent_to_child_mapping: null
       object_names:
       - mug
-      - bowl
-      - potted_meat_can
+      - e_cups
+      - knife
+      - fork
       - spoon
-      - strawberry
-      - mustard_bottle
-      - dice
-      - golf_ball
-      - c_lego_duplo
-      - banana
+      - c_cups
+      - d_cups
+      - cracker_box
+      - sugar_box
+      - pudding_box
       object_init_sampler:
         _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
         rotations: ${constants.rotations_all}
-      positioning_procedures:
-      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
-        agent_id: agent_id_0
-        sensor_id: view_finder
-      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
-        agent_id: agent_id_0
-        sensor_id: patch
-        allow_translation: false
-        max_orientation_attempts: 3
     eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
     logging:
       monty_log_level: BASIC
@@ -182,13 +186,13 @@ experiment:
       wandb_id:
         _target_: wandb.util.generate_id
       wandb_group: benchmark_experiments
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: base_10simobj_surf_agent_mujoco
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
-    max_total_steps: 6000
+    max_total_steps: 5000
     n_train_epochs: 3
-    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10similarobj/pretrained/
     n_eval_epochs: ${constants.rotations_all_count}
     min_lms_match: 1
     seed: 42

--- a/tests/conf/snapshots/randomrot_rawnoise_10distinctobj_surf_agent_mujoco.yaml
+++ b/tests/conf/snapshots/randomrot_rawnoise_10distinctobj_surf_agent_mujoco.yaml
@@ -10,33 +10,31 @@ experiment:
         min_train_steps: 3
         max_total_steps: 2500
       motor_system_config:
-        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
         policy_selector:
-          _target_: tbp.monty.frameworks.models.motor_policy_selectors.DistantPolicySelector
-          jump_to_goal:
-            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.JumpToGoal}
-            agent_id: agent_id_0
-            sensor_id: view_finder
-          look_at_goal:
-            _target_: ${monty.class:tbp.monty.frameworks.models.salience.motor_policy.LookAtGoal}
-            agent_id: agent_id_0
-            sensor_id: view_finder
-          default:
-            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicyRandomWalk}
-            agent_id: agent_id_0
+          policy:
             action_sampler:
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               actions:
-              - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.LookDown}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
-              rotation_degrees: 5.0
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveForward}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveTangentially}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
+            use_goal_driven_actions: true
+            agent_id: agent_id_0
+            desired_object_distance: 0.025
+            alpha: 0.1
+            pc_alpha: 0.5
+            max_pc_bias_steps: 32
+            min_general_steps: 8
+            min_heading_steps: 12
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.SinglePolicySelector
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
       learning_modules:
         learning_module_0:
           hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
           hypotheses_updater_args:
-            max_nneighbors: 5
+            max_nneighbors: 10
           _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
           feature_weights:
             patch:
@@ -59,35 +57,37 @@ experiment:
             elapsed_steps_factor: 10
             min_post_goal_success_steps: 5
             x_percent_scale_factor: 0.75
-            desired_object_distance: 0.03
+            desired_object_distance: 0.025
       sensor_modules:
         sensor_module_0:
           _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
-          sensor_module_id: patch
           features:
           - pose_vectors
           - pose_fully_defined
           - on_object
           - object_coverage
+          - min_depth
+          - mean_depth
           - hsv
+          - principal_curvatures
           - principal_curvatures_log
+          sensor_module_id: patch
+          save_raw_obs: false
           delta_thresholds:
             on_object: 0
-            n_steps: 20
-            hsv:
-            - 0.1
-            - 0.1
-            - 0.1
-            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-            principal_curvatures_log:
-            - 2
-            - 2
             distance: 0.01
-          save_raw_obs: false
+          is_surface_sm: true
+          noise_params:
+            features:
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
-          save_raw_obs: false
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0
@@ -99,7 +99,7 @@ experiment:
       env_init_args:
         data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
         agents:
-        - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+        - _target_: tbp.monty.simulators.mujoco.agents.SurfaceAgent
           _partial_: true
           agent_id: agent_id_0
           sensor_configs:
@@ -108,23 +108,33 @@ experiment:
               resolution:
                 width: 64
                 height: 64
+              position:
+              - 0.0
+              - 0.0
+              - 0.0
               zoom: 10.0
             view_finder:
               _target_: tbp.monty.frameworks.sensors.SensorConfig
               resolution:
                 width: 64
                 height: 64
+              position:
+              - 0.0
+              - 0.0
+              - 0.03
               zoom: 1.0
           position:
           - 0.0
           - 1.5
-          - 0.2
-        raise_actuate_missing: false
+          - 0.1
       env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}
       transform:
       - _target_: tbp.monty.frameworks.environment_utils.transforms.MissingToMaxDepth
         agent_id: agent_id_0
         max_depth: 1
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.AddNoiseToRawDepthImage
+        agent_id: agent_id_0
+        sigma: 0.001
       - _target_: tbp.monty.frameworks.environment_utils.transforms.DepthTo3DLocations
         agent_id: agent_id_0
         sensor_ids:
@@ -141,6 +151,9 @@ experiment:
         - 1.0
         get_all_points: true
         use_semantic_sensor: false
+        depth_clip_sensors:
+        - 0
+        clip_value: 0.05
     eval_env_interface_args:
       parent_to_child_mapping: null
       object_names:
@@ -155,17 +168,7 @@ experiment:
       - c_lego_duplo
       - banana
       object_init_sampler:
-        _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
-        rotations: ${constants.rotations_all}
-      positioning_procedures:
-      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
-        agent_id: agent_id_0
-        sensor_id: view_finder
-      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
-        agent_id: agent_id_0
-        sensor_id: patch
-        allow_translation: false
-        max_orientation_attempts: 3
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
     eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
     logging:
       monty_log_level: BASIC
@@ -182,14 +185,14 @@ experiment:
       wandb_id:
         _target_: wandb.util.generate_id
       wandb_group: benchmark_experiments
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randomrot_rawnoise_10distinctobj_surf_agent_mujoco
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
-    max_total_steps: 6000
+    max_total_steps: 5000
     n_train_epochs: 3
     model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []

--- a/tests/conf/snapshots/randrot_10distinctobj_surf_agent_mujoco.yaml
+++ b/tests/conf/snapshots/randrot_10distinctobj_surf_agent_mujoco.yaml
@@ -10,28 +10,26 @@ experiment:
         min_train_steps: 3
         max_total_steps: 2500
       motor_system_config:
-        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
         policy_selector:
-          _target_: tbp.monty.frameworks.models.motor_policy_selectors.DistantPolicySelector
-          jump_to_goal:
-            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.JumpToGoal}
-            agent_id: agent_id_0
-            sensor_id: view_finder
-          look_at_goal:
-            _target_: ${monty.class:tbp.monty.frameworks.models.salience.motor_policy.LookAtGoal}
-            agent_id: agent_id_0
-            sensor_id: view_finder
-          default:
-            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicyRandomWalk}
-            agent_id: agent_id_0
+          policy:
             action_sampler:
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               actions:
-              - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.LookDown}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
-              rotation_degrees: 5.0
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveForward}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveTangentially}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
+            use_goal_driven_actions: true
+            agent_id: agent_id_0
+            desired_object_distance: 0.025
+            alpha: 0.1
+            pc_alpha: 0.5
+            max_pc_bias_steps: 32
+            min_general_steps: 8
+            min_heading_steps: 12
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.SinglePolicySelector
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
       learning_modules:
         learning_module_0:
           hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
@@ -59,17 +57,21 @@ experiment:
             elapsed_steps_factor: 10
             min_post_goal_success_steps: 5
             x_percent_scale_factor: 0.75
-            desired_object_distance: 0.03
+            desired_object_distance: 0.025
       sensor_modules:
         sensor_module_0:
           _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          is_surface_sm: true
           sensor_module_id: patch
           features:
           - pose_vectors
           - pose_fully_defined
           - on_object
           - object_coverage
+          - min_depth
+          - mean_depth
           - hsv
+          - principal_curvatures
           - principal_curvatures_log
           delta_thresholds:
             on_object: 0
@@ -85,7 +87,7 @@ experiment:
             distance: 0.01
           save_raw_obs: false
         sensor_module_1:
-          _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
           save_raw_obs: false
       sm_to_agent_dict:
@@ -99,18 +101,26 @@ experiment:
       env_init_args:
         data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
         agents:
-        - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+        - _target_: tbp.monty.simulators.mujoco.agents.SurfaceAgent
           _partial_: true
           agent_id: agent_id_0
           sensor_configs:
             patch:
               _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.0
               resolution:
                 width: 64
                 height: 64
               zoom: 10.0
             view_finder:
               _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.03
               resolution:
                 width: 64
                 height: 64
@@ -118,7 +128,7 @@ experiment:
           position:
           - 0.0
           - 1.5
-          - 0.2
+          - 0.1
         raise_actuate_missing: false
       env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}
       transform:
@@ -141,6 +151,9 @@ experiment:
         - 1.0
         get_all_points: true
         use_semantic_sensor: false
+        depth_clip_sensors:
+        - 0
+        clip_value: 0.05
     eval_env_interface_args:
       parent_to_child_mapping: null
       object_names:
@@ -155,17 +168,7 @@ experiment:
       - c_lego_duplo
       - banana
       object_init_sampler:
-        _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
-        rotations: ${constants.rotations_all}
-      positioning_procedures:
-      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
-        agent_id: agent_id_0
-        sensor_id: view_finder
-      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
-        agent_id: agent_id_0
-        sensor_id: patch
-        allow_translation: false
-        max_orientation_attempts: 3
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
     eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
     logging:
       monty_log_level: BASIC
@@ -182,14 +185,14 @@ experiment:
       wandb_id:
         _target_: wandb.util.generate_id
       wandb_group: benchmark_experiments
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_10distinctobj_surf_agent_mujoco
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
-    max_total_steps: 6000
+    max_total_steps: 5000
     n_train_epochs: 3
     model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_5lms_dist_agent_mujoco.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_5lms_dist_agent_mujoco.yaml
@@ -1,0 +1,508 @@
+experiment:
+  config:
+    do_eval: true
+    do_train: false
+    monty_config:
+      monty_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.model.MontyForEvidenceGraphMatching}
+      monty_args:
+        num_exploratory_steps: 1000
+        min_eval_steps: ${constants.min_eval_steps}
+        min_train_steps: 3
+        max_total_steps: 2500
+      motor_system_config:
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
+        policy_selector:
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.DistantPolicySelector
+          jump_to_goal:
+            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.JumpToGoal}
+            agent_id: agent_id_0
+            sensor_id: view_finder
+          look_at_goal:
+            _target_: ${monty.class:tbp.monty.frameworks.models.salience.motor_policy.LookAtGoal}
+            agent_id: agent_id_0
+            sensor_id: view_finder
+          default:
+            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicyRandomWalk}
+            agent_id: agent_id_0
+            action_sampler:
+              _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
+              actions:
+              - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.LookDown}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
+              rotation_degrees: 5.0
+      learning_modules:
+        learning_module_0:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+            patch_0:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+        learning_module_1:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+            patch_1:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+        learning_module_2:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+            patch_2:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+        learning_module_3:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+            patch_3:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+        learning_module_4:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+            patch_4:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+      sensor_modules:
+        sensor_module_0:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_0
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
+        sensor_module_1:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_1
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
+        sensor_module_2:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_2
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
+        sensor_module_3:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_3
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
+        sensor_module_4:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_4
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
+        sensor_module_5:
+          _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
+          sensor_module_id: view_finder
+          save_raw_obs: true
+      sm_to_agent_dict:
+        patch_0: agent_id_0
+        patch_1: agent_id_0
+        patch_2: agent_id_0
+        patch_3: agent_id_0
+        patch_4: agent_id_0
+        view_finder: agent_id_0
+      sm_to_lm_matrix:
+      - - 0
+      - - 1
+      - - 2
+      - - 3
+      - - 4
+      lm_to_lm_matrix: null
+      lm_to_lm_vote_matrix:
+      - - 1
+        - 2
+        - 3
+        - 4
+      - - 0
+        - 2
+        - 3
+        - 4
+      - - 0
+        - 1
+        - 3
+        - 4
+      - - 0
+        - 1
+        - 2
+        - 4
+      - - 0
+        - 1
+        - 2
+        - 3
+    environment:
+      env_init_args:
+        data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
+        agents:
+        - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+          _partial_: true
+          agent_id: agent_id_0
+          sensor_configs:
+            patch_0:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - 0.0
+              - 0.0
+              - 0.0
+              zoom: 10.0
+            patch_1:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - 0.0
+              - 0.01
+              - 0.0
+              zoom: 10.0
+            patch_2:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - 0.0
+              - -0.01
+              - 0.0
+              zoom: 10.0
+            patch_3:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - 0.01
+              - 0.0
+              - 0.0
+              zoom: 10.0
+            patch_4:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - -0.01
+              - 0.0
+              - 0.0
+              zoom: 10.0
+            view_finder:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - 0.0
+              - 0.0
+              - 0.0
+              zoom: 1.0
+          position:
+          - 0.0
+          - 1.5
+          - 0.2
+      env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}
+      transform:
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.MissingToMaxDepth
+        agent_id: agent_id_0
+        max_depth: 1
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.DepthTo3DLocations
+        agent_id: agent_id_0
+        sensor_ids:
+        - patch_0
+        - patch_1
+        - patch_2
+        - patch_3
+        - patch_4
+        - view_finder
+        resolutions:
+        - - 64
+          - 64
+        - - 64
+          - 64
+        - - 64
+          - 64
+        - - 64
+          - 64
+        - - 64
+          - 64
+        - - 64
+          - 64
+        world_coord: true
+        zooms:
+        - 10.0
+        - 10.0
+        - 10.0
+        - 10.0
+        - 10.0
+        - 1.0
+        get_all_points: true
+        use_semantic_sensor: false
+    eval_env_interface_args:
+      parent_to_child_mapping: null
+      object_names:
+      - mug
+      - bowl
+      - potted_meat_can
+      - spoon
+      - strawberry
+      - mustard_bottle
+      - dice
+      - golf_ball
+      - c_lego_duplo
+      - banana
+      object_init_sampler:
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
+      positioning_procedures:
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: view_finder
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: patch_0
+        allow_translation: false
+        max_orientation_attempts: 3
+    eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
+    logging:
+      monty_log_level: BASIC
+      monty_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.BasicCSVStatsHandler}
+      wandb_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbTableStatsHandler}
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbChartStatsHandler}
+      python_log_level: WARNING
+      python_log_to_file: true
+      python_log_to_stderr: true
+      output_dir: ${path.expanduser:${oc.env:MONTY_LOGS}/projects/monty_runs}
+      resume_wandb_run: false
+      wandb_id:
+        _target_: wandb.util.generate_id
+      wandb_group: benchmark_experiments
+      run_name: randrot_noise_10distinctobj_5lms_dist_agent
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/supervised_pre_training_5lms/pretrained/
+    n_eval_epochs: 10
+    min_lms_match: 3
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+episodes: all
+num_parallel: 16
+print_cfg: false
+quiet_habitat_logs: true
+constants:
+  default_all_noise_params:
+    features:
+      pose_vectors: 2
+      hsv: 0.1
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01
+    location: 0.002
+  default_sensor_features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - hsv
+  - principal_curvatures_log
+  min_eval_steps: 20
+  pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_ycb_v13}
+  compositional_pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_compositional_objects_v4}
+  rotations_all_count: 14
+  rotations_all:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0
+  - - 0
+    - 270
+    - 0
+  - - 90
+    - 0
+    - 0
+  - - 90
+    - 180
+    - 0
+  - - 35
+    - 45
+    - 0
+  - - 325
+    - 45
+    - 0
+  - - 35
+    - 315
+    - 0
+  - - 325
+    - 315
+    - 0
+  - - 35
+    - 135
+    - 0
+  - - 325
+    - 135
+    - 0
+  - - 35
+    - 225
+    - 0
+  - - 325
+    - 225
+    - 0
+  rotations_3_count: 3
+  rotations_3:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_dist_agent_mujoco.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_dist_agent_mujoco.yaml
@@ -36,7 +36,7 @@ experiment:
         learning_module_0:
           hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
           hypotheses_updater_args:
-            max_nneighbors: 5
+            max_nneighbors: 10
           _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
           feature_weights:
             patch:
@@ -68,26 +68,23 @@ experiment:
           - pose_vectors
           - pose_fully_defined
           - on_object
-          - object_coverage
           - hsv
           - principal_curvatures_log
           delta_thresholds:
             on_object: 0
-            n_steps: 20
-            hsv:
-            - 0.1
-            - 0.1
-            - 0.1
-            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-            principal_curvatures_log:
-            - 2
-            - 2
             distance: 0.01
           save_raw_obs: false
+          noise_params:
+            features:
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
           sensor_module_id: view_finder
-          save_raw_obs: false
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0
@@ -155,8 +152,7 @@ experiment:
       - c_lego_duplo
       - banana
       object_init_sampler:
-        _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
-        rotations: ${constants.rotations_all}
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
       positioning_procedures:
       - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
         agent_id: agent_id_0
@@ -182,14 +178,14 @@ experiment:
       wandb_id:
         _target_: wandb.util.generate_id
       wandb_group: benchmark_experiments
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_noise_10distinctobj_dist_agent_mujoco
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
     max_total_steps: 6000
     n_train_epochs: 3
     model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_dist_on_distm_mujoco.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_dist_on_distm_mujoco.yaml
@@ -36,7 +36,7 @@ experiment:
         learning_module_0:
           hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
           hypotheses_updater_args:
-            max_nneighbors: 5
+            max_nneighbors: 10
           _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
           feature_weights:
             patch:
@@ -68,26 +68,23 @@ experiment:
           - pose_vectors
           - pose_fully_defined
           - on_object
-          - object_coverage
           - hsv
           - principal_curvatures_log
           delta_thresholds:
             on_object: 0
-            n_steps: 20
-            hsv:
-            - 0.1
-            - 0.1
-            - 0.1
-            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-            principal_curvatures_log:
-            - 2
-            - 2
             distance: 0.01
           save_raw_obs: false
+          noise_params:
+            features:
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
           sensor_module_id: view_finder
-          save_raw_obs: false
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0
@@ -155,8 +152,7 @@ experiment:
       - c_lego_duplo
       - banana
       object_init_sampler:
-        _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
-        rotations: ${constants.rotations_all}
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
       positioning_procedures:
       - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
         agent_id: agent_id_0
@@ -182,14 +178,14 @@ experiment:
       wandb_id:
         _target_: wandb.util.generate_id
       wandb_group: benchmark_experiments
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_noise_10distinctobj_dist_on_distm_mujoco
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
     max_total_steps: 6000
     n_train_epochs: 3
-    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    model_name_or_path: ${constants.pretrained_dir}/supervised_pre_training_base/pretrained/
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_surf_agent_mujoco.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_surf_agent_mujoco.yaml
@@ -10,33 +10,31 @@ experiment:
         min_train_steps: 3
         max_total_steps: 2500
       motor_system_config:
-        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
         policy_selector:
-          _target_: tbp.monty.frameworks.models.motor_policy_selectors.DistantPolicySelector
-          jump_to_goal:
-            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.JumpToGoal}
-            agent_id: agent_id_0
-            sensor_id: view_finder
-          look_at_goal:
-            _target_: ${monty.class:tbp.monty.frameworks.models.salience.motor_policy.LookAtGoal}
-            agent_id: agent_id_0
-            sensor_id: view_finder
-          default:
-            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicyRandomWalk}
-            agent_id: agent_id_0
+          policy:
             action_sampler:
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               actions:
-              - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.LookDown}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
-              rotation_degrees: 5.0
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveForward}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveTangentially}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
+            use_goal_driven_actions: true
+            agent_id: agent_id_0
+            desired_object_distance: 0.025
+            alpha: 0.1
+            pc_alpha: 0.5
+            max_pc_bias_steps: 32
+            min_general_steps: 8
+            min_heading_steps: 12
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.SinglePolicySelector
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
       learning_modules:
         learning_module_0:
           hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
           hypotheses_updater_args:
-            max_nneighbors: 5
+            max_nneighbors: 10
           _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
           feature_weights:
             patch:
@@ -59,35 +57,37 @@ experiment:
             elapsed_steps_factor: 10
             min_post_goal_success_steps: 5
             x_percent_scale_factor: 0.75
-            desired_object_distance: 0.03
+            desired_object_distance: 0.025
       sensor_modules:
         sensor_module_0:
           _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
-          sensor_module_id: patch
           features:
           - pose_vectors
           - pose_fully_defined
           - on_object
           - object_coverage
+          - min_depth
+          - mean_depth
           - hsv
+          - principal_curvatures
           - principal_curvatures_log
+          sensor_module_id: patch
+          save_raw_obs: false
           delta_thresholds:
             on_object: 0
-            n_steps: 20
-            hsv:
-            - 0.1
-            - 0.1
-            - 0.1
-            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-            principal_curvatures_log:
-            - 2
-            - 2
             distance: 0.01
-          save_raw_obs: false
+          is_surface_sm: true
+          noise_params:
+            features:
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
-          save_raw_obs: false
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0
@@ -99,18 +99,26 @@ experiment:
       env_init_args:
         data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
         agents:
-        - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+        - _target_: tbp.monty.simulators.mujoco.agents.SurfaceAgent
           _partial_: true
           agent_id: agent_id_0
           sensor_configs:
             patch:
               _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.0
               resolution:
                 width: 64
                 height: 64
               zoom: 10.0
             view_finder:
               _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.03
               resolution:
                 width: 64
                 height: 64
@@ -118,7 +126,7 @@ experiment:
           position:
           - 0.0
           - 1.5
-          - 0.2
+          - 0.1
         raise_actuate_missing: false
       env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}
       transform:
@@ -141,6 +149,9 @@ experiment:
         - 1.0
         get_all_points: true
         use_semantic_sensor: false
+        depth_clip_sensors:
+        - 0
+        clip_value: 0.05
     eval_env_interface_args:
       parent_to_child_mapping: null
       object_names:
@@ -155,17 +166,7 @@ experiment:
       - c_lego_duplo
       - banana
       object_init_sampler:
-        _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
-        rotations: ${constants.rotations_all}
-      positioning_procedures:
-      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
-        agent_id: agent_id_0
-        sensor_id: view_finder
-      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
-        agent_id: agent_id_0
-        sensor_id: patch
-        allow_translation: false
-        max_orientation_attempts: 3
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
     eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
     logging:
       monty_log_level: BASIC
@@ -182,14 +183,14 @@ experiment:
       wandb_id:
         _target_: wandb.util.generate_id
       wandb_group: benchmark_experiments
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_noise_10distinctobj_surf_agent_mujoco
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
-    max_total_steps: 6000
+    max_total_steps: 5000
     n_train_epochs: 3
     model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []

--- a/tests/conf/snapshots/randrot_noise_10distinctobj_vocus_on_vocusm_mujoco.yaml
+++ b/tests/conf/snapshots/randrot_noise_10distinctobj_vocus_on_vocusm_mujoco.yaml
@@ -36,7 +36,7 @@ experiment:
         learning_module_0:
           hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
           hypotheses_updater_args:
-            max_nneighbors: 5
+            max_nneighbors: 10
           _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
           feature_weights:
             patch:
@@ -68,26 +68,33 @@ experiment:
           - pose_vectors
           - pose_fully_defined
           - on_object
-          - object_coverage
           - hsv
           - principal_curvatures_log
           delta_thresholds:
             on_object: 0
-            n_steps: 20
-            hsv:
-            - 0.1
-            - 0.1
-            - 0.1
-            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-            principal_curvatures_log:
-            - 2
-            - 2
             distance: 0.01
           save_raw_obs: false
+          noise_params:
+            features:
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
           sensor_module_id: view_finder
           save_raw_obs: false
+          salience_strategy:
+            _target_: tbp.monty.frameworks.models.salience.strategies.vocus2.Vocus2.from_config
+            config:
+              _target_: tbp.monty.frameworks.models.salience.strategies.vocus2.vocus2.Vocus2SalienceConfig
+              center_sigma: 1.0
+              surround_sigma: 6.5
+              n_scales: 2
+              max_octaves: 5
+              use_depth: true
+              use_orientation: false
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0
@@ -112,8 +119,8 @@ experiment:
             view_finder:
               _target_: tbp.monty.frameworks.sensors.SensorConfig
               resolution:
-                width: 64
-                height: 64
+                width: 256
+                height: 256
               zoom: 1.0
           position:
           - 0.0
@@ -133,8 +140,8 @@ experiment:
         resolutions:
         - - 64
           - 64
-        - - 64
-          - 64
+        - - 256
+          - 256
         world_coord: true
         zooms:
         - 10.0
@@ -155,8 +162,7 @@ experiment:
       - c_lego_duplo
       - banana
       object_init_sampler:
-        _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
-        rotations: ${constants.rotations_all}
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
       positioning_procedures:
       - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
         agent_id: agent_id_0
@@ -182,14 +188,14 @@ experiment:
       wandb_id:
         _target_: wandb.util.generate_id
       wandb_group: benchmark_experiments
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_noise_10distinctobj_vocus_on_vocusm_mujoco
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
     max_total_steps: 6000
     n_train_epochs: 3
-    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    model_name_or_path: ${constants.pretrained_dir}/supervised_pre_training_10distinctobj_vocus2/pretrained/
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []

--- a/tests/conf/snapshots/randrot_noise_10simobj_dist_agent_mujoco.yaml
+++ b/tests/conf/snapshots/randrot_noise_10simobj_dist_agent_mujoco.yaml
@@ -36,7 +36,7 @@ experiment:
         learning_module_0:
           hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
           hypotheses_updater_args:
-            max_nneighbors: 5
+            max_nneighbors: 10
           _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
           feature_weights:
             patch:
@@ -68,26 +68,23 @@ experiment:
           - pose_vectors
           - pose_fully_defined
           - on_object
-          - object_coverage
           - hsv
           - principal_curvatures_log
           delta_thresholds:
             on_object: 0
-            n_steps: 20
-            hsv:
-            - 0.1
-            - 0.1
-            - 0.1
-            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-            principal_curvatures_log:
-            - 2
-            - 2
             distance: 0.01
           save_raw_obs: false
+          noise_params:
+            features:
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
           _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
           sensor_module_id: view_finder
-          save_raw_obs: false
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0
@@ -145,18 +142,17 @@ experiment:
       parent_to_child_mapping: null
       object_names:
       - mug
-      - bowl
-      - potted_meat_can
+      - e_cups
+      - knife
+      - fork
       - spoon
-      - strawberry
-      - mustard_bottle
-      - dice
-      - golf_ball
-      - c_lego_duplo
-      - banana
+      - c_cups
+      - d_cups
+      - cracker_box
+      - sugar_box
+      - pudding_box
       object_init_sampler:
-        _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
-        rotations: ${constants.rotations_all}
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
       positioning_procedures:
       - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
         agent_id: agent_id_0
@@ -182,14 +178,14 @@ experiment:
       wandb_id:
         _target_: wandb.util.generate_id
       wandb_group: benchmark_experiments
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_noise_10simobj_dist_agent_mujoco
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
     max_total_steps: 6000
     n_train_epochs: 3
-    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10similarobj/pretrained/
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []

--- a/tests/conf/snapshots/randrot_noise_10simobj_surf_agent_mujoco.yaml
+++ b/tests/conf/snapshots/randrot_noise_10simobj_surf_agent_mujoco.yaml
@@ -10,33 +10,31 @@ experiment:
         min_train_steps: 3
         max_total_steps: 2500
       motor_system_config:
-        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
         policy_selector:
-          _target_: tbp.monty.frameworks.models.motor_policy_selectors.DistantPolicySelector
-          jump_to_goal:
-            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.JumpToGoal}
-            agent_id: agent_id_0
-            sensor_id: view_finder
-          look_at_goal:
-            _target_: ${monty.class:tbp.monty.frameworks.models.salience.motor_policy.LookAtGoal}
-            agent_id: agent_id_0
-            sensor_id: view_finder
-          default:
-            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicyRandomWalk}
-            agent_id: agent_id_0
+          policy:
             action_sampler:
               _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
               actions:
-              - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.LookDown}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
-              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
-              rotation_degrees: 5.0
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveForward}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveTangentially}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
+            use_goal_driven_actions: true
+            agent_id: agent_id_0
+            desired_object_distance: 0.025
+            alpha: 0.1
+            pc_alpha: 0.5
+            max_pc_bias_steps: 32
+            min_general_steps: 8
+            min_heading_steps: 12
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.SinglePolicySelector
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
       learning_modules:
         learning_module_0:
           hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
           hypotheses_updater_args:
-            max_nneighbors: 5
+            max_nneighbors: 10
           _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
           feature_weights:
             patch:
@@ -59,35 +57,37 @@ experiment:
             elapsed_steps_factor: 10
             min_post_goal_success_steps: 5
             x_percent_scale_factor: 0.75
-            desired_object_distance: 0.03
+            desired_object_distance: 0.025
       sensor_modules:
         sensor_module_0:
           _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
-          sensor_module_id: patch
           features:
           - pose_vectors
           - pose_fully_defined
           - on_object
           - object_coverage
+          - min_depth
+          - mean_depth
           - hsv
+          - principal_curvatures
           - principal_curvatures_log
+          sensor_module_id: patch
+          save_raw_obs: false
           delta_thresholds:
             on_object: 0
-            n_steps: 20
-            hsv:
-            - 0.1
-            - 0.1
-            - 0.1
-            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
-            principal_curvatures_log:
-            - 2
-            - 2
             distance: 0.01
-          save_raw_obs: false
+          is_surface_sm: true
+          noise_params:
+            features:
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
         sensor_module_1:
-          _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
           sensor_module_id: view_finder
-          save_raw_obs: false
+          save_raw_obs: true
       sm_to_agent_dict:
         patch: agent_id_0
         view_finder: agent_id_0
@@ -99,18 +99,26 @@ experiment:
       env_init_args:
         data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
         agents:
-        - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+        - _target_: tbp.monty.simulators.mujoco.agents.SurfaceAgent
           _partial_: true
           agent_id: agent_id_0
           sensor_configs:
             patch:
               _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.0
               resolution:
                 width: 64
                 height: 64
               zoom: 10.0
             view_finder:
               _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.03
               resolution:
                 width: 64
                 height: 64
@@ -118,7 +126,7 @@ experiment:
           position:
           - 0.0
           - 1.5
-          - 0.2
+          - 0.1
         raise_actuate_missing: false
       env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}
       transform:
@@ -141,31 +149,24 @@ experiment:
         - 1.0
         get_all_points: true
         use_semantic_sensor: false
+        depth_clip_sensors:
+        - 0
+        clip_value: 0.05
     eval_env_interface_args:
       parent_to_child_mapping: null
       object_names:
       - mug
-      - bowl
-      - potted_meat_can
+      - e_cups
+      - knife
+      - fork
       - spoon
-      - strawberry
-      - mustard_bottle
-      - dice
-      - golf_ball
-      - c_lego_duplo
-      - banana
+      - c_cups
+      - d_cups
+      - cracker_box
+      - sugar_box
+      - pudding_box
       object_init_sampler:
-        _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
-        rotations: ${constants.rotations_all}
-      positioning_procedures:
-      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
-        agent_id: agent_id_0
-        sensor_id: view_finder
-      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
-        agent_id: agent_id_0
-        sensor_id: patch
-        allow_translation: false
-        max_orientation_attempts: 3
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
     eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
     logging:
       monty_log_level: BASIC
@@ -182,14 +183,14 @@ experiment:
       wandb_id:
         _target_: wandb.util.generate_id
       wandb_group: benchmark_experiments
-      run_name: base_config_10distinctobj_dist_agent_mujoco
+      run_name: randrot_noise_10simobj_surf_agent_mujoco
     show_sensor_output: false
     max_train_steps: 1000
     max_eval_steps: 500
     max_total_steps: 6000
     n_train_epochs: 3
-    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10distinctobj/pretrained/
-    n_eval_epochs: ${constants.rotations_all_count}
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_10similarobj/pretrained/
+    n_eval_epochs: 10
     min_lms_match: 1
     seed: 42
     supervised_lm_ids: []


### PR DESCRIPTION
Created experiment configurations for the benchmarks listed in `benchmarks/ycb_10objs.csv`. We decided to exclude the `base_10multi_distinctobj_dist_agent` for now, as it uses distractor objects that we haven't implemented in MuJoCo and we've decided we don't want to implement them at this time.

I've run all of these locally, and the run to completion with reasonable overall stats. The numbers look good even with these still running on Habitat trained models.