### PR TITLE
test: all `GraphLearningTest` cases pass in both modes

### DIFF
--- a/tests/integration/frameworks/models/graph_learning_test.py
+++ b/tests/integration/frameworks/models/graph_learning_test.py
@@ -509,7 +509,7 @@ class GraphLearningTest(BaseGraphTest):
                 "on object",
             )
 
-    def test_detailed_logging(self):
+    def test_detailed_logging(self) -> None:
         exp = instantiate_experiment(self.feature_pred_off_object_cfg.experiment)
         with exp:
             exp.run()
@@ -547,7 +547,7 @@ class GraphLearningTest(BaseGraphTest):
             "even those off the object.",
         )
         self.assertEqual(
-            len(detailed_stats["1"]["LM_0"]["possible_matches"]),
+            detailed_stats["1"]["LM_0"]["individual_ts_reached_at_step"],
             train_stats.loc[1]["monty_matching_steps"],
             "matching steps in detailed stats don't match with those in train stats.",
         )

--- a/tests/mujoco/integration/frameworks/models/graph_learning_test.py
+++ b/tests/mujoco/integration/frameworks/models/graph_learning_test.py
@@ -508,7 +508,6 @@ class GraphLearningTest(BaseGraphTest):
         with exp:
             exp.run()
 
-        # TODO: improve load_stats with a structured return type
         train_stats, eval_stats, detailed_stats, lm_models = load_stats(
             exp.output_dir,
             load_train=True,
@@ -542,7 +541,7 @@ class GraphLearningTest(BaseGraphTest):
             "even those off the object.",
         )
         self.assertEqual(
-            len(detailed_stats["1"]["LM_0"]["possible_matches"]),
+            detailed_stats["1"]["LM_0"]["individual_ts_reached_at_step"],
             train_stats.loc[1]["monty_matching_steps"],
             "matching steps in detailed stats don't match with those in train stats.",
         )

--- a/tests/mujoco/integration/frameworks/models/graph_learning_test.py
+++ b/tests/mujoco/integration/frameworks/models/graph_learning_test.py
@@ -508,6 +508,7 @@ class GraphLearningTest(BaseGraphTest):
         with exp:
             exp.run()
 
+        # TODO: improve load_stats with a structured return type
         train_stats, eval_stats, detailed_stats, lm_models = load_stats(
             exp.output_dir,
             load_train=True,


### PR DESCRIPTION
`GraphLearningTest::test_detailed_logging()` failed when `_recreation_mode = True` because it relied on accumulating `possible_matches` across episodes. I adjusted the test to compare against `detailed_stats['1']['LM_0']['individual_ts_reached_at_step']` instead, which works in both modes.

With this change, all the tests in `tests/integration/frameworks/models/graph_learning_test.py` pass in both modes.
