### PR TITLE
chore: create MuJoCo versions of ycb_77objs benchmarks

### DIFF
--- a/src/tbp/monty/conf/experiment/base_77obj_dist_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/base_77obj_dist_agent_mujoco.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp1000_emin_t3_tot2500
+  - /monty/motor_system_config: distant_5
+  - /monty/learning_module: evidence_1lm_nn5_dod003
+  - /monty/sensor_module: camera_dist_delta_salience
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_ycb_dist_agent
+  - /env_interface: eval_77obj_predefined
+  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: basic_warning_wandb_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_77obj/pretrained/
+    n_eval_epochs: ${constants.rotations_3_count}
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+    logging:
+      run_name: base_77obj_dist_agent_mujoco

--- a/src/tbp/monty/conf/experiment/base_77obj_surf_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/base_77obj_surf_agent_mujoco.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp1000_emin_t3_tot2500
+  - /monty/motor_system_config: surface_curvature_informed_goal1
+  - /monty/learning_module: evidence_1lm_nn5_dod0025
+  - /monty/sensor_module: camera_surf_delta
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_ycb_surf_agent
+  - /env_interface: eval_77obj_predefined
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0_clip
+  - /logging: basic_warning_wandb_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 5000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_77obj/pretrained/
+    n_eval_epochs: ${constants.rotations_3_count}
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+    logging:
+      run_name: base_77obj_surf_agent_mujoco

--- a/src/tbp/monty/conf/experiment/randrot_noise_77obj_5lms_dist_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_noise_77obj_5lms_dist_agent_mujoco.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp1000_emin_t3_tot2500
+  - /monty/motor_system_config: distant_5
+  - /monty/learning_module: evidence_5lm_nn10_dod003
+  - /monty/sensor_module: 5sm_camera_dist_noise
+  - /monty/connectivity: 5lm_5sm
+  - /environment: mujoco_dist_agent_sensors5
+  - /env_interface: eval_77obj_random
+  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch0
+  - /env_interface/transform: missing_depthto3d_sensor6
+  - /logging: basic_warning_wandb_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/supervised_pre_training_5lms_all_objects/pretrained/
+    n_eval_epochs: 1
+    min_lms_match: 3
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+    logging:
+      run_name: randrot_noise_77obj_5lms_dist_agent_mujoco

--- a/src/tbp/monty/conf/experiment/randrot_noise_77obj_dist_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_noise_77obj_dist_agent_mujoco.yaml
@@ -1,0 +1,30 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp1000_emin_t3_tot2500
+  - /monty/motor_system_config: distant_5
+  - /monty/learning_module: evidence_1lm_nn10_dod003
+  - /monty/sensor_module: camera_dist_noise_raw1_salience
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_ycb_dist_agent
+  - /env_interface: eval_77obj_random
+  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0
+  - /logging: basic_warning_wandb_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_77obj/pretrained/
+    n_eval_epochs: ${constants.rotations_3_count}
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+    logging:
+      run_name: randrot_noise_77obj_dist_agent_mujoco

--- a/src/tbp/monty/conf/experiment/randrot_noise_77obj_surf_agent_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/randrot_noise_77obj_surf_agent_mujoco.yaml
@@ -1,0 +1,29 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp1000_emin_t3_tot2500
+  - /monty/motor_system_config: surface_curvature_informed_goal1
+  - /monty/learning_module: evidence_1lm_nn10_dod0025
+  - /monty/sensor_module: camera_surf_noise_raw1
+  - /monty/connectivity: 1lm_1sm
+  - /environment: mujoco_ycb_surf_agent
+  - /env_interface: eval_77obj_random
+  - /env_interface/transform: missing_depthto3d_sensor2_semantic0_clip
+  - /logging: basic_warning_wandb_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 5000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_77obj/pretrained/
+    n_eval_epochs: ${constants.rotations_3_count}
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+    logging:
+      run_name: randrot_noise_77obj_surf_agent_mujoco

--- a/tests/conf/snapshots/base_77obj_dist_agent_mujoco.yaml
+++ b/tests/conf/snapshots/base_77obj_dist_agent_mujoco.yaml
@@ -1,0 +1,340 @@
+experiment:
+  config:
+    do_eval: true
+    do_train: false
+    monty_config:
+      monty_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.model.MontyForEvidenceGraphMatching}
+      monty_args:
+        num_exploratory_steps: 1000
+        min_eval_steps: ${constants.min_eval_steps}
+        min_train_steps: 3
+        max_total_steps: 2500
+      motor_system_config:
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
+        policy_selector:
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.DistantPolicySelector
+          jump_to_goal:
+            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.JumpToGoal}
+            agent_id: agent_id_0
+            sensor_id: view_finder
+          look_at_goal:
+            _target_: ${monty.class:tbp.monty.frameworks.models.salience.motor_policy.LookAtGoal}
+            agent_id: agent_id_0
+            sensor_id: view_finder
+          default:
+            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicyRandomWalk}
+            agent_id: agent_id_0
+            action_sampler:
+              _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
+              actions:
+              - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.LookDown}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
+              rotation_degrees: 5.0
+      learning_modules:
+        learning_module_0:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 5
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+      sensor_modules:
+        sensor_module_0:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: false
+        sensor_module_1:
+          _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
+          sensor_module_id: view_finder
+          save_raw_obs: false
+      sm_to_agent_dict:
+        patch: agent_id_0
+        view_finder: agent_id_0
+      sm_to_lm_matrix:
+      - - 0
+      lm_to_lm_matrix: null
+      lm_to_lm_vote_matrix: null
+    environment:
+      env_init_args:
+        data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
+        agents:
+        - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+          _partial_: true
+          agent_id: agent_id_0
+          sensor_configs:
+            patch:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              zoom: 10.0
+            view_finder:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              zoom: 1.0
+          position:
+          - 0.0
+          - 1.5
+          - 0.2
+        raise_actuate_missing: false
+      env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}
+      transform:
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.MissingToMaxDepth
+        agent_id: agent_id_0
+        max_depth: 1
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.DepthTo3DLocations
+        agent_id: agent_id_0
+        sensor_ids:
+        - patch
+        - view_finder
+        resolutions:
+        - - 64
+          - 64
+        - - 64
+          - 64
+        world_coord: true
+        zooms:
+        - 10.0
+        - 1.0
+        get_all_points: true
+        use_semantic_sensor: false
+    eval_env_interface_args:
+      parent_to_child_mapping: null
+      object_names:
+      - mug
+      - bowl
+      - potted_meat_can
+      - master_chef_can
+      - i_cups
+      - spoon
+      - b_cups
+      - pitcher_base
+      - knife
+      - b_marbles
+      - h_cups
+      - strawberry
+      - power_drill
+      - padlock
+      - golf_ball
+      - hammer
+      - softball
+      - orange
+      - c_lego_duplo
+      - c_toy_airplane
+      - b_lego_duplo
+      - banana
+      - nine_hole_peg_test
+      - tomato_soup_can
+      - baseball
+      - g_cups
+      - gelatin_box
+      - lemon
+      - plum
+      - racquetball
+      - plate
+      - pudding_box
+      - e_cups
+      - apple
+      - j_cups
+      - foam_brick
+      - large_marker
+      - peach
+      - phillips_screwdriver
+      - a_toy_airplane
+      - e_lego_duplo
+      - sugar_box
+      - a_colored_wood_blocks
+      - c_cups
+      - pear
+      - f_cups
+      - wood_block
+      - d_lego_duplo
+      - b_toy_airplane
+      - b_colored_wood_blocks
+      - g_lego_duplo
+      - a_lego_duplo
+      - mini_soccer_ball
+      - medium_clamp
+      - a_marbles
+      - extra_large_clamp
+      - d_cups
+      - e_toy_airplane
+      - adjustable_wrench
+      - rubiks_cube
+      - f_lego_duplo
+      - a_cups
+      - skillet_lid
+      - sponge
+      - tennis_ball
+      - spatula
+      - d_toy_airplane
+      - chain
+      - scissors
+      - mustard_bottle
+      - bleach_cleanser
+      - tuna_fish_can
+      - cracker_box
+      - fork
+      - large_clamp
+      - dice
+      - flat_screwdriver
+      object_init_sampler:
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
+        rotations: ${constants.rotations_3}
+      positioning_procedures:
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: view_finder
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: patch
+        allow_translation: false
+        max_orientation_attempts: 3
+    eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
+    logging:
+      monty_log_level: BASIC
+      monty_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.BasicCSVStatsHandler}
+      wandb_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbTableStatsHandler}
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbChartStatsHandler}
+      python_log_level: WARNING
+      python_log_to_file: true
+      python_log_to_stderr: true
+      output_dir: ${path.expanduser:${oc.env:MONTY_LOGS}/projects/monty_runs}
+      resume_wandb_run: false
+      wandb_id:
+        _target_: wandb.util.generate_id
+      wandb_group: benchmark_experiments
+      run_name: base_77obj_dist_agent_mujoco
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_77obj/pretrained/
+    n_eval_epochs: ${constants.rotations_3_count}
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+episodes: all
+num_parallel: 16
+print_cfg: false
+quiet_habitat_logs: true
+constants:
+  default_all_noise_params:
+    features:
+      pose_vectors: 2
+      hsv: 0.1
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01
+    location: 0.002
+  default_sensor_features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - hsv
+  - principal_curvatures_log
+  min_eval_steps: 20
+  pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_ycb_v13}
+  compositional_pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_compositional_objects_v4}
+  rotations_all_count: 14
+  rotations_all:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0
+  - - 0
+    - 270
+    - 0
+  - - 90
+    - 0
+    - 0
+  - - 90
+    - 180
+    - 0
+  - - 35
+    - 45
+    - 0
+  - - 325
+    - 45
+    - 0
+  - - 35
+    - 315
+    - 0
+  - - 325
+    - 315
+    - 0
+  - - 35
+    - 135
+    - 0
+  - - 325
+    - 135
+    - 0
+  - - 35
+    - 225
+    - 0
+  - - 325
+    - 225
+    - 0
+  rotations_3_count: 3
+  rotations_3:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0

--- a/tests/conf/snapshots/base_77obj_surf_agent_mujoco.yaml
+++ b/tests/conf/snapshots/base_77obj_surf_agent_mujoco.yaml
@@ -1,0 +1,344 @@
+experiment:
+  config:
+    do_eval: true
+    do_train: false
+    monty_config:
+      monty_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.model.MontyForEvidenceGraphMatching}
+      monty_args:
+        num_exploratory_steps: 1000
+        min_eval_steps: ${constants.min_eval_steps}
+        min_train_steps: 3
+        max_total_steps: 2500
+      motor_system_config:
+        policy_selector:
+          policy:
+            action_sampler:
+              _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
+              actions:
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveForward}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveTangentially}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
+            use_goal_driven_actions: true
+            agent_id: agent_id_0
+            desired_object_distance: 0.025
+            alpha: 0.1
+            pc_alpha: 0.5
+            max_pc_bias_steps: 32
+            min_general_steps: 8
+            min_heading_steps: 12
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.SinglePolicySelector
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
+      learning_modules:
+        learning_module_0:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 5
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.025
+      sensor_modules:
+        sensor_module_0:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          is_surface_sm: true
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: false
+        sensor_module_1:
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
+          sensor_module_id: view_finder
+          save_raw_obs: false
+      sm_to_agent_dict:
+        patch: agent_id_0
+        view_finder: agent_id_0
+      sm_to_lm_matrix:
+      - - 0
+      lm_to_lm_matrix: null
+      lm_to_lm_vote_matrix: null
+    environment:
+      env_init_args:
+        data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
+        agents:
+        - _target_: tbp.monty.simulators.mujoco.agents.SurfaceAgent
+          _partial_: true
+          agent_id: agent_id_0
+          sensor_configs:
+            patch:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.0
+              resolution:
+                width: 64
+                height: 64
+              zoom: 10.0
+            view_finder:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.03
+              resolution:
+                width: 64
+                height: 64
+              zoom: 1.0
+          position:
+          - 0.0
+          - 1.5
+          - 0.1
+        raise_actuate_missing: false
+      env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}
+      transform:
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.MissingToMaxDepth
+        agent_id: agent_id_0
+        max_depth: 1
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.DepthTo3DLocations
+        agent_id: agent_id_0
+        sensor_ids:
+        - patch
+        - view_finder
+        resolutions:
+        - - 64
+          - 64
+        - - 64
+          - 64
+        world_coord: true
+        zooms:
+        - 10.0
+        - 1.0
+        get_all_points: true
+        use_semantic_sensor: false
+        depth_clip_sensors:
+        - 0
+        clip_value: 0.05
+    eval_env_interface_args:
+      parent_to_child_mapping: null
+      object_names:
+      - mug
+      - bowl
+      - potted_meat_can
+      - master_chef_can
+      - i_cups
+      - spoon
+      - b_cups
+      - pitcher_base
+      - knife
+      - b_marbles
+      - h_cups
+      - strawberry
+      - power_drill
+      - padlock
+      - golf_ball
+      - hammer
+      - softball
+      - orange
+      - c_lego_duplo
+      - c_toy_airplane
+      - b_lego_duplo
+      - banana
+      - nine_hole_peg_test
+      - tomato_soup_can
+      - baseball
+      - g_cups
+      - gelatin_box
+      - lemon
+      - plum
+      - racquetball
+      - plate
+      - pudding_box
+      - e_cups
+      - apple
+      - j_cups
+      - foam_brick
+      - large_marker
+      - peach
+      - phillips_screwdriver
+      - a_toy_airplane
+      - e_lego_duplo
+      - sugar_box
+      - a_colored_wood_blocks
+      - c_cups
+      - pear
+      - f_cups
+      - wood_block
+      - d_lego_duplo
+      - b_toy_airplane
+      - b_colored_wood_blocks
+      - g_lego_duplo
+      - a_lego_duplo
+      - mini_soccer_ball
+      - medium_clamp
+      - a_marbles
+      - extra_large_clamp
+      - d_cups
+      - e_toy_airplane
+      - adjustable_wrench
+      - rubiks_cube
+      - f_lego_duplo
+      - a_cups
+      - skillet_lid
+      - sponge
+      - tennis_ball
+      - spatula
+      - d_toy_airplane
+      - chain
+      - scissors
+      - mustard_bottle
+      - bleach_cleanser
+      - tuna_fish_can
+      - cracker_box
+      - fork
+      - large_clamp
+      - dice
+      - flat_screwdriver
+      object_init_sampler:
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
+        rotations: ${constants.rotations_3}
+    eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
+    logging:
+      monty_log_level: BASIC
+      monty_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.BasicCSVStatsHandler}
+      wandb_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbTableStatsHandler}
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbChartStatsHandler}
+      python_log_level: WARNING
+      python_log_to_file: true
+      python_log_to_stderr: true
+      output_dir: ${path.expanduser:${oc.env:MONTY_LOGS}/projects/monty_runs}
+      resume_wandb_run: false
+      wandb_id:
+        _target_: wandb.util.generate_id
+      wandb_group: benchmark_experiments
+      run_name: base_77obj_surf_agent_mujoco
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 5000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_77obj/pretrained/
+    n_eval_epochs: ${constants.rotations_3_count}
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+episodes: all
+num_parallel: 16
+print_cfg: false
+quiet_habitat_logs: true
+constants:
+  default_all_noise_params:
+    features:
+      pose_vectors: 2
+      hsv: 0.1
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01
+    location: 0.002
+  default_sensor_features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - hsv
+  - principal_curvatures_log
+  min_eval_steps: 20
+  pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_ycb_v13}
+  compositional_pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_compositional_objects_v4}
+  rotations_all_count: 14
+  rotations_all:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0
+  - - 0
+    - 270
+    - 0
+  - - 90
+    - 0
+    - 0
+  - - 90
+    - 180
+    - 0
+  - - 35
+    - 45
+    - 0
+  - - 325
+    - 45
+    - 0
+  - - 35
+    - 315
+    - 0
+  - - 325
+    - 315
+    - 0
+  - - 35
+    - 135
+    - 0
+  - - 325
+    - 135
+    - 0
+  - - 35
+    - 225
+    - 0
+  - - 325
+    - 225
+    - 0
+  rotations_3_count: 3
+  rotations_3:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0

--- a/tests/conf/snapshots/randrot_noise_77obj_5lms_dist_agent_mujoco.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_5lms_dist_agent_mujoco.yaml
@@ -1,0 +1,575 @@
+experiment:
+  config:
+    do_eval: true
+    do_train: false
+    monty_config:
+      monty_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.model.MontyForEvidenceGraphMatching}
+      monty_args:
+        num_exploratory_steps: 1000
+        min_eval_steps: ${constants.min_eval_steps}
+        min_train_steps: 3
+        max_total_steps: 2500
+      motor_system_config:
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
+        policy_selector:
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.DistantPolicySelector
+          jump_to_goal:
+            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.JumpToGoal}
+            agent_id: agent_id_0
+            sensor_id: view_finder
+          look_at_goal:
+            _target_: ${monty.class:tbp.monty.frameworks.models.salience.motor_policy.LookAtGoal}
+            agent_id: agent_id_0
+            sensor_id: view_finder
+          default:
+            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicyRandomWalk}
+            agent_id: agent_id_0
+            action_sampler:
+              _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
+              actions:
+              - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.LookDown}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
+              rotation_degrees: 5.0
+      learning_modules:
+        learning_module_0:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+            patch_0:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+        learning_module_1:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+            patch_1:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+        learning_module_2:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+            patch_2:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+        learning_module_3:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+            patch_3:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+        learning_module_4:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+            patch_4:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+      sensor_modules:
+        sensor_module_0:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_0
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
+        sensor_module_1:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_1
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
+        sensor_module_2:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_2
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
+        sensor_module_3:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_3
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
+        sensor_module_4:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_4
+          features: ${constants.default_sensor_features}
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          noise_params: ${constants.default_all_noise_params}
+        sensor_module_5:
+          _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
+          sensor_module_id: view_finder
+          save_raw_obs: true
+      sm_to_agent_dict:
+        patch_0: agent_id_0
+        patch_1: agent_id_0
+        patch_2: agent_id_0
+        patch_3: agent_id_0
+        patch_4: agent_id_0
+        view_finder: agent_id_0
+      sm_to_lm_matrix:
+      - - 0
+      - - 1
+      - - 2
+      - - 3
+      - - 4
+      lm_to_lm_matrix: null
+      lm_to_lm_vote_matrix:
+      - - 1
+        - 2
+        - 3
+        - 4
+      - - 0
+        - 2
+        - 3
+        - 4
+      - - 0
+        - 1
+        - 3
+        - 4
+      - - 0
+        - 1
+        - 2
+        - 4
+      - - 0
+        - 1
+        - 2
+        - 3
+    environment:
+      env_init_args:
+        data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
+        agents:
+        - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+          _partial_: true
+          agent_id: agent_id_0
+          sensor_configs:
+            patch_0:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - 0.0
+              - 0.0
+              - 0.0
+              zoom: 10.0
+            patch_1:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - 0.0
+              - 0.01
+              - 0.0
+              zoom: 10.0
+            patch_2:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - 0.0
+              - -0.01
+              - 0.0
+              zoom: 10.0
+            patch_3:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - 0.01
+              - 0.0
+              - 0.0
+              zoom: 10.0
+            patch_4:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - -0.01
+              - 0.0
+              - 0.0
+              zoom: 10.0
+            view_finder:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              position:
+              - 0.0
+              - 0.0
+              - 0.0
+              zoom: 1.0
+          position:
+          - 0.0
+          - 1.5
+          - 0.2
+      env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}
+      transform:
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.MissingToMaxDepth
+        agent_id: agent_id_0
+        max_depth: 1
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.DepthTo3DLocations
+        agent_id: agent_id_0
+        sensor_ids:
+        - patch_0
+        - patch_1
+        - patch_2
+        - patch_3
+        - patch_4
+        - view_finder
+        resolutions:
+        - - 64
+          - 64
+        - - 64
+          - 64
+        - - 64
+          - 64
+        - - 64
+          - 64
+        - - 64
+          - 64
+        - - 64
+          - 64
+        world_coord: true
+        zooms:
+        - 10.0
+        - 10.0
+        - 10.0
+        - 10.0
+        - 10.0
+        - 1.0
+        get_all_points: true
+        use_semantic_sensor: false
+    eval_env_interface_args:
+      parent_to_child_mapping: null
+      object_names:
+      - mug
+      - bowl
+      - potted_meat_can
+      - master_chef_can
+      - i_cups
+      - spoon
+      - b_cups
+      - pitcher_base
+      - knife
+      - b_marbles
+      - h_cups
+      - strawberry
+      - power_drill
+      - padlock
+      - golf_ball
+      - hammer
+      - softball
+      - orange
+      - c_lego_duplo
+      - c_toy_airplane
+      - b_lego_duplo
+      - banana
+      - nine_hole_peg_test
+      - tomato_soup_can
+      - baseball
+      - g_cups
+      - gelatin_box
+      - lemon
+      - plum
+      - racquetball
+      - plate
+      - pudding_box
+      - e_cups
+      - apple
+      - j_cups
+      - foam_brick
+      - large_marker
+      - peach
+      - phillips_screwdriver
+      - a_toy_airplane
+      - e_lego_duplo
+      - sugar_box
+      - a_colored_wood_blocks
+      - c_cups
+      - pear
+      - f_cups
+      - wood_block
+      - d_lego_duplo
+      - b_toy_airplane
+      - b_colored_wood_blocks
+      - g_lego_duplo
+      - a_lego_duplo
+      - mini_soccer_ball
+      - medium_clamp
+      - a_marbles
+      - extra_large_clamp
+      - d_cups
+      - e_toy_airplane
+      - adjustable_wrench
+      - rubiks_cube
+      - f_lego_duplo
+      - a_cups
+      - skillet_lid
+      - sponge
+      - tennis_ball
+      - spatula
+      - d_toy_airplane
+      - chain
+      - scissors
+      - mustard_bottle
+      - bleach_cleanser
+      - tuna_fish_can
+      - cracker_box
+      - fork
+      - large_clamp
+      - dice
+      - flat_screwdriver
+      object_init_sampler:
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
+      positioning_procedures:
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: view_finder
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: patch_0
+        allow_translation: false
+        max_orientation_attempts: 3
+    eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
+    logging:
+      monty_log_level: BASIC
+      monty_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.BasicCSVStatsHandler}
+      wandb_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbTableStatsHandler}
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbChartStatsHandler}
+      python_log_level: WARNING
+      python_log_to_file: true
+      python_log_to_stderr: true
+      output_dir: ${path.expanduser:${oc.env:MONTY_LOGS}/projects/monty_runs}
+      resume_wandb_run: false
+      wandb_id:
+        _target_: wandb.util.generate_id
+      wandb_group: benchmark_experiments
+      run_name: randrot_noise_77obj_5lms_dist_agent_mujoco
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/supervised_pre_training_5lms_all_objects/pretrained/
+    n_eval_epochs: 1
+    min_lms_match: 3
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+episodes: all
+num_parallel: 16
+print_cfg: false
+quiet_habitat_logs: true
+constants:
+  default_all_noise_params:
+    features:
+      pose_vectors: 2
+      hsv: 0.1
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01
+    location: 0.002
+  default_sensor_features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - hsv
+  - principal_curvatures_log
+  min_eval_steps: 20
+  pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_ycb_v13}
+  compositional_pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_compositional_objects_v4}
+  rotations_all_count: 14
+  rotations_all:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0
+  - - 0
+    - 270
+    - 0
+  - - 90
+    - 0
+    - 0
+  - - 90
+    - 180
+    - 0
+  - - 35
+    - 45
+    - 0
+  - - 325
+    - 45
+    - 0
+  - - 35
+    - 315
+    - 0
+  - - 325
+    - 315
+    - 0
+  - - 35
+    - 135
+    - 0
+  - - 325
+    - 135
+    - 0
+  - - 35
+    - 225
+    - 0
+  - - 325
+    - 225
+    - 0
+  rotations_3_count: 3
+  rotations_3:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0

--- a/tests/conf/snapshots/randrot_noise_77obj_dist_agent_mujoco.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_dist_agent_mujoco.yaml
@@ -1,0 +1,336 @@
+experiment:
+  config:
+    do_eval: true
+    do_train: false
+    monty_config:
+      monty_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.model.MontyForEvidenceGraphMatching}
+      monty_args:
+        num_exploratory_steps: 1000
+        min_eval_steps: ${constants.min_eval_steps}
+        min_train_steps: 3
+        max_total_steps: 2500
+      motor_system_config:
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
+        policy_selector:
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.DistantPolicySelector
+          jump_to_goal:
+            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.JumpToGoal}
+            agent_id: agent_id_0
+            sensor_id: view_finder
+          look_at_goal:
+            _target_: ${monty.class:tbp.monty.frameworks.models.salience.motor_policy.LookAtGoal}
+            agent_id: agent_id_0
+            sensor_id: view_finder
+          default:
+            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicyRandomWalk}
+            agent_id: agent_id_0
+            action_sampler:
+              _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
+              actions:
+              - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.LookDown}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
+              rotation_degrees: 5.0
+      learning_modules:
+        learning_module_0:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.03
+      sensor_modules:
+        sensor_module_0:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          save_raw_obs: false
+          noise_params:
+            features:
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
+        sensor_module_1:
+          _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
+          sensor_module_id: view_finder
+          save_raw_obs: true
+      sm_to_agent_dict:
+        patch: agent_id_0
+        view_finder: agent_id_0
+      sm_to_lm_matrix:
+      - - 0
+      lm_to_lm_matrix: null
+      lm_to_lm_vote_matrix: null
+    environment:
+      env_init_args:
+        data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
+        agents:
+        - _target_: tbp.monty.simulators.mujoco.agents.DistantAgent
+          _partial_: true
+          agent_id: agent_id_0
+          sensor_configs:
+            patch:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              zoom: 10.0
+            view_finder:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              resolution:
+                width: 64
+                height: 64
+              zoom: 1.0
+          position:
+          - 0.0
+          - 1.5
+          - 0.2
+        raise_actuate_missing: false
+      env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}
+      transform:
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.MissingToMaxDepth
+        agent_id: agent_id_0
+        max_depth: 1
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.DepthTo3DLocations
+        agent_id: agent_id_0
+        sensor_ids:
+        - patch
+        - view_finder
+        resolutions:
+        - - 64
+          - 64
+        - - 64
+          - 64
+        world_coord: true
+        zooms:
+        - 10.0
+        - 1.0
+        get_all_points: true
+        use_semantic_sensor: false
+    eval_env_interface_args:
+      parent_to_child_mapping: null
+      object_names:
+      - mug
+      - bowl
+      - potted_meat_can
+      - master_chef_can
+      - i_cups
+      - spoon
+      - b_cups
+      - pitcher_base
+      - knife
+      - b_marbles
+      - h_cups
+      - strawberry
+      - power_drill
+      - padlock
+      - golf_ball
+      - hammer
+      - softball
+      - orange
+      - c_lego_duplo
+      - c_toy_airplane
+      - b_lego_duplo
+      - banana
+      - nine_hole_peg_test
+      - tomato_soup_can
+      - baseball
+      - g_cups
+      - gelatin_box
+      - lemon
+      - plum
+      - racquetball
+      - plate
+      - pudding_box
+      - e_cups
+      - apple
+      - j_cups
+      - foam_brick
+      - large_marker
+      - peach
+      - phillips_screwdriver
+      - a_toy_airplane
+      - e_lego_duplo
+      - sugar_box
+      - a_colored_wood_blocks
+      - c_cups
+      - pear
+      - f_cups
+      - wood_block
+      - d_lego_duplo
+      - b_toy_airplane
+      - b_colored_wood_blocks
+      - g_lego_duplo
+      - a_lego_duplo
+      - mini_soccer_ball
+      - medium_clamp
+      - a_marbles
+      - extra_large_clamp
+      - d_cups
+      - e_toy_airplane
+      - adjustable_wrench
+      - rubiks_cube
+      - f_lego_duplo
+      - a_cups
+      - skillet_lid
+      - sponge
+      - tennis_ball
+      - spatula
+      - d_toy_airplane
+      - chain
+      - scissors
+      - mustard_bottle
+      - bleach_cleanser
+      - tuna_fish_can
+      - cracker_box
+      - fork
+      - large_clamp
+      - dice
+      - flat_screwdriver
+      object_init_sampler:
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
+      positioning_procedures:
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: view_finder
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: patch
+        allow_translation: false
+        max_orientation_attempts: 3
+    eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
+    logging:
+      monty_log_level: BASIC
+      monty_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.BasicCSVStatsHandler}
+      wandb_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbTableStatsHandler}
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbChartStatsHandler}
+      python_log_level: WARNING
+      python_log_to_file: true
+      python_log_to_stderr: true
+      output_dir: ${path.expanduser:${oc.env:MONTY_LOGS}/projects/monty_runs}
+      resume_wandb_run: false
+      wandb_id:
+        _target_: wandb.util.generate_id
+      wandb_group: benchmark_experiments
+      run_name: randrot_noise_77obj_dist_agent_mujoco
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 6000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_77obj/pretrained/
+    n_eval_epochs: ${constants.rotations_3_count}
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+episodes: all
+num_parallel: 16
+print_cfg: false
+quiet_habitat_logs: true
+constants:
+  default_all_noise_params:
+    features:
+      pose_vectors: 2
+      hsv: 0.1
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01
+    location: 0.002
+  default_sensor_features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - hsv
+  - principal_curvatures_log
+  min_eval_steps: 20
+  pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_ycb_v13}
+  compositional_pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_compositional_objects_v4}
+  rotations_all_count: 14
+  rotations_all:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0
+  - - 0
+    - 270
+    - 0
+  - - 90
+    - 0
+    - 0
+  - - 90
+    - 180
+    - 0
+  - - 35
+    - 45
+    - 0
+  - - 325
+    - 45
+    - 0
+  - - 35
+    - 315
+    - 0
+  - - 325
+    - 315
+    - 0
+  - - 35
+    - 135
+    - 0
+  - - 325
+    - 135
+    - 0
+  - - 35
+    - 225
+    - 0
+  - - 325
+    - 225
+    - 0
+  rotations_3_count: 3
+  rotations_3:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0

--- a/tests/conf/snapshots/randrot_noise_77obj_surf_agent_mujoco.yaml
+++ b/tests/conf/snapshots/randrot_noise_77obj_surf_agent_mujoco.yaml
@@ -1,0 +1,341 @@
+experiment:
+  config:
+    do_eval: true
+    do_train: false
+    monty_config:
+      monty_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.model.MontyForEvidenceGraphMatching}
+      monty_args:
+        num_exploratory_steps: 1000
+        min_eval_steps: ${constants.min_eval_steps}
+        min_train_steps: 3
+        max_total_steps: 2500
+      motor_system_config:
+        policy_selector:
+          policy:
+            action_sampler:
+              _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
+              actions:
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveForward}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.MoveTangentially}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientHorizontal}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.OrientVertical}
+            _target_: tbp.monty.frameworks.models.motor_policies.SurfacePolicyCurvatureInformed
+            use_goal_driven_actions: true
+            agent_id: agent_id_0
+            desired_object_distance: 0.025
+            alpha: 0.1
+            pc_alpha: 0.5
+            max_pc_bias_steps: 32
+            min_general_steps: 8
+            min_heading_steps: 12
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.SinglePolicySelector
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
+      learning_modules:
+        learning_module_0:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          hypotheses_updater_args:
+            max_nneighbors: 10
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          feature_weights:
+            patch:
+              hsv: ${np.array:[2, 0.5, 0.5]}
+              pose_vectors: ${np.ones:3}
+              principal_curvatures_log: ${np.ones:2}
+          tolerances:
+            patch:
+              hsv: ${np.array:[0.1, 0.2, 0.2]}
+              principal_curvatures_log: ${np.ones:2}
+          max_match_distance: 0.01
+          x_percent_threshold: 20
+          evidence_threshold_config: all
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 100
+          gsg:
+            _target_: tbp.monty.frameworks.models.goal_generation.EvidenceGoalGenerator
+            goal_tolerances:
+              location: 0.015
+            elapsed_steps_factor: 10
+            min_post_goal_success_steps: 5
+            x_percent_scale_factor: 0.75
+            desired_object_distance: 0.025
+      sensor_modules:
+        sensor_module_0:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures
+          - principal_curvatures_log
+          sensor_module_id: patch
+          save_raw_obs: false
+          delta_thresholds:
+            on_object: 0
+            distance: 0.01
+          is_surface_sm: true
+          noise_params:
+            features:
+              pose_vectors: 2
+              hsv: 0.1
+              principal_curvatures_log: 0.1
+              pose_fully_defined: 0.01
+            location: 0.002
+        sensor_module_1:
+          _target_: tbp.monty.frameworks.models.sensor_modules.Probe
+          sensor_module_id: view_finder
+          save_raw_obs: true
+      sm_to_agent_dict:
+        patch: agent_id_0
+        view_finder: agent_id_0
+      sm_to_lm_matrix:
+      - - 0
+      lm_to_lm_matrix: null
+      lm_to_lm_vote_matrix: null
+    environment:
+      env_init_args:
+        data_path: ${path.expanduser:${oc.env:MONTY_DATA}/mujoco/objects/ycb}
+        agents:
+        - _target_: tbp.monty.simulators.mujoco.agents.SurfaceAgent
+          _partial_: true
+          agent_id: agent_id_0
+          sensor_configs:
+            patch:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.0
+              resolution:
+                width: 64
+                height: 64
+              zoom: 10.0
+            view_finder:
+              _target_: tbp.monty.frameworks.sensors.SensorConfig
+              position:
+              - 0.0
+              - 0.0
+              - 0.03
+              resolution:
+                width: 64
+                height: 64
+              zoom: 1.0
+          position:
+          - 0.0
+          - 1.5
+          - 0.1
+        raise_actuate_missing: false
+      env_init_func: ${monty.class:tbp.monty.simulators.mujoco.MuJoCoSimulator}
+      transform:
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.MissingToMaxDepth
+        agent_id: agent_id_0
+        max_depth: 1
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.DepthTo3DLocations
+        agent_id: agent_id_0
+        sensor_ids:
+        - patch
+        - view_finder
+        resolutions:
+        - - 64
+          - 64
+        - - 64
+          - 64
+        world_coord: true
+        zooms:
+        - 10.0
+        - 1.0
+        get_all_points: true
+        use_semantic_sensor: false
+        depth_clip_sensors:
+        - 0
+        clip_value: 0.05
+    eval_env_interface_args:
+      parent_to_child_mapping: null
+      object_names:
+      - mug
+      - bowl
+      - potted_meat_can
+      - master_chef_can
+      - i_cups
+      - spoon
+      - b_cups
+      - pitcher_base
+      - knife
+      - b_marbles
+      - h_cups
+      - strawberry
+      - power_drill
+      - padlock
+      - golf_ball
+      - hammer
+      - softball
+      - orange
+      - c_lego_duplo
+      - c_toy_airplane
+      - b_lego_duplo
+      - banana
+      - nine_hole_peg_test
+      - tomato_soup_can
+      - baseball
+      - g_cups
+      - gelatin_box
+      - lemon
+      - plum
+      - racquetball
+      - plate
+      - pudding_box
+      - e_cups
+      - apple
+      - j_cups
+      - foam_brick
+      - large_marker
+      - peach
+      - phillips_screwdriver
+      - a_toy_airplane
+      - e_lego_duplo
+      - sugar_box
+      - a_colored_wood_blocks
+      - c_cups
+      - pear
+      - f_cups
+      - wood_block
+      - d_lego_duplo
+      - b_toy_airplane
+      - b_colored_wood_blocks
+      - g_lego_duplo
+      - a_lego_duplo
+      - mini_soccer_ball
+      - medium_clamp
+      - a_marbles
+      - extra_large_clamp
+      - d_cups
+      - e_toy_airplane
+      - adjustable_wrench
+      - rubiks_cube
+      - f_lego_duplo
+      - a_cups
+      - skillet_lid
+      - sponge
+      - tennis_ball
+      - spatula
+      - d_toy_airplane
+      - chain
+      - scissors
+      - mustard_bottle
+      - bleach_cleanser
+      - tuna_fish_can
+      - cracker_box
+      - fork
+      - large_clamp
+      - dice
+      - flat_screwdriver
+      object_init_sampler:
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.RandomRotation
+    eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
+    logging:
+      monty_log_level: BASIC
+      monty_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.BasicCSVStatsHandler}
+      wandb_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbTableStatsHandler}
+      - ${monty.class:tbp.monty.frameworks.loggers.wandb_handlers.BasicWandbChartStatsHandler}
+      python_log_level: WARNING
+      python_log_to_file: true
+      python_log_to_stderr: true
+      output_dir: ${path.expanduser:${oc.env:MONTY_LOGS}/projects/monty_runs}
+      resume_wandb_run: false
+      wandb_id:
+        _target_: wandb.util.generate_id
+      wandb_group: benchmark_experiments
+      run_name: randrot_noise_77obj_surf_agent_mujoco
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 500
+    max_total_steps: 5000
+    n_train_epochs: 3
+    model_name_or_path: ${constants.pretrained_dir}/surf_agent_1lm_77obj/pretrained/
+    n_eval_epochs: ${constants.rotations_3_count}
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+episodes: all
+num_parallel: 16
+print_cfg: false
+quiet_habitat_logs: true
+constants:
+  default_all_noise_params:
+    features:
+      pose_vectors: 2
+      hsv: 0.1
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01
+    location: 0.002
+  default_sensor_features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - hsv
+  - principal_curvatures_log
+  min_eval_steps: 20
+  pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_ycb_v13}
+  compositional_pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_compositional_objects_v4}
+  rotations_all_count: 14
+  rotations_all:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0
+  - - 0
+    - 270
+    - 0
+  - - 90
+    - 0
+    - 0
+  - - 90
+    - 180
+    - 0
+  - - 35
+    - 45
+    - 0
+  - - 325
+    - 45
+    - 0
+  - - 35
+    - 315
+    - 0
+  - - 325
+    - 315
+    - 0
+  - - 35
+    - 135
+    - 0
+  - - 325
+    - 135
+    - 0
+  - - 35
+    - 225
+    - 0
+  - - 325
+    - 225
+    - 0
+  rotations_3_count: 3
+  rotations_3:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0


### PR DESCRIPTION
Created experiment configurations for the benchmarks listed in `benchmarks/ycb_77objs.csv`.

 I've run all of these locally, and the run to completion with reasonable overall stats.

### Diff of old configs to new

```diff
=== diff: randrot_noise_77obj_dist_agent.yaml <-> randrot_noise_77obj_dist_agent_mujoco.yaml ===
-   - /environment: habitat_ycb_dist_agent_semantics0
+   - /environment: mujoco_ycb_dist_agent
-       run_name: randrot_noise_77obj_dist_agent
+       run_name: randrot_noise_77obj_dist_agent_mujoco

=== diff: base_77obj_dist_agent.yaml <-> base_77obj_dist_agent_mujoco.yaml ===
-   - /environment: habitat_ycb_dist_agent_semantics0
+   - /environment: mujoco_ycb_dist_agent
-       run_name: base_77obj_dist_agent
+       run_name: base_77obj_dist_agent_mujoco

=== diff: base_77obj_surf_agent.yaml <-> base_77obj_surf_agent_mujoco.yaml ===
-   - /environment: habitat_ycb_surf_agent
+   - /environment: mujoco_ycb_surf_agent
-       run_name: base_77obj_surf_agent
+       run_name: base_77obj_surf_agent_mujoco

=== diff: randrot_noise_77obj_surf_agent.yaml <-> randrot_noise_77obj_surf_agent_mujoco.yaml ===
-   - /environment: habitat_ycb_surf_agent
+   - /environment: mujoco_ycb_surf_agent
-       run_name: randrot_noise_77obj_surf_agent
+       run_name: randrot_noise_77obj_surf_agent_mujoco

=== diff: randrot_noise_77obj_5lms_dist_agent.yaml <-> randrot_noise_77obj_5lms_dist_agent_mujoco.yaml ===
-   - /environment: habitat_dist_agent_sensors5
+   - /environment: mujoco_dist_agent_sensors5
-       run_name: randrot_noise_77obj_5lms_dist_agent
+       run_name: randrot_noise_77obj_5lms_dist_agent_mujoco

```
