### PR TITLE
feat!: AttentionSystem and Segmentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,4 @@ outputs/
 
 # MuJoCo
 MUJOCO_LOG.TXT
+src/tbp/feat.comp_benefits_figures.code-workspace

--- a/src/tbp/monty/attention/__init__.py
+++ b/src/tbp/monty/attention/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.

--- a/src/tbp/monty/attention/attention_system.py
+++ b/src/tbp/monty/attention/attention_system.py
@@ -6,19 +6,92 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
+"""Global attention over the regions of space proposed by SMs and LMs.
+
+Each step, sensor and learning modules propose regions -- lists of goals whose
+locations trace out the surface they are attending to. The attention system
+voxelizes those locations into a persistent grid, and only goals that land in an
+occupied voxel of the updated grid are passed on toward the motor system.
+"""
+
 from __future__ import annotations
 
-from src.tbp.monty.cmp import Goal
+from typing import Sequence
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+from tbp.monty.attention.voxels import VOXEL_LEVELS, voxelize_and_bin_points
+from tbp.monty.cmp import Goal
+
+
+def empty_voxel_grid() -> pd.DataFrame:
+    """Build the frame the attention system holds when no voxels are occupied.
+
+    Returns:
+        A frame with no rows, an (x, y, z) MultiIndex, and age/count columns.
+
+    """
+    return pd.DataFrame(
+        {
+            "age": pd.Series(dtype=np.int32),
+            "count": pd.Series(dtype=np.int32),
+        },
+        index=pd.MultiIndex.from_tuples([], names=VOXEL_LEVELS),
+    )
 
 
 class AttentionSystem:
-    """Global attention system."""
+    """Global attention system.
 
-    def __init__(self, voxel_size: float = 0.05):
+    Maintains a voxelized estimate of the regions of space currently attended to,
+    merging in the regions delivered on each step. The grid is a memory rather
+    than a snapshot of the latest look: a re-observed voxel is refreshed to a full
+    age with its count accumulated, one that was not seen ages by a step, and one
+    whose age runs out is dropped.
+    """
+
+    def __init__(self, voxel_size: float = 0.05, lifetime: int = 6):
+        """Initialize the attention system.
+
+        Args:
+            voxel_size: Edge length of a voxel, in world units.
+            lifetime: How many steps a voxel survives without being re-observed.
+
+        Raises:
+            ValueError: If lifetime is not positive.
+        """
+        if lifetime < 1:
+            raise ValueError(f"lifetime must be >= 1, got {lifetime}")
         self._voxel_size = voxel_size
+        self._lifetime = lifetime
+        self._voxel_grid = empty_voxel_grid()
+
+    @property
+    def voxel_size(self) -> float:
+        """Edge length of a voxel, in world units."""
+        return self._voxel_size
+
+    @property
+    def lifetime(self) -> int:
+        """How many steps a voxel survives without being re-observed."""
+        return self._lifetime
+
+    @property
+    def grid(self) -> pd.DataFrame:
+        """The voxel grid: (x, y, z) MultiIndex rows with age/count columns."""
+        return self._voxel_grid
 
     def step(self, goals: list[Goal], regions: list[list[Goal]]) -> list[Goal]:
         """Update the attention system with new goals and regions.
+
+        Each region's goal locations are voxelized and merged into the grid,
+        which then ages and expires as a whole. Goals are filtered against the
+        updated grid: only those whose location falls in an occupied voxel are
+        returned. Goals without a location pass through, since they cannot be
+        spatially filtered. While the grid is empty -- no module has proposed a
+        region yet -- goals pass through unfiltered.
 
         Args:
             goals: A list of goals to update the attention system with.
@@ -27,4 +100,170 @@ class AttentionSystem:
         Returns:
             Filtered list of goals.
         """
-        raise NotImplementedError
+        observed = self._observe(regions)
+        # Age what is already held before folding in what was just seen, so that
+        # a re-observed voxel's fresh row lands on top of the tick rather than
+        # after it.
+        aged = self._age(self._voxel_grid)
+        merged = self._merge(aged, observed)
+        self._voxel_grid = self._expire(merged)
+        return self._filter(goals)
+
+    def contains_points(
+        self, points: npt.NDArray[np.floating]
+    ) -> npt.NDArray[np.bool_]:
+        """Test which locations fall within an occupied voxel.
+
+        Args:
+            points: a (N, 3) array of points.
+
+        Returns:
+            A boolean array with shape (N,).
+
+        """
+        occupied = self._voxel_grid.index
+        points = np.atleast_2d(points)
+        if len(occupied) == 0:
+            return np.zeros(len(points), dtype=bool)
+
+        indices = np.floor(points / self._voxel_size).astype(int)
+        query = pd.MultiIndex.from_arrays(indices.T, names=VOXEL_LEVELS)
+        return query.isin(occupied)
+
+    def reset(self) -> None:
+        """Discard the current grid."""
+        self._voxel_grid = empty_voxel_grid()
+
+    def _observe(self, regions: list[list[Goal]]) -> pd.DataFrame:
+        """Voxelize this step's regions into a fresh grid.
+
+        Every observed voxel starts with a full lifetime. Its count is the number
+        of regions that saw it this step, so regions from different modules each
+        contribute a sighting; ageing and tallying against what is already held
+        happen in _merge.
+
+        Args:
+            regions: A list of regions, where each region is a list of goals.
+
+        Returns:
+            The grid built from this step's regions alone.
+
+        """
+        per_region_voxels = []
+        for region in regions:
+            locations = [g.location for g in region if g.location is not None]
+            if not locations:
+                continue
+            per_region_voxels.extend(
+                voxelize_and_bin_points(np.asarray(locations), self._voxel_size)
+            )
+        if not per_region_voxels:
+            return empty_voxel_grid()
+
+        index = pd.MultiIndex.from_tuples(per_region_voxels, names=VOXEL_LEVELS)
+        counts = (
+            pd.Series(1, index=index, dtype=np.int32)
+            .groupby(level=list(VOXEL_LEVELS))
+            .sum()
+            .astype(np.int32)
+        )
+        return pd.DataFrame(
+            {
+                "age": np.full(len(counts), self._lifetime, dtype=np.int32),
+                "count": counts,
+            }
+        )
+
+    def _age(self, remembered: pd.DataFrame) -> pd.DataFrame:
+        """Tick every held voxel one step closer to expiring.
+
+        Args:
+            remembered: The voxels held going into this step.
+
+        Returns:
+            The frame with every age decremented by one.
+
+        """
+        if len(remembered) == 0:
+            return remembered
+
+        aged = remembered.copy()
+        # Subtracting through the frame would widen the dtype, so write back the
+        # declared one: age is meant to stay an integer count of steps.
+        aged["age"] = (aged["age"] - 1).astype(np.int32)
+        return aged
+
+    def _merge(self, remembered: pd.DataFrame, observed: pd.DataFrame) -> pd.DataFrame:
+        """Fold this step's observations into the voxels already held.
+
+        A re-observed voxel is replaced wholesale by its fresh row, so its age
+        returns to a full lifetime. Its ``count`` is the exception: sightings
+        accumulate, so the fresh tally is added to the one already held. A voxel
+        that was not seen this step is carried through untouched, keeping
+        whatever age it arrived with.
+
+        Args:
+            remembered: The voxels held from earlier steps, already aged.
+            observed: The grid built from this step's regions alone.
+
+        Returns:
+            The merged frame, before expired voxels are dropped.
+
+        """
+        if len(remembered) == 0:
+            return observed
+        if len(observed) == 0:
+            return remembered
+
+        fresh = observed.copy()
+        seen_before = fresh.index.intersection(remembered.index)
+        if len(seen_before):
+            fresh.loc[seen_before, "count"] = (
+                fresh.loc[seen_before, "count"].to_numpy()
+                + remembered.loc[seen_before, "count"].to_numpy()
+            ).astype(np.int32)
+
+        # The fresh row wins outright, so drop the stale one it replaces.
+        carried = remembered.drop(index=fresh.index, errors="ignore")
+        if len(carried) == 0:
+            return fresh
+        return pd.concat([fresh, carried])
+
+    @staticmethod
+    def _expire(data: pd.DataFrame) -> pd.DataFrame:
+        """Drop voxels whose age has run out.
+
+        Args:
+            data: A merged frame, possibly holding voxels aged past their end.
+
+        Returns:
+            The frame with expired rows removed.
+
+        """
+        if len(data) == 0:
+            return data
+        return data[data["age"].to_numpy() > 0]
+
+    def _filter(self, goals: Sequence[Goal]) -> list[Goal]:
+        """Keep the goals that live in the updated grid.
+
+        Args:
+            goals: The goals collected from all modules this step.
+
+        Returns:
+            The goals inside an occupied voxel, plus any without a location.
+            All goals, if the grid is empty.
+
+        """
+        if len(self._voxel_grid) == 0:
+            return list(goals)
+
+        located = [g for g in goals if g.location is not None]
+        unlocated = [g for g in goals if g.location is None]
+        if not located:
+            return unlocated
+
+        contained = self.contains_points(
+            np.asarray([g.location for g in located])
+        )
+        return [g for g, keep in zip(located, contained) if keep] + unlocated

--- a/src/tbp/monty/attention/attention_system.py
+++ b/src/tbp/monty/attention/attention_system.py
@@ -6,14 +6,6 @@
 # Use of this source code is governed by the MIT
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
-"""Global attention over the regions of space proposed by SMs and LMs.
-
-Each step, sensor and learning modules propose regions -- lists of goals whose
-locations trace out the surface they are attending to. The attention system
-voxelizes those locations into a persistent grid, and only goals that land in an
-occupied voxel of the updated grid are passed on toward the motor system.
-"""
-
 from __future__ import annotations
 
 from typing import Sequence
@@ -43,29 +35,33 @@ def empty_voxel_grid() -> pd.DataFrame:
 
 
 class AttentionSystem:
-    """Global attention system.
+    """Global attention over the regions of space proposed by SMs and LMs.
 
-    Maintains a voxelized estimate of the regions of space currently attended to,
-    merging in the regions delivered on each step. The grid is a memory rather
-    than a snapshot of the latest look: a re-observed voxel is refreshed to a full
-    age with its count accumulated, one that was not seen ages by a step, and one
-    whose age runs out is dropped.
+    Each step, sensor and learning modules propose regions -- lists of goals
+    whose locations trace out the surface they are attending to. Those locations
+    are voxelized into a persistent grid, and only goals that land in an
+    occupied voxel of the updated grid are passed on toward the motor system.
+
+    The grid is a memory rather than a snapshot of the latest look: a
+    re-observed voxel is refreshed to a full age with its count accumulated, one
+    that was not seen ages by a step, and one whose age runs out is dropped.
     """
 
-    def __init__(self, voxel_size: float = 0.05, lifetime: int = 6):
+    def __init__(self, voxel_size: float = 0.05, voxel_lifetime: int = 6):
         """Initialize the attention system.
 
         Args:
             voxel_size: Edge length of a voxel, in world units.
-            lifetime: How many steps a voxel survives without being re-observed.
+            voxel_lifetime: How many steps a voxel survives without being
+                re-observed.
 
         Raises:
-            ValueError: If lifetime is not positive.
+            ValueError: If voxel_lifetime is not positive.
         """
-        if lifetime < 1:
-            raise ValueError(f"lifetime must be >= 1, got {lifetime}")
+        if voxel_lifetime < 1:
+            raise ValueError(f"voxel_lifetime must be >= 1, got {voxel_lifetime}")
         self._voxel_size = voxel_size
-        self._lifetime = lifetime
+        self._voxel_lifetime = voxel_lifetime
         self._voxel_grid = empty_voxel_grid()
 
     @property
@@ -74,9 +70,9 @@ class AttentionSystem:
         return self._voxel_size
 
     @property
-    def lifetime(self) -> int:
+    def voxel_lifetime(self) -> int:
         """How many steps a voxel survives without being re-observed."""
-        return self._lifetime
+        return self._voxel_lifetime
 
     @property
     def grid(self) -> pd.DataFrame:
@@ -169,7 +165,7 @@ class AttentionSystem:
         )
         return pd.DataFrame(
             {
-                "age": np.full(len(counts), self._lifetime, dtype=np.int32),
+                "age": np.full(len(counts), self._voxel_lifetime, dtype=np.int32),
                 "count": counts,
             }
         )

--- a/src/tbp/monty/attention/attention_system.py
+++ b/src/tbp/monty/attention/attention_system.py
@@ -1,0 +1,30 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+from src.tbp.monty.cmp import Goal
+
+
+class AttentionSystem:
+    """Global attention system."""
+
+    def __init__(self, voxel_size: float = 0.05):
+        self._voxel_size = voxel_size
+
+    def step(self, goals: list[Goal], regions: list[list[Goal]]) -> list[Goal]:
+        """Update the attention system with new goals and regions.
+
+        Args:
+            goals: A list of goals to update the attention system with.
+            regions: A list of regions, where each region is a list of goals.
+
+        Returns:
+            Filtered list of goals.
+        """
+        raise NotImplementedError

--- a/src/tbp/monty/attention/attention_system.py
+++ b/src/tbp/monty/attention/attention_system.py
@@ -14,8 +14,10 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from tbp.monty.attention.telemetry import AttentionSystemTelemetry
 from tbp.monty.attention.voxels import VOXEL_LEVELS, voxelize_and_bin_points
 from tbp.monty.cmp import Goal
+from tbp.monty.memento import Memento
 
 
 def empty_voxel_grid() -> pd.DataFrame:
@@ -47,13 +49,19 @@ class AttentionSystem:
     that was not seen ages by a step, and one whose age runs out is dropped.
     """
 
-    def __init__(self, voxel_size: float = 0.05, voxel_lifetime: int = 6):
+    def __init__(
+        self,
+        voxel_size: float = 0.05,
+        voxel_lifetime: int = 6,
+        telemetry: AttentionSystemTelemetry | None = None,
+    ):
         """Initialize the attention system.
 
         Args:
             voxel_size: Edge length of a voxel, in world units.
             voxel_lifetime: How many steps a voxel survives without being
                 re-observed.
+            telemetry: Telemetry storage for the attention system.
 
         Raises:
             ValueError: If voxel_lifetime is not positive.
@@ -62,6 +70,9 @@ class AttentionSystem:
             raise ValueError(f"voxel_lifetime must be >= 1, got {voxel_lifetime}")
         self._voxel_size = voxel_size
         self._voxel_lifetime = voxel_lifetime
+        self._telemetry = (
+            AttentionSystemTelemetry() if telemetry is None else telemetry
+        )
         self._voxel_grid = empty_voxel_grid()
 
     @property
@@ -103,6 +114,7 @@ class AttentionSystem:
         aged = self._age(self._voxel_grid)
         merged = self._merge(aged, observed)
         self._voxel_grid = self._expire(merged)
+        self._telemetry.voxel_grid(self._voxel_grid)
         return self._filter(goals)
 
     def contains_points(
@@ -127,8 +139,17 @@ class AttentionSystem:
         return query.isin(occupied)
 
     def reset(self) -> None:
-        """Discard the current grid."""
+        """Discard the current grid and recorded telemetry."""
         self._voxel_grid = empty_voxel_grid()
+        self._telemetry.reset()
+
+    def state_dict(self) -> Memento:
+        """Export the recorded telemetry.
+
+        Returns:
+            The telemetry's state dict.
+        """
+        return self._telemetry.state_dict()
 
     def _observe(self, regions: list[list[Goal]]) -> pd.DataFrame:
         """Voxelize this step's regions into a fresh grid.

--- a/src/tbp/monty/attention/attention_system.py
+++ b/src/tbp/monty/attention/attention_system.py
@@ -51,7 +51,7 @@ class AttentionSystem:
 
     def __init__(
         self,
-        voxel_size: float = 0.05,
+        voxel_size: float = 0.005,
         voxel_lifetime: int = 6,
         telemetry: AttentionSystemTelemetry | None = None,
     ):
@@ -147,9 +147,14 @@ class AttentionSystem:
         """Export the recorded telemetry.
 
         Returns:
-            The telemetry's state dict.
+            The telemetry's state dict, alongside the grid's voxel size and
+            lifetime so consumers can place voxels in world coordinates.
         """
-        return self._telemetry.state_dict()
+        return dict(
+            voxel_size=self._voxel_size,
+            voxel_lifetime=self._voxel_lifetime,
+            **self._telemetry.state_dict(),
+        )
 
     def _observe(self, regions: list[list[Goal]]) -> pd.DataFrame:
         """Voxelize this step's regions into a fresh grid.

--- a/src/tbp/monty/attention/telemetry.py
+++ b/src/tbp/monty/attention/telemetry.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+import pandas as pd
+
+from tbp.monty.memento import Memento
+
+__all__ = ["AttentionSystemTelemetry"]
+
+
+class AttentionSystemTelemetry:
+    """Keeps track of the attention system's telemetry.
+
+    Records a snapshot of the voxel grid after each step. The state dict
+    flattens each snapshot into plain arrays (voxel coordinates plus the age and
+    count columns), so it is JSON-encodable by BufferEncoder with no special
+    handling.
+    """
+
+    def __init__(self) -> None:
+        self.voxel_grids: list[pd.DataFrame] = []
+
+    def reset(self) -> None:
+        """Reset the telemetry."""
+        self.voxel_grids = []
+
+    def voxel_grid(self, grid: pd.DataFrame) -> None:
+        """Record a snapshot of the voxel grid.
+
+        Args:
+            grid: The attention system's voxel grid after a step.
+        """
+        self.voxel_grids.append(grid.copy())
+
+    def state_dict(self) -> Memento:
+        """Return the recorded voxel grid snapshots.
+
+        Returns:
+            Dictionary containing one entry per step in `voxel_grids`, each
+            holding the occupied `voxels` as an (N, 3) array and the aligned
+            `age` and `count` arrays.
+        """
+        return dict(
+            voxel_grids=[
+                dict(
+                    voxels=grid.index.to_frame(index=False).to_numpy(),
+                    age=grid["age"].to_numpy(),
+                    count=grid["count"].to_numpy(),
+                )
+                for grid in self.voxel_grids
+            ]
+        )

--- a/src/tbp/monty/attention/voxels.py
+++ b/src/tbp/monty/attention/voxels.py
@@ -1,0 +1,60 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable, Mapping, Protocol, Sequence, Tuple
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+from tbp.monty.frameworks.models.buffer import BufferEncoder
+
+Voxel = Tuple[int, int, int]  # hashable voxel coordinates.
+
+
+def as_array_voxels(voxels: Iterable) -> npt.NDArray[np.int_]:
+    array = np.asarray(voxels, dtype=int)
+    array = array.reshape(-1, 3) if array.ndim == 1 else array
+    assert array.ndim == 2 and array.shape[1] == 3
+    return array
+
+
+def as_tuple_voxels(voxels: Iterable) -> tuple[Voxel, ...]:
+    # Coerce to builtin ints: numpy scalars are not JSON-serializable, and these
+    # tuples end up in telemetry.
+    array_voxels = as_array_voxels(voxels)  # This does validation for us.
+    return tuple(tuple(int(c) for c in row) for row in array_voxels)
+
+
+def voxelize_and_bin_points(
+    points: npt.NDArray[np.floating],
+    voxel_size: float,
+) -> dict[Voxel, list[int]]:
+    """Quantize/bin 3D locations into voxels.
+
+    Args:
+        points: An array containing (x, y, z) coordinates.
+        voxel_size: Edge length of a voxel.
+
+    Returns:
+        covoxel_points: A dictionary from voxel (x, y, z) to the the indices of the
+            points inside it. (indices index into ``points``.) The keys of this
+            dictionary are all the occupied voxels.
+
+    """
+    # as_tuple_voxels validates the shape and coerces to builtin ints, which these
+    # keys need since they become index labels and end up in telemetry.
+    voxels = as_tuple_voxels(np.floor(points / voxel_size))
+    covoxel_points: dict[Voxel, list[int]] = defaultdict(list)
+    for point_ind, voxel in enumerate(voxels):
+        covoxel_points[voxel].append(point_ind)
+
+    return covoxel_points

--- a/src/tbp/monty/attention/voxels.py
+++ b/src/tbp/monty/attention/voxels.py
@@ -9,15 +9,16 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Iterable, Mapping, Protocol, Sequence, Tuple
+from typing import Iterable, Tuple
 
 import numpy as np
 import numpy.typing as npt
-import pandas as pd
 
-from tbp.monty.frameworks.models.buffer import BufferEncoder
+# Hashable voxel coordinates.
+Voxel = Tuple[int, int, int]
 
-Voxel = Tuple[int, int, int]  # hashable voxel coordinates.
+# Names of the row index levels: a voxel's integer grid coordinate.
+VOXEL_LEVELS = ("x", "y", "z")
 
 
 def as_array_voxels(voxels: Iterable) -> npt.NDArray[np.int_]:

--- a/src/tbp/monty/conf/env_interface/eval_compositional_lvl3_predefined_limited.yaml
+++ b/src/tbp/monty/conf/env_interface/eval_compositional_lvl3_predefined_limited.yaml
@@ -1,0 +1,113 @@
+# @package experiment.config
+
+do_eval: true
+eval_env_interface_args:
+  parent_to_child_mapping:
+    001_cube:
+    - 001_cube
+    002_cube_tbp_horz:
+    - 001_cube
+    - 021_logo_tbp
+    003_cube_tbp_vert:
+    - 001_cube
+    - 021_logo_tbp
+    004_cube_numenta_horz:
+    - 001_cube
+    - 022_logo_numenta
+    005_cube_numenta_vert:
+    - 001_cube
+    - 022_logo_numenta
+    006_disk:
+    - 006_disk
+    007_disk_tbp_horz:
+    - 006_disk
+    - 021_logo_tbp
+    008_disk_tbp_vert:
+    - 006_disk
+    - 021_logo_tbp
+    009_disk_numenta_horz:
+    - 006_disk
+    - 022_logo_numenta
+    010_disk_numenta_vert:
+    - 006_disk
+    - 022_logo_numenta
+    011_cylinder:
+    - 011_cylinder
+    012_cylinder_tbp_horz:
+    - 011_cylinder
+    - 021_logo_tbp
+    013_cylinder_tbp_vert:
+    - 011_cylinder
+    - 021_logo_tbp
+    014_cylinder_numenta_horz:
+    - 011_cylinder
+    - 022_logo_numenta
+    015_cylinder_numenta_vert:
+    - 011_cylinder
+    - 022_logo_numenta
+    016_sphere:
+    - 016_sphere
+    017_sphere_tbp_horz:
+    - 016_sphere
+    - 021_logo_tbp
+    018_sphere_tbp_vert:
+    - 016_sphere
+    - 021_logo_tbp
+    019_sphere_numenta_horz:
+    - 016_sphere
+    - 022_logo_numenta
+    020_sphere_numenta_vert:
+    - 016_sphere
+    - 022_logo_numenta
+    021_logo_tbp:
+    - 021_logo_tbp
+    022_logo_numenta:
+    - 022_logo_numenta
+    023_mug:
+    - 023_mug
+    024_mug_tbp_horz:
+    - 023_mug
+    - 021_logo_tbp
+    025_mug_tbp_vert:
+    - 023_mug
+    - 021_logo_tbp
+    026_mug_numenta_horz:
+    - 023_mug
+    - 022_logo_numenta
+    027_mug_numenta_vert:
+    - 023_mug
+    - 022_logo_numenta
+    028_mug_tbp_horz_bent:
+    - 023_mug
+    - 021_logo_tbp
+  object_names:
+  # - 001_cube
+  # - 006_disk
+  - 002_cube_tbp_horz
+  # - 004_cube_numenta_horz
+  # - 007_disk_tbp_horz
+  # - 009_disk_numenta_horz
+  # - 011_cylinder
+  # - 016_sphere
+  # - 023_mug
+  # - 012_cylinder_tbp_horz
+  # - 014_cylinder_numenta_horz
+  # - 017_sphere_tbp_horz
+  # - 019_sphere_numenta_horz
+  # - 024_mug_tbp_horz
+  # - 026_mug_numenta_horz
+  # - 003_cube_tbp_vert
+  # - 005_cube_numenta_vert
+  # - 008_disk_tbp_vert
+  # - 010_disk_numenta_vert
+  # - 013_cylinder_tbp_vert
+  # - 015_cylinder_numenta_vert
+  # - 018_sphere_tbp_vert
+  # - 020_sphere_numenta_vert
+  # - 025_mug_tbp_vert
+  # - 027_mug_numenta_vert
+  object_init_sampler:
+    _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
+    rotations:
+    - [0, 0, 0]
+eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}

--- a/src/tbp/monty/conf/env_interface/transform/missing_depthto3d_sensor3_256.yaml
+++ b/src/tbp/monty/conf/env_interface/transform/missing_depthto3d_sensor3_256.yaml
@@ -1,0 +1,26 @@
+# @package experiment.config.environment
+
+transform:
+- _target_: tbp.monty.frameworks.environment_utils.transforms.MissingToMaxDepth
+  agent_id: agent_id_0
+  max_depth: 1
+- _target_: tbp.monty.frameworks.environment_utils.transforms.DepthTo3DLocations
+  agent_id: agent_id_0
+  sensor_ids:
+  - patch_0
+  - patch_1
+  - view_finder
+  resolutions:
+  - - 64
+    - 64
+  - - 64
+    - 64
+  - - 256
+    - 256
+  world_coord: true
+  zooms:
+  - 10.0
+  - 5.0
+  - 1.0
+  get_all_points: true
+  use_semantic_sensor: false

--- a/src/tbp/monty/conf/environment/habitat_dist_agent_sensors2_256.yaml
+++ b/src/tbp/monty/conf/environment/habitat_dist_agent_sensors2_256.yaml
@@ -1,0 +1,64 @@
+# @package experiment.config.environment
+
+env_init_args:
+  objects:
+  - name: coneSolid
+    position:
+    - 0.0
+    - 1.5
+    - -0.1
+  scene_id: null
+  seed: 42
+  data_path: ${path.expanduser:${oc.env:MONTY_DATA}/habitat/objects/compositional_objects}
+  agents:
+    agent_args:
+      agent_id: agent_id_0
+      sensor_ids:
+      - patch_0
+      - patch_1
+      - view_finder
+      height: 0.0
+      position:
+      - 0.0
+      - 1.5
+      - 0.2
+      resolutions:
+      - - 64
+        - 64
+      - - 64
+        - 64
+      - - 256
+        - 256
+      positions:
+      - - 0.0
+        - 0.0
+        - 0.0
+      - - 0.0
+        - 0.0
+        - 0.0
+      - - 0.0
+        - 0.0
+        - 0.0
+      rotations:
+      - - 1.0
+        - 0.0
+        - 0.0
+        - 0.0
+      - - 1.0
+        - 0.0
+        - 0.0
+        - 0.0
+      - - 1.0
+        - 0.0
+        - 0.0
+        - 0.0
+      semantics:
+      - false
+      - false
+      - false
+      zooms:
+      - 10.0
+      - 5.0
+      - 1.0
+    agent_type: ${monty.class:tbp.monty.simulators.habitat.MultiSensorAgent}
+env_init_func: ${monty.class:tbp.monty.simulators.habitat.environment.HabitatEnvironment}

--- a/src/tbp/monty/conf/experiment/infer_comp_lvl3_seg_slic.yaml
+++ b/src/tbp/monty/conf/experiment/infer_comp_lvl3_seg_slic.yaml
@@ -1,0 +1,42 @@
+# @package _global_
+
+defaults:
+  - /monty: evidencegraph_exp1000_emin_t3_tot2500
+  - /monty/motor_system_config: distant_5
+  - /monty/learning_module: evidence_2lm_burst_gsg0
+  - /monty/sensor_module: 2sm_camera_dist_vocus2_slic
+  - /monty/connectivity: 2lm_2sm
+  - /environment: habitat_dist_agent_sensors2_256
+  - /env_interface: eval_compositional_lvl3_predefined_limited
+  - /env_interface/positioning_procedures_eval: getgoodview_viewfinder_patch0
+  - /env_interface/transform: missing_depthto3d_sensor3_256
+  - /logging: detailed_debug_monty_runs
+
+experiment:
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+  config:
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 50
+    max_total_steps: 6000
+    n_train_epochs: 3
+    n_eval_epochs: 1
+    # The repo-wide constants point at pretrained_compositional_objects_v4, which
+    # does not exist locally; these models were trained as v3 (see tbp.monty).
+    model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_compositional_objects_v3}/supervised_pre_training_objects_with_logos_lvl3_comp_models/pretrained/
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+    logging:
+      run_name: infer_comp_lvl3_seg_slic
+      detailed_save_per_episode: true
+      output_dir: /Users/scott/tbp/projects/comp_benefits_figures/experiment_output
+    monty_config:
+      sensor_modules:
+        sensor_module_0:
+          save_raw_obs: false
+        sensor_module_1:
+          save_raw_obs: false
+        sensor_module_2:
+          save_raw_obs: true

--- a/src/tbp/monty/conf/monty/learning_module/evidence_2lm_burst_gsg0.yaml
+++ b/src/tbp/monty/conf/monty/learning_module/evidence_2lm_burst_gsg0.yaml
@@ -1,0 +1,38 @@
+# @package experiment.config.monty_config.learning_modules
+
+defaults:
+  - hypotheses_updater/burst_sampling@learning_module_0
+  - hypotheses_updater/burst_sampling@learning_module_1
+
+learning_module_0:
+  _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+  max_match_distance: 0.01
+  tolerances:
+    patch_0:
+      hsv: ${np.array:[0.1, 1, 1]}
+      principal_curvatures_log: ${np.ones:2}
+  feature_weights: {}
+  max_graph_size: 0.3
+  num_model_voxels_per_dim: 200
+  max_nodes_per_graph: 2000
+  gsg: null
+  evidence_threshold_config: all
+  object_evidence_threshold: 1
+learning_module_1:
+  _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+  max_match_distance: 0.01
+  tolerances:
+    patch_1:
+      hsv: ${np.array:[0.1, 1, 1]}
+      principal_curvatures_log: ${np.ones:2}
+    learning_module_0:
+      object_id: 1
+  feature_weights:
+    learning_module_0:
+      object_id: 1
+  max_graph_size: 0.4
+  num_model_voxels_per_dim: 200
+  max_nodes_per_graph: 2000
+  gsg: null
+  evidence_threshold_config: all
+  object_evidence_threshold: 1

--- a/src/tbp/monty/conf/monty/sensor_module/2sm_camera_dist_vocus2_slic.yaml
+++ b/src/tbp/monty/conf/monty/sensor_module/2sm_camera_dist_vocus2_slic.yaml
@@ -1,0 +1,70 @@
+# @package experiment.config.monty_config.sensor_modules
+
+sensor_module_0:
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+  sensor_module_id: patch_0
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - min_depth
+  - mean_depth
+  - hsv
+  - principal_curvatures_log
+  delta_thresholds:
+    on_object: 0
+    n_steps: 20
+    hsv:
+    - 0.1
+    - 0.1
+    - 0.1
+    pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+    principal_curvatures_log:
+    - 2
+    - 2
+    distance: 0.01
+  save_raw_obs: true
+sensor_module_1:
+  _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+  sensor_module_id: patch_1
+  features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - object_coverage
+  - hsv
+  - principal_curvatures_log
+  delta_thresholds:
+    on_object: 0
+    n_steps: 100
+    hsv:
+    - 0.2
+    - 0.2
+    - 0.2
+    pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+    principal_curvatures_log:
+    - 4
+    - 4
+    distance: 0.05
+  save_raw_obs: true
+sensor_module_2:
+  _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
+  sensor_module_id: view_finder
+  save_raw_obs: false
+  salience_strategy:
+    _target_: tbp.monty.frameworks.models.salience.strategies.vocus2.Vocus2.from_config
+    config:
+      _target_: tbp.monty.frameworks.models.salience.strategies.vocus2.vocus2.Vocus2SalienceConfig
+      center_sigma: 1.0
+      surround_sigma: 6.5
+      n_scales: 2
+      max_octaves: 5
+      use_depth: true
+      use_orientation: false
+  segmentation_strategy:
+    _target_: tbp.monty.frameworks.models.salience.segmentation.strategies.slic_merge.SlicMerge
+  snapshot_telemetry:
+    _target_: tbp.monty.frameworks.models.salience.telemetry.SalienceSMTelemetry
+    save_segmentation: true
+

--- a/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
+++ b/src/tbp/monty/frameworks/loggers/graph_matching_loggers.py
@@ -575,6 +575,10 @@ class DetailedGraphMatchingLogger(BasicGraphMatchingLogger):
             if len(sm.state_dict()["raw_observations"]) > 0:
                 buffer_data[f"SM_{i}"] = sm.state_dict()
 
+        attention_state = model.attention_system.state_dict()
+        if len(attention_state["voxel_grids"]) > 0:
+            buffer_data["attention_system"] = attention_state
+
         # TODO ensure will work with multiple, independent sensor agents
         buffer_data["motor_system"] = {}
         buffer_data["motor_system"]["action_sequence"] = (

--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -448,6 +448,9 @@ class LearningModule(
     def load_state_dict(self, memento: Memento) -> None:
         pass
 
+    def propose_regions(self) -> list[list[Goal]]:
+        return []
+
 
 class LMMemory(Snapshotable, metaclass=abc.ABCMeta):
     """Like a long-term memory storing all the knowledge an LM has."""
@@ -576,3 +579,6 @@ class SensorModule(RuntimeSensorModule, ExperimentSensorModule, metaclass=abc.AB
     @abc.abstractmethod
     def reset(self) -> None:
         pass
+
+    def propose_regions(self) -> list[list[Goal]]:
+        return []

--- a/src/tbp/monty/frameworks/models/abstract_monty_classes.py
+++ b/src/tbp/monty/frameworks/models/abstract_monty_classes.py
@@ -448,7 +448,7 @@ class LearningModule(
     def load_state_dict(self, memento: Memento) -> None:
         pass
 
-    def propose_regions(self) -> list[list[Goal]]:
+    def propose_region(self) -> list[Goal]:
         return []
 
 
@@ -580,5 +580,5 @@ class SensorModule(RuntimeSensorModule, ExperimentSensorModule, metaclass=abc.AB
     def reset(self) -> None:
         pass
 
-    def propose_regions(self) -> list[list[Goal]]:
+    def propose_region(self) -> list[Goal]:
         return []

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -148,6 +148,10 @@ class MontyBase(Monty):
         self._goals: list[Goal] = []
         self._attention_system = AttentionSystem(voxel_size=0.05)
 
+    @property
+    def attention_system(self) -> AttentionSystem:
+        return self._attention_system
+
     def step(
         self,
         ctx: RuntimeContext,

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -13,6 +13,7 @@ import copy
 import logging
 from typing import Any, ClassVar, Sequence
 
+from src.tbp.monty.attention.attention_system import AttentionSystem
 from tbp.monty.cmp import Goal, Message
 from tbp.monty.frameworks.actions.actions import Action
 from tbp.monty.frameworks.environments.environment import SemanticID
@@ -145,6 +146,7 @@ class MontyBase(Monty):
         self._is_done = False
         self._actions: list[Action] = []
         self._goals: list[Goal] = []
+        self._attention_system = AttentionSystem(voxel_size=0.05)
 
     def step(
         self,

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -146,7 +146,7 @@ class MontyBase(Monty):
         self._is_done = False
         self._actions: list[Action] = []
         self._goals: list[Goal] = []
-        self._attention_system = AttentionSystem(voxel_size=0.05)
+        self._attention_system = AttentionSystem()
 
     @property
     def attention_system(self) -> AttentionSystem:

--- a/src/tbp/monty/frameworks/models/monty_base.py
+++ b/src/tbp/monty/frameworks/models/monty_base.py
@@ -13,7 +13,7 @@ import copy
 import logging
 from typing import Any, ClassVar, Sequence
 
-from src.tbp.monty.attention.attention_system import AttentionSystem
+from tbp.monty.attention.attention_system import AttentionSystem
 from tbp.monty.cmp import Goal, Message
 from tbp.monty.frameworks.actions.actions import Action
 from tbp.monty.frameworks.environments.environment import SemanticID
@@ -335,6 +335,12 @@ class MontyBase(Monty):
             goals = sm.propose_goals()
             self._goals.extend(goals)
 
+        # The attention system folds the proposed regions into its voxel grid and
+        # returns only the goals that fall within it.
+        regions = [lm.propose_region() for lm in self.learning_modules]
+        regions.extend(sm.propose_region() for sm in self.sensor_modules)
+        self._goals = self._attention_system.step(self._goals, regions)
+
     def _step_motor_system(
         self,
         ctx: RuntimeContext,
@@ -398,6 +404,7 @@ class MontyBase(Monty):
 
         self.motor_system.reset()
         self._goals = []
+        self._attention_system.reset()
 
     def snapshot(self) -> Memento:
         lm_dict = {

--- a/src/tbp/monty/frameworks/models/salience/on_object_observation.py
+++ b/src/tbp/monty/frameworks/models/salience/on_object_observation.py
@@ -20,6 +20,8 @@ class OnObjectObservation:
     center_location: np.ndarray | None
     locations: np.ndarray
     salience: np.ndarray
+    on_object_mask: np.ndarray
+    locations_map: np.ndarray
 
 
 def on_object_observation(
@@ -38,7 +40,8 @@ def on_object_observation(
 
     Returns:
         The grid/matrix formatted (unraveled) on-object salience and location data,
-        along with the location corresponding to the central pixel.
+        along with the location corresponding to the central pixel and the
+        image-shaped on-object mask and locations map.
     """
     rgba = observation["rgba"]
     grid_shape = rgba.shape[:2]
@@ -59,4 +62,6 @@ def on_object_observation(
         center_location=center_location,
         salience=on_object_salience,
         locations=on_object_locations,
+        on_object_mask=on_object,
+        locations_map=locations,
     )

--- a/src/tbp/monty/frameworks/models/salience/segmentation/__init__.py
+++ b/src/tbp/monty/frameworks/models/salience/segmentation/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2025 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.

--- a/src/tbp/monty/frameworks/models/salience/segmentation/protocol.py
+++ b/src/tbp/monty/frameworks/models/salience/segmentation/protocol.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+from typing import Protocol
+
+import numpy as np
+import numpy.typing as npt
+
+from tbp.monty.context import RuntimeContext
+
+
+class SegmentationStrategy(Protocol):
+    def __call__(
+        self,
+        ctx: RuntimeContext,
+        rgba: npt.NDArray[np.uint8],
+        depth: npt.NDArray[np.float64] | None = None,
+        locations: npt.NDArray[np.float64] | None = None,
+    ) -> npt.NDArray[np.uint8]: ...

--- a/src/tbp/monty/frameworks/models/salience/segmentation/strategies/__init__.py
+++ b/src/tbp/monty/frameworks/models/salience/segmentation/strategies/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from .slic_merge import SlicMerge
+
+__all__ = ["SlicMerge"]

--- a/src/tbp/monty/frameworks/models/salience/segmentation/strategies/slic_merge.py
+++ b/src/tbp/monty/frameworks/models/salience/segmentation/strategies/slic_merge.py
@@ -1,0 +1,172 @@
+# Copyright 2025-2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+from collections import deque
+
+import cv2
+import numpy as np
+import numpy.typing as npt
+from skimage.segmentation import slic
+
+from tbp.monty.context import RuntimeContext
+from tbp.monty.frameworks.models.salience.segmentation.protocol import (
+    SegmentationStrategy,
+)
+
+
+class SlicMerge(SegmentationStrategy):
+    """Scikit-image SLIC superpixel segmentation with region merging."""
+
+    def __init__(
+        self,
+        n_seeds: int = 50,
+        compactness: float = 10.0,
+        max_iter: int = 10,
+        sigma: float = 1.0,
+        enforce_connectivity: bool = True,
+        min_size_factor: float = 0.5,
+        max_size_factor: float = 3.0,
+        segment_in_lab: bool = True,
+        merge_threshold: float = 10,
+        merge_in_lab: bool = True,
+    ) -> None:
+        """Initialize the SLIC superpixel segmentation with region merging strategy.
+
+        Args:
+            n_seeds: Number of superpixels to generate, though this is approximate.
+                SLIC initializes seeds on a reglar lattice, so the actual number of
+                superpixels may be larger.
+            compactness: Balances color proximity and space proximity. Higher values
+                give more weight to space proximity, resulting in more square
+                superpixels.
+            max_iter: Maximum number of iterations for SLIC.
+            sigma: Width of Gaussian smoothing kernel for pre-processing.
+            enforce_connectivity: Whether to enforce connectivity of superpixels.
+            min_size_factor: Minimum size of superpixels as a fraction of average size.
+            max_size_factor: Maximum size of superpixels as a fraction of average size.
+            segment_in_lab: Whether to perform segmentation in LAB color space.
+            merge_threshold: Color distance threshold for merging superpixels,
+                where "color distance" refers to the CIE76. Standard values:
+                    < 1: not perceptible
+                    1-2: perceptible through close observation
+                    2-10: perceptible at a glance
+                    10-50: colors are more similar than opposite
+                    > 50: colors are more opposite than similar
+            merge_in_lab: Whether to compute color distance in LAB color space.
+                Default is True, which is recommended for perceptual color distance.
+        """
+        self._n_seeds = n_seeds
+        self._compactness = compactness
+        self._max_iter = max_iter
+        self._sigma = sigma
+        self._enforce_connectivity = enforce_connectivity
+        self._min_size_factor = min_size_factor
+        self._max_size_factor = max_size_factor
+        self._segment_in_lab = segment_in_lab
+        self._merge_threshold = merge_threshold
+        self._merge_in_lab = merge_in_lab
+
+    def __call__(
+        self,
+        ctx: RuntimeContext,  # noqa: ARG002
+        rgba: np.ndarray,
+        depth: np.ndarray | None = None,  # noqa: ARG002
+        locations: np.ndarray | None = None,  # noqa: ARG002
+    ) -> np.ndarray:
+        # Fixation is at center of image
+        image = rgba[:, :, :3]
+        h, w = image.shape[:2]
+        y, x = h // 2, w // 2
+
+        # Run SLIC to get initial superpixel segmentation. It returns a 2D image
+        # where each pixel holds the (integer-valued) ID of the region it was
+        # assigned to.
+        region_image: npt.NDArray[np.integer] = slic(
+            image,
+            n_segments=self._n_seeds,
+            compactness=self._compactness,
+            max_num_iter=self._max_iter,
+            sigma=self._sigma,
+            spacing=None,  # Use default spacing
+            convert2lab=self._segment_in_lab,
+            enforce_connectivity=self._enforce_connectivity,
+            min_size_factor=self._min_size_factor,
+            max_size_factor=self._max_size_factor,
+            start_label=0,
+            mask=None,
+            channel_axis=-1,
+        )
+
+        # Get a version of the input image that's in the color space we want to
+        # use for merging. By default, this is the LAB color space.
+        if self._merge_in_lab:
+            merge_image = cv2.cvtColor(image, cv2.COLOR_RGB2LAB).astype(np.float32)
+            merge_thresh = self._merge_threshold
+        else:
+            merge_image = image.astype(np.float32)
+            merge_thresh = self._merge_threshold * 2.55  # Scale to 0-255 range
+
+        # Compute mean color per superpixel
+        n_regions = region_image.max() + 1
+        region_colors = np.zeros((n_regions, 3), dtype=np.float32)
+
+        # Vectorized computation of mean colors
+        for lbl in range(n_regions):
+            mask = region_image == lbl
+            if mask.any():
+                region_colors[lbl] = merge_image[mask].mean(axis=0)
+
+        # Build adjacency graph
+        adj: list[set[int]] = [set() for _ in range(n_regions)]
+
+        # - Regions are adjacent to their left/right neights.
+        h_neighbors = region_image[:, :-1] != region_image[:, 1:]
+        for i, j in zip(*np.where(h_neighbors)):
+            a, b = region_image[i, j], region_image[i, j + 1]
+            adj[a].add(b)
+            adj[b].add(a)
+
+        # - Regions are adjacent to their neighbors above and below.
+        v_neighbors = region_image[:-1, :] != region_image[1:, :]
+        for i, j in zip(*np.where(v_neighbors)):
+            a, b = region_image[i, j], region_image[i + 1, j]
+            adj[a].add(b)
+            adj[b].add(a)
+
+        # Breadth-first merge from the point of fixation.
+        central_region = region_image[y, x]
+        accepted_regions: set[int] = {
+            central_region
+        }  # foreground = attentional region.
+        visited = {central_region}
+        queue = deque([central_region])
+        while queue:
+            current = queue.popleft()
+            for neighbor in adj[current]:
+                if neighbor in visited:
+                    continue
+                visited.add(neighbor)
+
+                # Compute mean color distance between current and neighbor superpixels.
+                # If the colors are below the merging threshold, add the new region
+                # to the region set.
+                color_distance = np.linalg.norm(
+                    region_colors[current] - region_colors[neighbor]
+                )
+                if color_distance < merge_thresh:
+                    accepted_regions.add(neighbor)
+                    queue.append(neighbor)
+
+        # Create output mask from the set of accepted regions.
+        mask = np.zeros((h, w), dtype=np.uint8)
+        for lbl in accepted_regions:
+            mask[region_image == lbl] = 1
+
+        return mask

--- a/src/tbp/monty/frameworks/models/salience/sensor_module.py
+++ b/src/tbp/monty/frameworks/models/salience/sensor_module.py
@@ -19,9 +19,13 @@ from tbp.monty.frameworks.models.abstract_monty_classes import (
 )
 from tbp.monty.frameworks.models.motor_system_state import AgentState, SensorState
 from tbp.monty.frameworks.models.salience.on_object_observation import (
+    OnObjectObservation,
     on_object_observation,
 )
 from tbp.monty.frameworks.models.salience.return_inhibitor import ReturnInhibitor
+from tbp.monty.frameworks.models.salience.segmentation.protocol import (
+    SegmentationStrategy,
+)
 from tbp.monty.frameworks.models.salience.strategies import (
     SalienceStrategy,
     Uniform,
@@ -41,6 +45,7 @@ class SalienceSM(SensorModule):
         salience_strategy: SalienceStrategy | None = None,
         return_inhibitor: ReturnInhibitor | None = None,
         snapshot_telemetry: SnapshotTelemetry | None = None,
+        segmentation_strategy: SegmentationStrategy | None = None,
     ) -> None:
         self._sensor_module_id = sensor_module_id
         self._save_raw_obs = save_raw_obs
@@ -54,8 +59,10 @@ class SalienceSM(SensorModule):
             SnapshotTelemetry() if snapshot_telemetry is None else snapshot_telemetry
         )
 
+        self._segmentation_strategy = segmentation_strategy
+
         self._goals: list[Goal] = []
-        self._region = list[Goal] = []
+        self._region: list[Goal] = []
         # TODO: Goes away once experiment code is extracted
         self.is_exploring = False
 
@@ -128,6 +135,60 @@ class SalienceSM(SensorModule):
             for i in range(len(on_object.locations))
         ]
 
+        self._region = self._segment_region(ctx, observation, on_object, salience)
+
+    def _segment_region(
+        self,
+        ctx: RuntimeContext,
+        observation: SensorObservation,
+        on_object: OnObjectObservation,
+        salience: np.ndarray,
+    ) -> list[Goal]:
+        """Segment the surface under fixation into a region proposal.
+
+        The region is the set of on-object locations inside the segmented
+        surface, expressed as goals so it can travel to the attention system via
+        ``propose_region``.
+
+        Args:
+            ctx: The runtime context.
+            observation: Sensor observation.
+            on_object: The on-object view of the observation.
+            salience: Weighted salience, aligned with ``on_object.locations``.
+
+        Returns:
+            The region's goals, or an empty list without a segmentation strategy.
+        """
+        if self._segmentation_strategy is None:
+            return []
+
+        segmentation_map = self._segmentation_strategy(
+            ctx=ctx, rgba=observation["rgba"], depth=observation["depth"]
+        )
+
+        # Restore the weighted salience to image shape; boolean-mask indexing and
+        # np.where enumerate pixels in the same row-major order.
+        salience_map = np.zeros(on_object.on_object_mask.shape)
+        salience_map[on_object.on_object_mask] = salience
+
+        surface_mask = segmentation_map.astype(bool) & on_object.on_object_mask
+        surface_locations = on_object.locations_map[surface_mask]
+        surface_salience = salience_map[surface_mask]
+
+        return [
+            Goal(
+                location=surface_locations[i],
+                morphological_features=None,
+                non_morphological_features=None,
+                confidence=surface_salience[i],
+                use_state=False,
+                sender_id=self._sensor_module_id,
+                sender_type="SM",
+                goal_tolerances=None,
+            )
+            for i in range(len(surface_locations))
+        ]
+
     def _weight_salience(
         self,
         ctx: RuntimeContext,
@@ -169,6 +230,7 @@ class SalienceSM(SensorModule):
 
     def reset(self) -> None:
         self._goals.clear()
+        self._region.clear()
         self._return_inhibitor.reset()
         self._snapshot_telemetry.reset()
         self.is_exploring = False

--- a/src/tbp/monty/frameworks/models/salience/sensor_module.py
+++ b/src/tbp/monty/frameworks/models/salience/sensor_module.py
@@ -55,6 +55,7 @@ class SalienceSM(SensorModule):
         )
 
         self._goals: list[Goal] = []
+        self._region = list[Goal] = []
         # TODO: Goes away once experiment code is extracted
         self.is_exploring = False
 
@@ -73,6 +74,9 @@ class SalienceSM(SensorModule):
             + qt.rotate_vectors(agent.rotation, sensor.position),
             rotation=agent.rotation * sensor.rotation,
         )
+
+    def propose_region(self) -> list[Goal]:
+        return self._region
 
     def step(
         self,

--- a/src/tbp/monty/frameworks/models/salience/sensor_module.py
+++ b/src/tbp/monty/frameworks/models/salience/sensor_module.py
@@ -30,7 +30,7 @@ from tbp.monty.frameworks.models.salience.strategies import (
     SalienceStrategy,
     Uniform,
 )
-from tbp.monty.frameworks.models.sensor_modules import SnapshotTelemetry
+from tbp.monty.frameworks.models.salience.telemetry import SalienceSMTelemetry
 from tbp.monty.frameworks.sensors import SensorID
 from tbp.monty.memento import Memento
 
@@ -44,7 +44,7 @@ class SalienceSM(SensorModule):
         save_raw_obs: bool = False,
         salience_strategy: SalienceStrategy | None = None,
         return_inhibitor: ReturnInhibitor | None = None,
-        snapshot_telemetry: SnapshotTelemetry | None = None,
+        snapshot_telemetry: SalienceSMTelemetry | None = None,
         segmentation_strategy: SegmentationStrategy | None = None,
     ) -> None:
         self._sensor_module_id = sensor_module_id
@@ -56,7 +56,7 @@ class SalienceSM(SensorModule):
             ReturnInhibitor() if return_inhibitor is None else return_inhibitor
         )
         self._snapshot_telemetry = (
-            SnapshotTelemetry() if snapshot_telemetry is None else snapshot_telemetry
+            SalienceSMTelemetry() if snapshot_telemetry is None else snapshot_telemetry
         )
 
         self._segmentation_strategy = segmentation_strategy
@@ -103,11 +103,6 @@ class SalienceSM(SensorModule):
             motor_only_step: Whether the current step is a motor-only step.
 
         """
-        if self._save_raw_obs and not self.is_exploring:
-            self._snapshot_telemetry.raw_observation(
-                observation, self.state.rotation, self.state.position
-            )
-
         if motor_only_step:
             return
 
@@ -135,7 +130,16 @@ class SalienceSM(SensorModule):
             for i in range(len(on_object.locations))
         ]
 
-        self._region = self._segment_region(ctx, observation, on_object, salience)
+        segmentation_map, self._region = self._segment_region(
+            ctx, observation, on_object, salience
+        )
+
+        if not self.is_exploring:
+            if self._save_raw_obs:
+                self._snapshot_telemetry.raw_observation(
+                    observation, self.state.rotation, self.state.position
+                )
+            self._snapshot_telemetry.record(segmentation_map, self._region)
 
     def _segment_region(
         self,
@@ -143,7 +147,7 @@ class SalienceSM(SensorModule):
         observation: SensorObservation,
         on_object: OnObjectObservation,
         salience: np.ndarray,
-    ) -> list[Goal]:
+    ) -> tuple[np.ndarray | None, list[Goal]]:
         """Segment the surface under fixation into a region proposal.
 
         The region is the set of on-object locations inside the segmented
@@ -157,10 +161,11 @@ class SalienceSM(SensorModule):
             salience: Weighted salience, aligned with ``on_object.locations``.
 
         Returns:
-            The region's goals, or an empty list without a segmentation strategy.
+            The segmentation mask and the region's goals; None and an empty
+            list without a segmentation strategy.
         """
         if self._segmentation_strategy is None:
-            return []
+            return None, []
 
         segmentation_map = self._segmentation_strategy(
             ctx=ctx, rgba=observation["rgba"], depth=observation["depth"]
@@ -175,7 +180,7 @@ class SalienceSM(SensorModule):
         surface_locations = on_object.locations_map[surface_mask]
         surface_salience = salience_map[surface_mask]
 
-        return [
+        return segmentation_map, [
             Goal(
                 location=surface_locations[i],
                 morphological_features=None,

--- a/src/tbp/monty/frameworks/models/salience/telemetry.py
+++ b/src/tbp/monty/frameworks/models/salience/telemetry.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+import numpy as np
+
+from tbp.monty.cmp import Goal
+from tbp.monty.frameworks.models.sensor_modules import SnapshotTelemetry
+from tbp.monty.memento import Memento
+
+__all__ = ["SalienceSMTelemetry"]
+
+
+class SalienceSMTelemetry(SnapshotTelemetry):
+    """Keeps track of all of SalienceSM's telemetry.
+
+    On top of the raw observation snapshots, optionally records, per step, the
+    2D segmentation mask and the region the sensor module proposed from it.
+    Everything stored here is JSON-encodable by BufferEncoder (ndarrays and
+    Goals), so the state dict rides into the detailed logging stream with no
+    special handling.
+    """
+
+    def __init__(self, save_segmentation: bool = False) -> None:
+        """Initialize the telemetry.
+
+        Args:
+            save_segmentation: Whether to record segmentation masks and regions.
+        """
+        super().__init__()
+        self._save_segmentation = save_segmentation
+        self.segmentation_maps: list[np.ndarray | None] = []
+        self.regions: list[list[Goal]] = []
+
+    def reset(self) -> None:
+        """Reset the telemetry."""
+        super().reset()
+        self.segmentation_maps = []
+        self.regions = []
+
+    def record(
+        self,
+        segmentation_map: np.ndarray | None,
+        region: list[Goal],
+    ) -> None:
+        """Record one step's segmentation mask and region proposal.
+
+        Does nothing unless the telemetry was created with `save_segmentation`.
+
+        Args:
+            segmentation_map: The 2D segmentation mask, or None if no
+                segmentation strategy ran this step.
+            region: The region proposed from the segmentation.
+        """
+        if not self._save_segmentation:
+            return
+        self.segmentation_maps.append(segmentation_map)
+        self.regions.append(list(region))
+
+    def state_dict(self) -> Memento:
+        """Return all recorded telemetry.
+
+        Returns:
+            The raw observation snapshots (see `SnapshotTelemetry.state_dict`),
+            plus a list of segmentation masks in `segmentation_maps` and a list
+            of proposed regions in `regions`, one entry per recorded step.
+        """
+        return dict(
+            **super().state_dict(),
+            segmentation_maps=self.segmentation_maps,
+            regions=self.regions,
+        )

--- a/tests/conf/snapshots/infer_comp_lvl3_seg_slic.yaml
+++ b/tests/conf/snapshots/infer_comp_lvl3_seg_slic.yaml
@@ -1,0 +1,436 @@
+experiment:
+  config:
+    do_eval: true
+    do_train: false
+    monty_config:
+      monty_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.model.MontyForEvidenceGraphMatching}
+      monty_args:
+        num_exploratory_steps: 1000
+        min_eval_steps: ${constants.min_eval_steps}
+        min_train_steps: 3
+        max_total_steps: 2500
+      motor_system_config:
+        _target_: tbp.monty.frameworks.models.motor_system.MotorSystem
+        policy_selector:
+          _target_: tbp.monty.frameworks.models.motor_policy_selectors.DistantPolicySelector
+          jump_to_goal:
+            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.JumpToGoal}
+            agent_id: agent_id_0
+            sensor_id: view_finder
+          look_at_goal:
+            _target_: ${monty.class:tbp.monty.frameworks.models.salience.motor_policy.LookAtGoal}
+            agent_id: agent_id_0
+            sensor_id: view_finder
+          default:
+            _target_: ${monty.class:tbp.monty.frameworks.models.motor_policies.InformedPolicyRandomWalk}
+            agent_id: agent_id_0
+            action_sampler:
+              _target_: tbp.monty.frameworks.actions.action_samplers.ConstantSampler
+              actions:
+              - ${monty.class:tbp.monty.frameworks.actions.actions.LookUp}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.LookDown}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnLeft}
+              - ${monty.class:tbp.monty.frameworks.actions.actions.TurnRight}
+              rotation_degrees: 5.0
+      learning_modules:
+        learning_module_0:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          max_match_distance: 0.01
+          tolerances:
+            patch_0:
+              hsv: ${np.array:[0.1, 1, 1]}
+              principal_curvatures_log: ${np.ones:2}
+          feature_weights: {}
+          max_graph_size: 0.3
+          num_model_voxels_per_dim: 200
+          max_nodes_per_graph: 2000
+          gsg: null
+          evidence_threshold_config: all
+          object_evidence_threshold: 1
+        learning_module_1:
+          hypotheses_updater_class: ${monty.class:tbp.monty.frameworks.models.evidence_matching.burst_sampling.BurstSamplingHypothesesUpdater}
+          _target_: tbp.monty.frameworks.models.evidence_matching.learning_module.EvidenceGraphLM
+          max_match_distance: 0.01
+          tolerances:
+            patch_1:
+              hsv: ${np.array:[0.1, 1, 1]}
+              principal_curvatures_log: ${np.ones:2}
+            learning_module_0:
+              object_id: 1
+          feature_weights:
+            learning_module_0:
+              object_id: 1
+          max_graph_size: 0.4
+          num_model_voxels_per_dim: 200
+          max_nodes_per_graph: 2000
+          gsg: null
+          evidence_threshold_config: all
+          object_evidence_threshold: 1
+      sensor_modules:
+        sensor_module_0:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_0
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - min_depth
+          - mean_depth
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 20
+            hsv:
+            - 0.1
+            - 0.1
+            - 0.1
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 2
+            - 2
+            distance: 0.01
+          save_raw_obs: false
+        sensor_module_1:
+          _target_: tbp.monty.frameworks.models.sensor_modules.CameraSM
+          sensor_module_id: patch_1
+          features:
+          - pose_vectors
+          - pose_fully_defined
+          - on_object
+          - object_coverage
+          - hsv
+          - principal_curvatures_log
+          delta_thresholds:
+            on_object: 0
+            n_steps: 100
+            hsv:
+            - 0.2
+            - 0.2
+            - 0.2
+            pose_vectors: ${np.list_eval:[np.pi / 4, np.pi * 2, np.pi * 2]}
+            principal_curvatures_log:
+            - 4
+            - 4
+            distance: 0.05
+          save_raw_obs: false
+        sensor_module_2:
+          _target_: tbp.monty.frameworks.models.salience.sensor_module.SalienceSM
+          sensor_module_id: view_finder
+          save_raw_obs: true
+          salience_strategy:
+            _target_: tbp.monty.frameworks.models.salience.strategies.vocus2.Vocus2.from_config
+            config:
+              _target_: tbp.monty.frameworks.models.salience.strategies.vocus2.vocus2.Vocus2SalienceConfig
+              center_sigma: 1.0
+              surround_sigma: 6.5
+              n_scales: 2
+              max_octaves: 5
+              use_depth: true
+              use_orientation: false
+          segmentation_strategy:
+            _target_: tbp.monty.frameworks.models.salience.segmentation.strategies.slic_merge.SlicMerge
+          snapshot_telemetry:
+            _target_: tbp.monty.frameworks.models.salience.telemetry.SalienceSMTelemetry
+            save_segmentation: true
+      sm_to_agent_dict:
+        patch_0: agent_id_0
+        patch_1: agent_id_0
+        view_finder: agent_id_0
+      sm_to_lm_matrix:
+      - - 0
+      - - 1
+      lm_to_lm_matrix:
+      - []
+      - - 0
+      lm_to_lm_vote_matrix: null
+    environment:
+      env_init_args:
+        objects:
+        - name: coneSolid
+          position:
+          - 0.0
+          - 1.5
+          - -0.1
+        scene_id: null
+        seed: 42
+        data_path: ${path.expanduser:${oc.env:MONTY_DATA}/habitat/objects/compositional_objects}
+        agents:
+          agent_args:
+            agent_id: agent_id_0
+            sensor_ids:
+            - patch_0
+            - patch_1
+            - view_finder
+            height: 0.0
+            position:
+            - 0.0
+            - 1.5
+            - 0.2
+            resolutions:
+            - - 64
+              - 64
+            - - 64
+              - 64
+            - - 256
+              - 256
+            positions:
+            - - 0.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 0.0
+            - - 0.0
+              - 0.0
+              - 0.0
+            rotations:
+            - - 1.0
+              - 0.0
+              - 0.0
+              - 0.0
+            - - 1.0
+              - 0.0
+              - 0.0
+              - 0.0
+            - - 1.0
+              - 0.0
+              - 0.0
+              - 0.0
+            semantics:
+            - false
+            - false
+            - false
+            zooms:
+            - 10.0
+            - 5.0
+            - 1.0
+          agent_type: ${monty.class:tbp.monty.simulators.habitat.MultiSensorAgent}
+      env_init_func: ${monty.class:tbp.monty.simulators.habitat.environment.HabitatEnvironment}
+      transform:
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.MissingToMaxDepth
+        agent_id: agent_id_0
+        max_depth: 1
+      - _target_: tbp.monty.frameworks.environment_utils.transforms.DepthTo3DLocations
+        agent_id: agent_id_0
+        sensor_ids:
+        - patch_0
+        - patch_1
+        - view_finder
+        resolutions:
+        - - 64
+          - 64
+        - - 64
+          - 64
+        - - 256
+          - 256
+        world_coord: true
+        zooms:
+        - 10.0
+        - 5.0
+        - 1.0
+        get_all_points: true
+        use_semantic_sensor: false
+    eval_env_interface_args:
+      parent_to_child_mapping:
+        001_cube:
+        - 001_cube
+        002_cube_tbp_horz:
+        - 001_cube
+        - 021_logo_tbp
+        003_cube_tbp_vert:
+        - 001_cube
+        - 021_logo_tbp
+        004_cube_numenta_horz:
+        - 001_cube
+        - 022_logo_numenta
+        005_cube_numenta_vert:
+        - 001_cube
+        - 022_logo_numenta
+        006_disk:
+        - 006_disk
+        007_disk_tbp_horz:
+        - 006_disk
+        - 021_logo_tbp
+        008_disk_tbp_vert:
+        - 006_disk
+        - 021_logo_tbp
+        009_disk_numenta_horz:
+        - 006_disk
+        - 022_logo_numenta
+        010_disk_numenta_vert:
+        - 006_disk
+        - 022_logo_numenta
+        011_cylinder:
+        - 011_cylinder
+        012_cylinder_tbp_horz:
+        - 011_cylinder
+        - 021_logo_tbp
+        013_cylinder_tbp_vert:
+        - 011_cylinder
+        - 021_logo_tbp
+        014_cylinder_numenta_horz:
+        - 011_cylinder
+        - 022_logo_numenta
+        015_cylinder_numenta_vert:
+        - 011_cylinder
+        - 022_logo_numenta
+        016_sphere:
+        - 016_sphere
+        017_sphere_tbp_horz:
+        - 016_sphere
+        - 021_logo_tbp
+        018_sphere_tbp_vert:
+        - 016_sphere
+        - 021_logo_tbp
+        019_sphere_numenta_horz:
+        - 016_sphere
+        - 022_logo_numenta
+        020_sphere_numenta_vert:
+        - 016_sphere
+        - 022_logo_numenta
+        021_logo_tbp:
+        - 021_logo_tbp
+        022_logo_numenta:
+        - 022_logo_numenta
+        023_mug:
+        - 023_mug
+        024_mug_tbp_horz:
+        - 023_mug
+        - 021_logo_tbp
+        025_mug_tbp_vert:
+        - 023_mug
+        - 021_logo_tbp
+        026_mug_numenta_horz:
+        - 023_mug
+        - 022_logo_numenta
+        027_mug_numenta_vert:
+        - 023_mug
+        - 022_logo_numenta
+        028_mug_tbp_horz_bent:
+        - 023_mug
+        - 021_logo_tbp
+      object_names:
+      - 002_cube_tbp_horz
+      object_init_sampler:
+        _target_: tbp.monty.frameworks.environments.object_init_samplers.Predefined
+        rotations:
+        - - 0
+          - 0
+          - 0
+      positioning_procedures:
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: view_finder
+      - _target_: tbp.monty.frameworks.environments.positioning_procedures.GetGoodViewFactory
+        agent_id: agent_id_0
+        sensor_id: patch_0
+        allow_translation: false
+        max_orientation_attempts: 3
+    eval_env_interface_class: ${monty.class:tbp.monty.experiment.environment.OneObjectPerEpisodeInterface}
+    logging:
+      monty_log_level: DETAILED
+      monty_handlers:
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.BasicCSVStatsHandler}
+      - ${monty.class:tbp.monty.frameworks.loggers.monty_handlers.DetailedJSONHandler}
+      wandb_handlers: []
+      python_log_level: DEBUG
+      python_log_to_file: true
+      python_log_to_stderr: true
+      output_dir: /Users/scott/tbp/projects/comp_benefits_figures/experiment_output
+      run_name: infer_comp_lvl3_seg_slic
+      resume_wandb_run: false
+      wandb_id:
+        _target_: wandb.util.generate_id
+      wandb_group: debugging
+      detailed_save_per_episode: true
+    show_sensor_output: false
+    max_train_steps: 1000
+    max_eval_steps: 50
+    max_total_steps: 6000
+    n_train_epochs: 3
+    n_eval_epochs: 1
+    model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_compositional_objects_v3}/supervised_pre_training_objects_with_logos_lvl3_comp_models/pretrained/
+    min_lms_match: 1
+    seed: 42
+    supervised_lm_ids: []
+    python_log_level: DEBUG
+  _target_: tbp.monty.frameworks.experiments.object_recognition_experiments.MontyObjectRecognitionExperiment
+episodes: all
+num_parallel: 16
+print_cfg: false
+quiet_habitat_logs: true
+constants:
+  default_all_noise_params:
+    features:
+      pose_vectors: 2
+      hsv: 0.1
+      principal_curvatures_log: 0.1
+      pose_fully_defined: 0.01
+    location: 0.002
+  default_sensor_features:
+  - pose_vectors
+  - pose_fully_defined
+  - on_object
+  - hsv
+  - principal_curvatures_log
+  min_eval_steps: 20
+  pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_ycb_v13}
+  compositional_pretrained_dir: ${path.expanduser:${oc.env:MONTY_MODELS}/pretrained_compositional_objects_v4}
+  rotations_all_count: 14
+  rotations_all:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0
+  - - 0
+    - 270
+    - 0
+  - - 90
+    - 0
+    - 0
+  - - 90
+    - 180
+    - 0
+  - - 35
+    - 45
+    - 0
+  - - 325
+    - 45
+    - 0
+  - - 35
+    - 315
+    - 0
+  - - 325
+    - 315
+    - 0
+  - - 35
+    - 135
+    - 0
+  - - 325
+    - 135
+    - 0
+  - - 35
+    - 225
+    - 0
+  - - 325
+    - 225
+    - 0
+  rotations_3_count: 3
+  rotations_3:
+  - - 0
+    - 0
+    - 0
+  - - 0
+    - 90
+    - 0
+  - - 0
+    - 180
+    - 0

--- a/tests/unit/attention/__init__.py
+++ b/tests/unit/attention/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.

--- a/tests/unit/attention/attention_system_test.py
+++ b/tests/unit/attention/attention_system_test.py
@@ -1,0 +1,329 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from tbp.monty.attention.attention_system import AttentionSystem
+from tbp.monty.cmp import Goal
+
+# Two points inside one voxel, and a third far enough away to occupy its own.
+NEAR_POINTS = ([0.0, 0, 0], [0.005, 0, 0])
+FAR_POINT = [0.5, 0, 0]
+# The voxels those points fall in, at voxel_size=0.01.
+NEAR_VOXEL = (0, 0, 0)
+FAR_VOXEL = (50, 0, 0)
+
+
+def goal_at(location) -> Goal:
+    """Build a goal at the given location.
+
+    Returns:
+        A goal whose only meaningful property here is its location.
+
+    """
+    return Goal(
+        location=None if location is None else np.asarray(location, dtype=float),
+        morphological_features=None,
+        non_morphological_features=None,
+        confidence=0.5,
+        use_state=False,
+        sender_id="SM_0",
+        sender_type="SM",
+        goal_tolerances=None,
+    )
+
+
+def region(*locations) -> list[Goal]:
+    """Build a region from the given locations.
+
+    Returns:
+        One region: a list with one goal per location.
+
+    """
+    return [goal_at(location) for location in locations]
+
+
+def column_by_voxel(
+    system: AttentionSystem, column: str
+) -> dict[tuple[int, int, int], int]:
+    """Map each occupied voxel to one of its column values.
+
+    Returns:
+        Voxel coordinate to value, for every voxel the system holds.
+
+    """
+    data = system.grid
+    voxels = [tuple(int(c) for c in index) for index in data.index]
+    return dict(zip(voxels, data[column].to_numpy().ravel().tolist()))
+
+
+def ages_by_voxel(system: AttentionSystem) -> dict[tuple[int, int, int], int]:
+    """Map each occupied voxel to its remaining age.
+
+    Returns:
+        Voxel coordinate to age, for every voxel the system holds.
+
+    """
+    return column_by_voxel(system, "age")
+
+
+def counts_by_voxel(system: AttentionSystem) -> dict[tuple[int, int, int], int]:
+    """Map each occupied voxel to how many times it has been observed.
+
+    Returns:
+        Voxel coordinate to count, for every voxel the system holds.
+
+    """
+    return column_by_voxel(system, "count")
+
+
+class AttentionSystemGridTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.system = AttentionSystem(voxel_size=0.01)
+
+    def test_locations_sharing_a_voxel_collapse_to_one_row(self) -> None:
+        self.system.step([], [region(*NEAR_POINTS, FAR_POINT)])
+        self.assertEqual(len(self.system.grid), 2)
+
+    def test_no_regions_yield_an_empty_grid(self) -> None:
+        self.system.step([], [])
+        self.assertEqual(len(self.system.grid), 0)
+
+    def test_empty_regions_yield_an_empty_grid(self) -> None:
+        self.system.step([], [[], []])
+        self.assertEqual(len(self.system.grid), 0)
+
+    def test_goals_without_a_location_are_not_voxelized(self) -> None:
+        self.system.step([], [[goal_at(None)]])
+        self.assertEqual(len(self.system.grid), 0)
+
+    def test_a_step_adds_to_the_grid_rather_than_replacing_it(self) -> None:
+        self.system.step([], [region(*NEAR_POINTS)])
+        self.system.step([], [region(FAR_POINT)])
+        self.assertEqual(
+            sorted(ages_by_voxel(self.system)), [NEAR_VOXEL, FAR_VOXEL]
+        )
+
+    def test_regions_from_different_modules_merge_into_one_grid(self) -> None:
+        self.system.step([], [region(*NEAR_POINTS), region(FAR_POINT)])
+        self.assertEqual(
+            sorted(ages_by_voxel(self.system)), [NEAR_VOXEL, FAR_VOXEL]
+        )
+
+    def test_reset_discards_the_grid(self) -> None:
+        self.system.step([], [region(*NEAR_POINTS)])
+        self.system.reset()
+        self.assertEqual(len(self.system.grid), 0)
+
+
+class AttentionSystemAgeTest(unittest.TestCase):
+    """Voxels persist across steps, ageing until they are re-observed or expire."""
+
+    def setUp(self) -> None:
+        self.system = AttentionSystem(voxel_size=0.01, lifetime=3)
+
+    def observe_near(self) -> None:
+        """Observe the near voxel."""
+        self.system.step([], [region(NEAR_POINTS[0])])
+
+    def observe_far(self) -> None:
+        """Observe the far voxel."""
+        self.system.step([], [region(FAR_POINT)])
+
+    def test_age_starts_at_the_full_lifetime(self) -> None:
+        self.observe_near()
+        self.assertEqual(ages_by_voxel(self.system)[NEAR_VOXEL], 3)
+
+    def test_age_is_stored_as_an_integer(self) -> None:
+        self.observe_near()
+        self.assertEqual(self.system.grid["age"].to_numpy().dtype, np.int32)
+
+    def test_lifetime_is_exposed(self) -> None:
+        self.assertEqual(AttentionSystem(lifetime=9).lifetime, 9)
+
+    def test_lifetime_must_be_positive(self) -> None:
+        for bad in (0, -1):
+            with self.assertRaises(ValueError):
+                AttentionSystem(lifetime=bad)
+
+    def test_an_unobserved_voxel_is_remembered(self) -> None:
+        self.observe_near()
+        self.observe_far()
+        self.assertEqual(set(ages_by_voxel(self.system)), {NEAR_VOXEL, FAR_VOXEL})
+
+    def test_an_unobserved_voxel_ages_by_one_step(self) -> None:
+        self.observe_near()
+        self.observe_far()
+        self.assertEqual(ages_by_voxel(self.system)[NEAR_VOXEL], 2)
+
+    def test_a_re_observed_voxel_returns_to_a_full_age(self) -> None:
+        self.observe_near()
+        self.observe_far()
+        self.observe_near()
+        self.assertEqual(ages_by_voxel(self.system)[NEAR_VOXEL], 3)
+
+    def test_a_voxel_expires_after_its_lifetime_of_steps(self) -> None:
+        self.observe_near()
+        for _ in range(3):
+            self.observe_far()
+        self.assertEqual(set(ages_by_voxel(self.system)), {FAR_VOXEL})
+
+    def test_observing_nothing_still_ages_the_grid(self) -> None:
+        self.observe_near()
+        self.system.step([], [])
+        self.assertEqual(ages_by_voxel(self.system)[NEAR_VOXEL], 2)
+
+    def test_the_grid_empties_once_everything_expires(self) -> None:
+        self.observe_near()
+        for _ in range(3):
+            self.system.step([], [])
+        self.assertEqual(len(self.system.grid), 0)
+
+    def test_age_stays_an_integer_across_steps(self) -> None:
+        self.observe_near()
+        self.observe_far()
+        self.assertEqual(self.system.grid["age"].to_numpy().dtype, np.int32)
+
+
+class AttentionSystemCountTest(unittest.TestCase):
+    """Count tallies how many times a voxel has been observed."""
+
+    def setUp(self) -> None:
+        self.system = AttentionSystem(voxel_size=0.01, lifetime=3)
+
+    def observe_near(self) -> None:
+        """Observe the near voxel."""
+        self.system.step([], [region(NEAR_POINTS[0])])
+
+    def observe_far(self) -> None:
+        """Observe the far voxel."""
+        self.system.step([], [region(FAR_POINT)])
+
+    def test_a_newly_seen_voxel_starts_at_one(self) -> None:
+        self.observe_near()
+        self.assertEqual(counts_by_voxel(self.system)[NEAR_VOXEL], 1)
+
+    def test_re_observing_adds_to_the_count(self) -> None:
+        for expected in (1, 2, 3):
+            self.observe_near()
+            self.assertEqual(counts_by_voxel(self.system)[NEAR_VOXEL], expected)
+
+    def test_an_unobserved_voxel_keeps_its_count(self) -> None:
+        self.observe_near()
+        self.observe_near()
+        self.observe_far()
+        counts = counts_by_voxel(self.system)
+        self.assertEqual(counts[NEAR_VOXEL], 2)
+        self.assertEqual(counts[FAR_VOXEL], 1)
+
+    def test_counts_are_tallied_independently_per_voxel(self) -> None:
+        self.observe_near()
+        self.observe_far()
+        self.observe_far()
+        counts = counts_by_voxel(self.system)
+        self.assertEqual(counts[NEAR_VOXEL], 1)
+        self.assertEqual(counts[FAR_VOXEL], 2)
+
+    def test_each_region_seeing_a_voxel_contributes_a_sighting(self) -> None:
+        # Two modules propose overlapping regions on the same step.
+        self.system.step([], [region(NEAR_POINTS[0]), region(NEAR_POINTS[1])])
+        self.assertEqual(counts_by_voxel(self.system)[NEAR_VOXEL], 2)
+
+    def test_count_restarts_after_a_voxel_expires(self) -> None:
+        # An expired voxel is forgotten, so its tally starts over.
+        self.observe_near()
+        self.observe_near()
+        for _ in range(3):
+            self.system.step([], [])
+        self.assertEqual(len(self.system.grid), 0)
+        self.observe_near()
+        self.assertEqual(counts_by_voxel(self.system)[NEAR_VOXEL], 1)
+
+    def test_count_stays_an_integer_across_steps(self) -> None:
+        self.observe_near()
+        self.observe_near()
+        self.assertEqual(self.system.grid["count"].to_numpy().dtype, np.int32)
+
+
+class AttentionSystemContainsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.system = AttentionSystem(voxel_size=0.01)
+        self.system.step([], [region(*NEAR_POINTS, FAR_POINT)])
+
+    def test_many_locations_yield_an_array(self) -> None:
+        result = self.system.contains_points(np.array([[0.0, 0, 0], [9.0, 9, 9]]))
+        np.testing.assert_array_equal(result, [True, False])
+
+    def test_a_single_flat_point_is_accepted(self) -> None:
+        # Normalized to (1, 3), so the result is still an array.
+        np.testing.assert_array_equal(
+            self.system.contains_points(np.array([0.0, 0, 0])), [True]
+        )
+
+    def test_any_location_in_an_occupied_voxel_is_contained(self) -> None:
+        # A different point in the same voxel as an observed one.
+        np.testing.assert_array_equal(
+            self.system.contains_points(np.array([[0.009, 0, 0]])), [True]
+        )
+
+    def test_an_empty_grid_contains_nothing(self) -> None:
+        empty = AttentionSystem(voxel_size=0.01)
+        np.testing.assert_array_equal(
+            empty.contains_points(np.array([[0.0, 0, 0]])), [False]
+        )
+
+
+class AttentionSystemFilterTest(unittest.TestCase):
+    """Step returns only the goals that live in the updated voxel grid."""
+
+    def setUp(self) -> None:
+        self.system = AttentionSystem(voxel_size=0.01, lifetime=3)
+
+    def test_only_goals_inside_the_grid_are_returned(self) -> None:
+        inside = goal_at(NEAR_POINTS[0])
+        outside = goal_at([9.0, 9, 9])
+        returned = self.system.step(
+            [inside, outside], [region(*NEAR_POINTS)]
+        )
+        self.assertEqual(returned, [inside])
+
+    def test_goals_are_filtered_against_the_updated_grid(self) -> None:
+        # The region arrives on the same step as the goal it admits.
+        goal = goal_at(NEAR_POINTS[1])
+        self.assertEqual(
+            self.system.step([goal], [region(NEAR_POINTS[0])]), [goal]
+        )
+
+    def test_goals_pass_through_while_the_grid_is_empty(self) -> None:
+        goals = [goal_at(NEAR_POINTS[0]), goal_at([9.0, 9, 9])]
+        self.assertEqual(self.system.step(goals, []), goals)
+
+    def test_goals_without_a_location_pass_through(self) -> None:
+        unlocated = goal_at(None)
+        returned = self.system.step(
+            [goal_at([9.0, 9, 9]), unlocated], [region(NEAR_POINTS[0])]
+        )
+        self.assertEqual(returned, [unlocated])
+
+    def test_a_remembered_voxel_still_admits_goals(self) -> None:
+        self.system.step([], [region(NEAR_POINTS[0])])
+        goal = goal_at(NEAR_POINTS[0])
+        # The near voxel was not re-observed, but has not expired either.
+        self.assertEqual(self.system.step([goal], [region(FAR_POINT)]), [goal])
+
+    def test_an_expired_voxel_no_longer_admits_goals(self) -> None:
+        self.system.step([], [region(NEAR_POINTS[0])])
+        goal = goal_at(NEAR_POINTS[0])
+        for _ in range(2):
+            self.system.step([], [region(FAR_POINT)])
+        # This step ages the near voxel past its lifetime before filtering.
+        self.assertEqual(self.system.step([goal], [region(FAR_POINT)]), [])

--- a/tests/unit/attention/attention_system_test.py
+++ b/tests/unit/attention/attention_system_test.py
@@ -129,7 +129,7 @@ class AttentionSystemAgeTest(unittest.TestCase):
     """Voxels persist across steps, ageing until they are re-observed or expire."""
 
     def setUp(self) -> None:
-        self.system = AttentionSystem(voxel_size=0.01, lifetime=3)
+        self.system = AttentionSystem(voxel_size=0.01, voxel_lifetime=3)
 
     def observe_near(self) -> None:
         """Observe the near voxel."""
@@ -147,13 +147,13 @@ class AttentionSystemAgeTest(unittest.TestCase):
         self.observe_near()
         self.assertEqual(self.system.grid["age"].to_numpy().dtype, np.int32)
 
-    def test_lifetime_is_exposed(self) -> None:
-        self.assertEqual(AttentionSystem(lifetime=9).lifetime, 9)
+    def test_voxel_lifetime_is_exposed(self) -> None:
+        self.assertEqual(AttentionSystem(voxel_lifetime=9).voxel_lifetime, 9)
 
-    def test_lifetime_must_be_positive(self) -> None:
+    def test_voxel_lifetime_must_be_positive(self) -> None:
         for bad in (0, -1):
             with self.assertRaises(ValueError):
-                AttentionSystem(lifetime=bad)
+                AttentionSystem(voxel_lifetime=bad)
 
     def test_an_unobserved_voxel_is_remembered(self) -> None:
         self.observe_near()
@@ -198,7 +198,7 @@ class AttentionSystemCountTest(unittest.TestCase):
     """Count tallies how many times a voxel has been observed."""
 
     def setUp(self) -> None:
-        self.system = AttentionSystem(voxel_size=0.01, lifetime=3)
+        self.system = AttentionSystem(voxel_size=0.01, voxel_lifetime=3)
 
     def observe_near(self) -> None:
         """Observe the near voxel."""
@@ -286,7 +286,7 @@ class AttentionSystemFilterTest(unittest.TestCase):
     """Step returns only the goals that live in the updated voxel grid."""
 
     def setUp(self) -> None:
-        self.system = AttentionSystem(voxel_size=0.01, lifetime=3)
+        self.system = AttentionSystem(voxel_size=0.01, voxel_lifetime=3)
 
     def test_only_goals_inside_the_grid_are_returned(self) -> None:
         inside = goal_at(NEAR_POINTS[0])

--- a/tests/unit/attention/telemetry_test.py
+++ b/tests/unit/attention/telemetry_test.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+import json
+import unittest
+
+import numpy as np
+
+from tbp.monty.attention.attention_system import AttentionSystem
+from tbp.monty.attention.telemetry import AttentionSystemTelemetry
+from tbp.monty.frameworks.models.buffer import BufferEncoder
+
+from .attention_system_test import region
+
+NEAR_POINT = [0.0, 0, 0]
+FAR_POINT = [0.5, 0, 0]
+
+
+class AttentionSystemTelemetryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.telemetry = AttentionSystemTelemetry()
+        self.system = AttentionSystem(
+            voxel_size=0.01, voxel_lifetime=2, telemetry=self.telemetry
+        )
+
+    def test_each_step_records_a_snapshot(self) -> None:
+        self.system.step([], [region(NEAR_POINT)])
+        self.system.step([], [region(FAR_POINT)])
+        self.assertEqual(len(self.telemetry.voxel_grids), 2)
+
+    def test_a_snapshot_is_unaffected_by_later_steps(self) -> None:
+        self.system.step([], [region(NEAR_POINT)])
+        self.system.step([], [region(FAR_POINT)])
+        self.assertEqual(len(self.telemetry.voxel_grids[0]), 1)
+        self.assertEqual(len(self.telemetry.voxel_grids[1]), 2)
+
+    def test_reset_discards_the_snapshots(self) -> None:
+        self.system.step([], [region(NEAR_POINT)])
+        self.system.reset()
+        self.assertEqual(len(self.telemetry.voxel_grids), 0)
+
+    def test_state_dict_flattens_each_snapshot_into_arrays(self) -> None:
+        self.system.step([], [region(NEAR_POINT)])
+        self.system.step([], [region(NEAR_POINT, FAR_POINT)])
+        snapshot = self.system.state_dict()["voxel_grids"][1]
+        np.testing.assert_array_equal(
+            snapshot["voxels"], [[0, 0, 0], [50, 0, 0]]
+        )
+        np.testing.assert_array_equal(snapshot["age"], [2, 2])
+        np.testing.assert_array_equal(snapshot["count"], [2, 1])
+
+    def test_an_empty_grid_snapshot_is_exported_empty(self) -> None:
+        self.system.step([], [region(NEAR_POINT)])
+        # Two empty steps age the voxel past its lifetime of 2.
+        self.system.step([], [])
+        self.system.step([], [])
+        snapshot = self.system.state_dict()["voxel_grids"][2]
+        self.assertEqual(len(snapshot["voxels"]), 0)
+        self.assertEqual(len(snapshot["age"]), 0)
+
+    def test_state_dict_is_json_encodable(self) -> None:
+        self.system.step([], [region(NEAR_POINT)])
+        self.system.step([], [])
+        encoded = json.loads(
+            json.dumps(self.system.state_dict(), cls=BufferEncoder)
+        )
+        self.assertEqual(encoded["voxel_grids"][0]["voxels"], [[0, 0, 0]])
+
+    def test_a_default_telemetry_is_created_when_none_is_supplied(self) -> None:
+        system = AttentionSystem(voxel_size=0.01)
+        system.step([], [region(NEAR_POINT)])
+        self.assertEqual(len(system.state_dict()["voxel_grids"]), 1)

--- a/tests/unit/attention/telemetry_test.py
+++ b/tests/unit/attention/telemetry_test.py
@@ -77,3 +77,8 @@ class AttentionSystemTelemetryTest(unittest.TestCase):
         system = AttentionSystem(voxel_size=0.01)
         system.step([], [region(NEAR_POINT)])
         self.assertEqual(len(system.state_dict()["voxel_grids"]), 1)
+
+    def test_state_dict_carries_the_grid_geometry(self) -> None:
+        state = self.system.state_dict()
+        self.assertEqual(state["voxel_size"], 0.01)
+        self.assertEqual(state["voxel_lifetime"], 2)

--- a/tests/unit/frameworks/models/salience/segmentation/__init__.py
+++ b/tests/unit/frameworks/models/salience/segmentation/__init__.py
@@ -1,0 +1,8 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.

--- a/tests/unit/frameworks/models/salience/sensor_module_test.py
+++ b/tests/unit/frameworks/models/salience/sensor_module_test.py
@@ -48,6 +48,8 @@ def mocked_object_observation():
         center_location=None,
         locations=np.empty((0, 3)),
         salience=np.empty([]),
+        on_object_mask=np.zeros((64, 64), dtype=bool),
+        locations_map=np.zeros((64, 64, 3)),
     )
     with patch(
         "tbp.monty.frameworks.models.salience.sensor_module.on_object_observation",
@@ -119,6 +121,8 @@ class SalienceSMTest(unittest.TestCase):
             center_location=sentinel.center_location,
             locations=locations,
             salience=sentinel.salience_map,
+            on_object_mask=np.zeros((64, 64), dtype=bool),
+            locations_map=np.zeros((64, 64, 3)),
         )
         self.sensor_module._return_inhibitor.return_value = sentinel.ior_weights  # type: ignore[attr-defined]
         salience = 0.1 * np.array([1, 2, 3])
@@ -167,6 +171,88 @@ class SalienceSMTest(unittest.TestCase):
             self.assertEqual(g.goal_tolerances, expected_goal.goal_tolerances)
             self.assertEqual(g.sender_id, expected_goal.sender_id)
             self.assertEqual(g.sender_type, expected_goal.sender_type)
+
+
+class SalienceSMRegionTest(unittest.TestCase):
+    """The region is the segmented surface, proposed as goals."""
+
+    def setUp(self) -> None:
+        # A 2x2 frame: three on-object pixels, of which the segmentation covers
+        # (0, 0) and (1, 1). Locations encode their own pixel coordinates.
+        self.on_object_mask = np.array([[True, True], [False, True]])
+        self.locations_map = np.zeros((2, 2, 3))
+        for row in range(2):
+            for col in range(2):
+                self.locations_map[row, col] = [row, col, 1.0]
+        self.segmentation_map = np.array([[1, 0], [1, 1]], dtype=np.uint8)
+        # Weighted salience for the on-object pixels, in row-major order:
+        # (0, 0), (0, 1), (1, 1).
+        self.weighted_salience = np.array([0.1, 0.5, 0.9])
+
+        self.segmentation_strategy = MagicMock(return_value=self.segmentation_map)
+        self.sensor_module = SalienceSM(
+            sensor_module_id="test",
+            salience_strategy=MagicMock(return_value=sentinel.salience_map),
+            return_inhibitor=MagicMock(return_value=sentinel.ior_weights),
+            snapshot_telemetry=MagicMock(),
+            segmentation_strategy=self.segmentation_strategy,
+        )
+        self.sensor_module._weight_salience = MagicMock(  # type: ignore[method-assign]
+            return_value=self.weighted_salience
+        )
+        self.observation = SensorObservation(
+            rgba=np.zeros((2, 2, 4), dtype=np.uint8),
+            depth=np.zeros((2, 2)),
+        )
+        self.ctx = RuntimeContext(rng=np.random.RandomState())
+
+    def step(self) -> None:
+        """Step the sensor module with the mocked observation pipeline."""
+        pix_rows, pix_cols = np.where(self.on_object_mask)
+        on_object = OnObjectObservation(
+            center_location=None,
+            locations=self.locations_map[pix_rows, pix_cols],
+            salience=sentinel.salience_map,
+            on_object_mask=self.on_object_mask,
+            locations_map=self.locations_map,
+        )
+        with patch(
+            "tbp.monty.frameworks.models.salience.sensor_module."
+            "on_object_observation",
+            return_value=on_object,
+        ):
+            self.sensor_module.step(self.ctx, self.observation)
+
+    def test_region_is_the_on_object_part_of_the_segmented_surface(self) -> None:
+        self.step()
+        region = self.sensor_module.propose_region()
+        locations = [g.location.tolist() for g in region]
+        # (1, 0) is segmented but off-object; (0, 1) is on-object but outside
+        # the segmentation.
+        self.assertEqual(locations, [[0.0, 0.0, 1.0], [1.0, 1.0, 1.0]])
+
+    def test_region_goals_carry_the_weighted_salience(self) -> None:
+        self.step()
+        region = self.sensor_module.propose_region()
+        self.assertEqual([g.confidence for g in region], [0.1, 0.9])
+
+    def test_segmentation_strategy_receives_the_observation(self) -> None:
+        self.step()
+        self.segmentation_strategy.assert_called_once_with(
+            ctx=self.ctx,
+            rgba=self.observation["rgba"],
+            depth=self.observation["depth"],
+        )
+
+    def test_without_a_segmentation_strategy_the_region_is_empty(self) -> None:
+        self.sensor_module._segmentation_strategy = None
+        self.step()
+        self.assertEqual(self.sensor_module.propose_region(), [])
+
+    def test_reset_clears_the_region(self) -> None:
+        self.step()
+        self.sensor_module.reset()
+        self.assertEqual(self.sensor_module.propose_region(), [])
 
 
 class SalienceSMPrivateTest(unittest.TestCase):

--- a/tests/unit/frameworks/models/salience/sensor_module_test.py
+++ b/tests/unit/frameworks/models/salience/sensor_module_test.py
@@ -28,6 +28,7 @@ from tbp.monty.frameworks.models.salience.on_object_observation import (
 from tbp.monty.frameworks.models.salience.sensor_module import (
     SalienceSM,
 )
+from tbp.monty.frameworks.models.salience.telemetry import SalienceSMTelemetry
 from tbp.monty.frameworks.sensors import SensorID
 
 
@@ -253,6 +254,94 @@ class SalienceSMRegionTest(unittest.TestCase):
         self.step()
         self.sensor_module.reset()
         self.assertEqual(self.sensor_module.propose_region(), [])
+
+
+class SalienceSMTelemetryRecordingTest(unittest.TestCase):
+    """Segmentation masks and regions are stashed when telemetry is supplied."""
+
+    def setUp(self) -> None:
+        # The same 2x2 mocked pipeline as SalienceSMRegionTest, with telemetry.
+        self.on_object_mask = np.array([[True, True], [False, True]])
+        self.locations_map = np.zeros((2, 2, 3))
+        for row in range(2):
+            for col in range(2):
+                self.locations_map[row, col] = [row, col, 1.0]
+        self.segmentation_map = np.array([[1, 0], [1, 1]], dtype=np.uint8)
+        self.weighted_salience = np.array([0.1, 0.5, 0.9])
+
+        self.telemetry = SalienceSMTelemetry(save_segmentation=True)
+        self.sensor_module = SalienceSM(
+            sensor_module_id="test",
+            salience_strategy=MagicMock(return_value=sentinel.salience_map),
+            return_inhibitor=MagicMock(return_value=sentinel.ior_weights),
+            snapshot_telemetry=self.telemetry,
+            segmentation_strategy=MagicMock(return_value=self.segmentation_map),
+        )
+        self.sensor_module._weight_salience = MagicMock(  # type: ignore[method-assign]
+            return_value=self.weighted_salience
+        )
+        self.observation = SensorObservation(
+            rgba=np.zeros((2, 2, 4), dtype=np.uint8),
+            depth=np.zeros((2, 2)),
+        )
+        self.ctx = RuntimeContext(rng=np.random.RandomState())
+
+    def step(self) -> None:
+        """Step the sensor module with the mocked observation pipeline."""
+        pix_rows, pix_cols = np.where(self.on_object_mask)
+        on_object = OnObjectObservation(
+            center_location=None,
+            locations=self.locations_map[pix_rows, pix_cols],
+            salience=sentinel.salience_map,
+            on_object_mask=self.on_object_mask,
+            locations_map=self.locations_map,
+        )
+        with patch(
+            "tbp.monty.frameworks.models.salience.sensor_module."
+            "on_object_observation",
+            return_value=on_object,
+        ):
+            self.sensor_module.step(self.ctx, self.observation)
+
+    def test_step_records_the_segmentation_mask_and_region(self) -> None:
+        self.step()
+        state = self.telemetry.state_dict()
+        np.testing.assert_array_equal(
+            state["segmentation_maps"][0], self.segmentation_map
+        )
+        self.assertEqual(state["regions"][0], self.sensor_module.propose_region())
+
+    def test_step_does_not_record_while_exploring(self) -> None:
+        self.sensor_module.is_exploring = True
+        self.step()
+        self.assertEqual(self.telemetry.state_dict()["segmentation_maps"], [])
+
+    def test_without_a_segmentation_strategy_none_is_recorded(self) -> None:
+        self.sensor_module._segmentation_strategy = None
+        self.step()
+        state = self.telemetry.state_dict()
+        self.assertIsNone(state["segmentation_maps"][0])
+        self.assertEqual(state["regions"][0], [])
+
+    def test_state_dict_holds_snapshot_and_segmentation_telemetry(self) -> None:
+        self.step()
+        state = self.sensor_module.state_dict()
+        self.assertEqual(
+            set(state),
+            {"raw_observations", "sm_properties", "segmentation_maps", "regions"},
+        )
+
+    def test_recording_is_off_unless_save_segmentation_is_set(self) -> None:
+        self.sensor_module._snapshot_telemetry = SalienceSMTelemetry()
+        self.step()
+        state = self.sensor_module.state_dict()
+        self.assertEqual(state["segmentation_maps"], [])
+        self.assertEqual(state["regions"], [])
+
+    def test_reset_discards_the_recordings(self) -> None:
+        self.step()
+        self.sensor_module.reset()
+        self.assertEqual(self.telemetry.state_dict()["segmentation_maps"], [])
 
 
 class SalienceSMPrivateTest(unittest.TestCase):

--- a/tests/unit/frameworks/models/salience/telemetry_test.py
+++ b/tests/unit/frameworks/models/salience/telemetry_test.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+import json
+import unittest
+
+import numpy as np
+
+from tbp.monty.cmp import Goal
+from tbp.monty.frameworks.models.buffer import BufferEncoder
+from tbp.monty.frameworks.models.salience.telemetry import SalienceSMTelemetry
+
+
+def goal_at(location) -> Goal:
+    """Build a goal at the given location.
+
+    Returns:
+        A goal whose only meaningful property here is its location.
+
+    """
+    return Goal(
+        location=np.asarray(location, dtype=float),
+        morphological_features=None,
+        non_morphological_features=None,
+        confidence=0.5,
+        use_state=False,
+        sender_id="SM_0",
+        sender_type="SM",
+        goal_tolerances=None,
+    )
+
+
+class SalienceSMTelemetryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.telemetry = SalienceSMTelemetry(save_segmentation=True)
+        self.mask = np.array([[1, 0], [0, 1]], dtype=np.uint8)
+        self.region = [goal_at([0.0, 0, 1]), goal_at([1.0, 1, 1])]
+
+    def test_record_is_a_noop_by_default(self) -> None:
+        telemetry = SalienceSMTelemetry()
+        telemetry.record(self.mask, self.region)
+        state = telemetry.state_dict()
+        self.assertEqual(state["segmentation_maps"], [])
+        self.assertEqual(state["regions"], [])
+
+    def test_state_dict_includes_the_snapshot_telemetry(self) -> None:
+        state = self.telemetry.state_dict()
+        self.assertIn("raw_observations", state)
+        self.assertIn("sm_properties", state)
+
+    def test_records_one_entry_per_step(self) -> None:
+        self.telemetry.record(self.mask, self.region)
+        self.telemetry.record(None, [])
+        state = self.telemetry.state_dict()
+        self.assertEqual(len(state["segmentation_maps"]), 2)
+        self.assertEqual(len(state["regions"]), 2)
+
+    def test_state_dict_holds_what_was_recorded(self) -> None:
+        self.telemetry.record(self.mask, self.region)
+        state = self.telemetry.state_dict()
+        np.testing.assert_array_equal(state["segmentation_maps"][0], self.mask)
+        self.assertEqual(state["regions"][0], self.region)
+
+    def test_a_step_without_segmentation_records_none(self) -> None:
+        self.telemetry.record(None, [])
+        state = self.telemetry.state_dict()
+        self.assertIsNone(state["segmentation_maps"][0])
+        self.assertEqual(state["regions"][0], [])
+
+    def test_the_recorded_region_is_detached_from_the_callers_list(self) -> None:
+        region = list(self.region)
+        self.telemetry.record(self.mask, region)
+        region.clear()
+        self.assertEqual(len(self.telemetry.state_dict()["regions"][0]), 2)
+
+    def test_reset_discards_the_recordings(self) -> None:
+        self.telemetry.record(self.mask, self.region)
+        self.telemetry.reset()
+        state = self.telemetry.state_dict()
+        self.assertEqual(state["segmentation_maps"], [])
+        self.assertEqual(state["regions"], [])
+
+    def test_state_dict_is_json_encodable(self) -> None:
+        self.telemetry.record(self.mask, self.region)
+        self.telemetry.record(None, [])
+        encoded = json.loads(
+            json.dumps(self.telemetry.state_dict(), cls=BufferEncoder)
+        )
+        self.assertEqual(encoded["segmentation_maps"][0], [[1, 0], [0, 1]])
+        self.assertIsNone(encoded["segmentation_maps"][1])
+        self.assertEqual(len(encoded["regions"][0]), 2)


### PR DESCRIPTION
**Note: This PR was mistakenly opened for tbp.monty. It was intended for feat.comp_benefits_figures. I am closing it now.**

This PR is large. It brings in the whole segmentation framework (which is currently still tucked into SalienceSM), and it introduces the AttentionSystem class and the routing needed to step it.

Telemetry is also available for both segmentation and the attention system. @nielsleadholm I'm not sure the best way to handle telemetry for the LM's proposed regions, but we can work that out later.

I've also got some new configs used for testing the system, but most of these will be deleted once we've got the new compositional configs. So I wouldn't spend too much time reviewing those.

There are quite a few Claude-generated unit tests. As I noted on shortcut, they look right to me but they weren't hand-made. As such, I wouldn't worry about reviewing those too much either.

