### PR TITLE
docs: Fix symlink version number + add instructions for updating

### DIFF
--- a/docs/overview/benchmark-experiments.md
+++ b/docs/overview/benchmark-experiments.md
@@ -174,10 +174,18 @@ Note: To obtain these results, pretraining was run without parallelization acros
 > unzip compositional_objects_1.2.zip
 > ```
 >
-> Then create a symlink so that the experiment configs (which look for `~/tbp/data/habitat/objects/compositional_objects`) can find the versioned dataset folder:
+> Then create a symlink so that the experiment configs (which look for `~/tbp/data/habitat/objects/compositional_objects`) can find the versioned dataset folder. If this is the first time you are doing this, you can use:
 >
 > ```plaintext
 > mkdir -p ~/tbp/data/habitat/objects/
+>
+> ln -s ~/tbp/data/habitat/versioned_data/compositional_objects_1.2 ~/tbp/data/habitat/objects/compositional_objects
+> ```
+>
+> If you have a pre-existing symlink for an old version of the dataset, then you will need to remove this first, i.e.:
+>
+> ```plaintext
+> rm ~/tbp/data/habitat/objects/compositional_objects
 >
 > ln -s ~/tbp/data/habitat/versioned_data/compositional_objects_1.2 ~/tbp/data/habitat/objects/compositional_objects
 > ```

--- a/docs/overview/benchmark-experiments.md
+++ b/docs/overview/benchmark-experiments.md
@@ -179,7 +179,7 @@ Note: To obtain these results, pretraining was run without parallelization acros
 > ```plaintext
 > mkdir -p ~/tbp/data/habitat/objects/
 >
-> ln -s ~/tbp/data/habitat/versioned_data/compositional_objects_1.1 ~/tbp/data/habitat/objects/compositional_objects
+> ln -s ~/tbp/data/habitat/versioned_data/compositional_objects_1.2 ~/tbp/data/habitat/objects/compositional_objects
 > ```
 >
 > To generate the pretrained models, run the following experiments in order:


### PR DESCRIPTION
Fixes the version number for the symlink instructions for the compositional dataset (v1.2), and adds instructions for updating the link when it already exists. 