### PR TITLE
chore: Remove redundant additions and subtractions

### DIFF
--- a/src/tbp/monty/frameworks/utils/spatial_arithmetics.py
+++ b/src/tbp/monty/frameworks/utils/spatial_arithmetics.py
@@ -562,7 +562,7 @@ def apply_rf_transform_to_points(
     # Apply detected rotation to new locations
     rotated_locs = object_rotation.inv().apply(zero_centered_locs)
 
-    # Undo the 0 centering to bring back into model reference frame
+    # Undo the 0 centering and align the new points with the model's reference frame
     transformed_locations = rotated_locs + ref_point1
     features = rotate_multiple_pose_dependent_features(features, object_rotation.inv())
     return transformed_locations, features

--- a/src/tbp/monty/frameworks/utils/spatial_arithmetics.py
+++ b/src/tbp/monty/frameworks/utils/spatial_arithmetics.py
@@ -561,10 +561,8 @@ def apply_rf_transform_to_points(
     zero_centered_locs = locations - ref_point2
     # Apply detected rotation to new locations
     rotated_locs = object_rotation.inv().apply(zero_centered_locs)
-    # Apply the offset between the two reference points
-    ref_point_offset = ref_point1 - ref_point2
-    location_offset = rotated_locs + ref_point_offset
+
     # Undo the 0 centering to bring back into model reference frame
-    transformed_locations = location_offset + ref_point2
+    transformed_locations = rotated_locs + ref_point1
     features = rotate_multiple_pose_dependent_features(features, object_rotation.inv())
     return transformed_locations, features


### PR DESCRIPTION
While reading the `apply_rf_transform_to_points` method during the hackathon, I noticed that we have some redundant operations. Substituting in variables, you can see that the original lines are equivalent to:

```
transformed_locations = location_offset + ref_point2
= rotated_locs + ref_point_offset + ref_point2
= rotated_locs + (ref_point1 - ref_point2) + ref_point2
```

The last two terms cancel out, and it can just be:
```
transformed_locations = rotated_locs + ref_point1
```

I noticed this because it also fit better with my mental model of what is actually necessary. Hopefully this makes the function easier to understand for newcomers. 