### PR TITLE
fix: Add check for pre-existing lights in Mujoco

### DIFF
--- a/src/tbp/monty/simulators/mujoco/simulator.py
+++ b/src/tbp/monty/simulators/mujoco/simulator.py
@@ -248,13 +248,15 @@ class MuJoCoSimulator(SimulatedObjectEnvironment):
         self.spec.visual.headlight.ambient = (0.5, 0.5, 0.5)
         self.spec.visual.headlight.diffuse = (0.0, 0.0, 0.0)
         self.spec.visual.headlight.specular = (0.0, 0.0, 0.0)
-        # Add a directional light on the "front" side of the object.
-        self.spec.worldbody.add_light(
-            pos=(0, 0.0, 0.2),
-            diffuse=(0.6, 0.6, 0.6),
-            specular=(0.1, 0.1, 0.1),
-            type=mjtLightType.mjLIGHT_DIRECTIONAL,
-        )
+        # Add a directional light on the "front" side of the object,
+        # unless a previous recompile already added it.
+        if not self.spec.lights:
+            self.spec.worldbody.add_light(
+                pos=(0, 0.0, 0.2),
+                diffuse=(0.6, 0.6, 0.6),
+                specular=(0.1, 0.1, 0.1),
+                type=mjtLightType.mjLIGHT_DIRECTIONAL,
+            )
 
     def renderer_for_res(self, resolution: Resolution2D) -> Renderer:
         """Creates or returns a renderer of the specified resolution.


### PR DESCRIPTION
## The Problem 

While working with our compositional dataset (which is now supported in Mujoco thanks to Scott) in teleop, I noticed that the marble texture was very washed out and over-saturated. Looking at the standard YCB objects in Mujoco, these are also very "bright", most noticeable with lighter-textured objects. See examples below:

<img width="435" height="694" alt="bright_a" src="https://github.com/user-attachments/assets/b82c53bd-c31f-40fe-bce4-c73f67b70bef" />

<img width="450" height="697" alt="bright_b" src="https://github.com/user-attachments/assets/f9eea012-2474-472d-9145-69d374607070" />

## The Reason

The Mujoco simulator call to `_recompile` happens multiple times, including when an object is added. This in turn means that the `_configure_lights` addition of a directional light gets called multiple times. 

### The Solution

The solution I've added is to check whether this light has already been initialized. With this change in place, the objects look like we would expect.

<img width="405" height="688" alt="after_a" src="https://github.com/user-attachments/assets/2c8850f1-dd6d-41f5-99c1-afe66b93902a" />

<img width="422" height="688" alt="after_b" src="https://github.com/user-attachments/assets/b9c94e79-82eb-49a3-a932-341d3fbbc693" />
