### PR TITLE
ci: checkout tbp.monty to access .github/actions

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -49,6 +49,12 @@ jobs:
     name: pr-labels-triage
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout tbp.monty
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+          path: tbp.monty
       - name: reads as generated label is present
         if: ${{ contains(github.event.pull_request.labels.*.name, 'reads as generated') }}
         uses: ./tbp.monty/.github/actions/pin_comment


### PR DESCRIPTION
Labeling with `reads as generated` label caused an error in `pr-labels-triage` job:
```
Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/tbp.monty/tbp.monty/tbp.monty/.github/actions/pin_comment'. Did you forget to run actions/checkout before running your local action?
```