### PR TITLE
fix!: correctly merge new and previous pose vectors

### DIFF
--- a/src/tbp/monty/frameworks/models/object_model.py
+++ b/src/tbp/monty/frameworks/models/object_model.py
@@ -32,6 +32,7 @@ from tbp.monty.frameworks.utils.object_model_utils import (
     get_values_from_dense_last_dim,
     increment_sparse_tensor_by_count,
     pose_vector_mean,
+    pose_vector_merge,
     remove_close_points,
     torch_graph_to_numpy,
 )
@@ -841,18 +842,27 @@ class GridObjectModel(GraphObjectModel):
                 num_old_obs = num_obs_in_voxel - num_new_obs
 
                 if feature == "pose_vectors":
-                    if avg_feat is None:
-                        avg_feat = previous_average
-                    elif use_cds_to_update is False:
-                        avg_feat[3:] = previous_average[3:]
-                elif feature == "object_id" and avg_feat != previous_average:
-                    # TODO: Figure out a more nuanced way to take into account past obs
-                    if num_old_obs > num_new_obs:
-                        avg_feat = previous_average
-                    else:
-                        previous_average = avg_feat
-                # NOTE: could weight these
-                avg_feat = (avg_feat + previous_average) / 2
+                    avg_feat = (
+                        previous_average
+                        if avg_feat is None
+                        else pose_vector_merge(
+                            avg_feat,
+                            previous_average,
+                            use_cds_to_update,
+                            num_new_obs,
+                            num_old_obs,
+                        )
+                    )
+                else:
+                    if feature == "object_id" and avg_feat != previous_average:
+                        # TODO: Figure out a more nuanced way to take into account
+                        # past obs
+                        if num_old_obs > num_new_obs:
+                            avg_feat = previous_average
+                        else:
+                            previous_average = avg_feat
+                    # NOTE: could weight these
+                    avg_feat = (avg_feat + previous_average) / 2
             target_ids = target_fm[feature]
             new_feature_avg[target_ids[0] : target_ids[1]] = avg_feat
         return new_feature_avg

--- a/src/tbp/monty/frameworks/models/object_model.py
+++ b/src/tbp/monty/frameworks/models/object_model.py
@@ -842,17 +842,16 @@ class GridObjectModel(GraphObjectModel):
                 num_old_obs = num_obs_in_voxel - num_new_obs
 
                 if feature == "pose_vectors":
-                    avg_feat = (
-                        previous_average
-                        if avg_feat is None
-                        else pose_vector_merge(
+                    if avg_feat is None:
+                        avg_feat = previous_average
+                    else:
+                        avg_feat = pose_vector_merge(
                             avg_feat,
                             previous_average,
                             use_cds_to_update,
                             num_new_obs,
                             num_old_obs,
                         )
-                    )
                 else:
                     if feature == "object_id" and avg_feat != previous_average:
                         # TODO: Figure out a more nuanced way to take into account

--- a/src/tbp/monty/frameworks/models/object_model.py
+++ b/src/tbp/monty/frameworks/models/object_model.py
@@ -813,7 +813,7 @@ class GridObjectModel(GraphObjectModel):
             pdefined_ids = obs_fm["pose_fully_defined"]
             pose_vecs = new_features_in_voxel[:, pv_ids[0] : pv_ids[1]]
             pdefined = new_features_in_voxel[:, pdefined_ids[0] : pdefined_ids[1]]
-            pv_mean, use_cds_to_update = pose_vector_mean(pose_vecs, pdefined)
+            pv_mean, _ = pose_vector_mean(pose_vecs, pdefined)
         for feature in obs_fm:
             ids = obs_fm[feature]
             feats = new_features_in_voxel[:, ids[0] : ids[1]]
@@ -848,7 +848,6 @@ class GridObjectModel(GraphObjectModel):
                         avg_feat = pose_vector_merge(
                             avg_feat,
                             previous_average,
-                            use_cds_to_update,
                             num_new_obs,
                             num_old_obs,
                         )

--- a/src/tbp/monty/frameworks/models/object_model.py
+++ b/src/tbp/monty/frameworks/models/object_model.py
@@ -852,14 +852,14 @@ class GridObjectModel(GraphObjectModel):
                             num_new_obs,
                             num_old_obs,
                         )
-                else:
-                    if feature == "object_id" and avg_feat != previous_average:
+                elif feature == "object_id" and avg_feat != previous_average:
                         # TODO: Figure out a more nuanced way to take into account
                         # past obs
                         if num_old_obs > num_new_obs:
                             avg_feat = previous_average
                         else:
                             previous_average = avg_feat
+                else:
                     # NOTE: could weight these
                     avg_feat = (avg_feat + previous_average) / 2
             target_ids = target_fm[feature]

--- a/src/tbp/monty/frameworks/models/object_model.py
+++ b/src/tbp/monty/frameworks/models/object_model.py
@@ -853,12 +853,12 @@ class GridObjectModel(GraphObjectModel):
                             num_old_obs,
                         )
                 elif feature == "object_id":
-                        # TODO: Figure out a more nuanced way to take into account
-                        # past obs
-                        if num_old_obs > num_new_obs:
-                            avg_feat = previous_average
-                        else:
-                            previous_average = avg_feat
+                    # TODO: Figure out a more nuanced way to take into account
+                    # past obs
+                    if num_old_obs > num_new_obs:
+                        avg_feat = previous_average
+                    else:
+                        previous_average = avg_feat
                 else:
                     # NOTE: could weight these
                     avg_feat = (avg_feat + previous_average) / 2

--- a/src/tbp/monty/frameworks/models/object_model.py
+++ b/src/tbp/monty/frameworks/models/object_model.py
@@ -852,7 +852,7 @@ class GridObjectModel(GraphObjectModel):
                             num_new_obs,
                             num_old_obs,
                         )
-                elif feature == "object_id" and avg_feat != previous_average:
+                elif feature == "object_id":
                         # TODO: Figure out a more nuanced way to take into account
                         # past obs
                         if num_old_obs > num_new_obs:

--- a/src/tbp/monty/frameworks/utils/object_model_utils.py
+++ b/src/tbp/monty/frameworks/utils/object_model_utils.py
@@ -322,8 +322,8 @@ def orthonormal_pose_vectors(
 ) -> npt.NDArray[np.float64]:
     """Build a right-handed orthonormal pose from two rough directions.
 
-    The surface normal is used as a give, up to normalization. The curvature direction
-    is orthogonlized agaist it, so the returned pose vectors are always a valid
+    The surface normal is used as a given, up to normalization. The curvature direction
+    is orthogonalized against it, so the returned pose vectors are always a valid
     rotation matrix.
 
     Args:
@@ -357,7 +357,7 @@ def pose_vector_merge(
 
     Surface normals observed from opposite sides of a surface are not two estimates
     of the same direction, so they are not averaged. The side with more observations
-    is kept, the same way `pose_vector_mean` discards the minority side withing a
+    is kept, the same way `pose_vector_mean` discards the minority side within a
     single batch of observations.
 
     Curvature directions are ambiguous in direction, so the new one is flipped to agree

--- a/src/tbp/monty/frameworks/utils/object_model_utils.py
+++ b/src/tbp/monty/frameworks/utils/object_model_utils.py
@@ -441,7 +441,7 @@ def pose_vector_mean(pose_vecs, pose_fully_defined):
         # )
         # Just take 1st one. Shouldn't matter since cd should not be used anyways if
         # not pose_fully_defined. Only has a small effect on sampled possible poses.
-        pv_means = np.hstack([norm_mean, cds1[0], cds2[0]])
+        pv_means = orthonormal_pose_vectors(norm_mean, cds1[0])
         use_cds_to_update = False
     else:
         # Find cds pointing in opposing directions and invert them. This is needed
@@ -449,13 +449,8 @@ def pose_vector_mean(pose_vecs, pose_fully_defined):
         # equivalent. If we average over opposing directions, we will get noise.
         cd1_dirs = get_right_hand_angle(cds1, cds2[0], norm_mean) < 0
         cds1[cd1_dirs] = -cds1[cd1_dirs]
-        cd1_mean = normalize(np.mean(cds1, axis=0))
-        # Get the second cd by calculating a vector orthogonal to cd1 and surface normal
-        cd2_mean = normalize(np.cross(norm_mean, cd1_mean))
-        if get_right_hand_angle(cd1_mean, cd2_mean, norm_mean) < 0:
-            cd2_mean = -cd2_mean
+        pv_means = orthonormal_pose_vectors(norm_mean, np.mean(cds1, axis=0))
         use_cds_to_update = True
-        pv_means = np.hstack([norm_mean, cd1_mean, cd2_mean])
 
     assert not np.any(np.isnan(pv_means)), "NaN in pose vector mean"
     return pv_means, use_cds_to_update

--- a/src/tbp/monty/frameworks/utils/object_model_utils.py
+++ b/src/tbp/monty/frameworks/utils/object_model_utils.py
@@ -11,13 +11,17 @@
 import logging
 
 import numpy as np
+import numpy.typing as npt
 import torch
 
 from tbp.monty.frameworks.utils.spatial_arithmetics import (
+    TangentFrame,
     get_angle,
     get_right_hand_angle,
     normalize,
+    project_onto_tangent_plane,
 )
+from tbp.monty.math import DEFAULT_TOLERANCE
 
 logger = logging.getLogger(__name__)
 
@@ -310,6 +314,88 @@ def get_cubic_patches(arr_shape, centers, size):
     mask = np.any((new_centers < 0) | (new_centers >= np.array(arr_shape[:3])), axis=-1)
 
     return new_centers, mask
+
+
+def orthonormal_pose_vectors(
+    surface_normal: npt.NDArray[np.float64],
+    curvature_direction: npt.NDArray[np.float64],
+) -> npt.NDArray[np.float64]:
+    """Build a right-handed orthonormal pose from two rough directions.
+
+    The surface normal is used as a give, up to normalization. The curvature direction
+    is orthogonlized agaist it, so the returned pose vectors are always a valid
+    rotation matrix.
+
+    Args:
+        surface_normal: Surface normal direction. Does not need to be unit length.
+        curvature_direction: First curvature direction. Does not need to be unit length
+            or orthogonal to the surface normal.
+
+    Returns:
+        Flat array of nine elements holding the surface normal and the two curvature
+        directions.
+    """
+    normal = normalize(surface_normal)
+    tangent = project_onto_tangent_plane(curvature_direction, normal)
+    if np.linalg.norm(tangent) < DEFAULT_TOLERANCE:
+        # The curvature direction holds no information perpendicular to the surface
+        # normal, so fall back to an arbitrary direction in the tangent plane. The
+        # curvature directions are not used for matching in this case anyway.
+        tangent = TangentFrame(normal).basis_u
+    cd1 = normalize(tangent)
+    return np.hstack([normal, cd1, np.cross(normal, cd1)])
+
+
+def pose_vector_merge(
+    new_pose_vecs: npt.NDArray[np.float64],
+    previous_pose_vecs: npt.NDArray[np.float64],
+    use_cds_to_update: bool,
+    num_new_obs: int,
+    num_previous_obs: int,
+) -> npt.NDArray[np.float64]:
+    """Merge newly observed pose vectors into previous ones.
+
+    Surface normals observed from opposite sides of a surface are not two estimates
+    of the same direction, so they are not averaged. The side with more observations
+    is kept, the same way `pose_vector_mean` discards the minority side withing a
+    single batch of observations.
+
+    Curvature directions are ambiguous in direction, so the new one is flipped to agree
+    with the stored one before they are averaged.
+
+    Note that the returned pose vectors could be weighted by the number of observations,
+    but this is currently not implemented.
+
+    Args:
+        new_pose_vecs: Flat array of nine elements holding the pose vectors averaged
+            over the new observations.
+        previous_pose_vecs: Flat array of nine elements holding the averaged previous
+            pose vectors.
+        use_cds_to_update: Whether the new curvature directions are meaningful.
+        num_new_obs: Number of new observations.
+        num_previous_obs: Number of previous observations.
+
+    Returns:
+        Flat array of nine elements holding the merged pose vectors.
+    """
+    new_normal = new_pose_vecs[:3]
+    previous_normal = previous_pose_vecs[:3]
+    if np.dot(new_normal, previous_normal) < 0:
+        majority = (
+            new_pose_vecs if num_new_obs > num_previous_obs else previous_pose_vecs
+        )
+        return orthonormal_pose_vectors(majority[:3], majority[3:6])
+
+    if use_cds_to_update:
+        new_cd1 = new_pose_vecs[3:6]
+        previous_cd1 = previous_pose_vecs[3:6]
+        if np.dot(new_cd1, previous_cd1) < 0:
+            new_cd1 = -new_cd1
+        curvature_direction = new_cd1 + previous_cd1
+    else:
+        curvature_direction = previous_pose_vecs[3:6]
+
+    return orthonormal_pose_vectors(new_normal + previous_normal, curvature_direction)
 
 
 def pose_vector_mean(pose_vecs, pose_fully_defined):

--- a/src/tbp/monty/frameworks/utils/object_model_utils.py
+++ b/src/tbp/monty/frameworks/utils/object_model_utils.py
@@ -358,7 +358,7 @@ def pose_vector_merge(
     Surface normals observed from opposite sides of a surface are not two estimates
     of the same direction, so they are not averaged. The side with more observations
     is kept, the same way `pose_vector_mean` discards the minority side within a
-    single batch of observations.
+    single episode of observations.
 
     Curvature directions are ambiguous in direction, so the new one is flipped to agree
     with the stored one before they are averaged.

--- a/src/tbp/monty/frameworks/utils/object_model_utils.py
+++ b/src/tbp/monty/frameworks/utils/object_model_utils.py
@@ -21,6 +21,7 @@ from tbp.monty.frameworks.utils.spatial_arithmetics import (
     normalize,
     project_onto_tangent_plane,
 )
+from tbp.monty.geometry import Rotation
 from tbp.monty.math import DEFAULT_TOLERANCE
 
 logger = logging.getLogger(__name__)
@@ -349,53 +350,25 @@ def orthonormal_pose_vectors(
 def pose_vector_merge(
     new_pose_vecs: npt.NDArray[np.float64],
     previous_pose_vecs: npt.NDArray[np.float64],
-    use_cds_to_update: bool,
     num_new_obs: int,
     num_previous_obs: int,
 ) -> npt.NDArray[np.float64]:
-    """Merge newly observed pose vectors into previous ones.
-
-    Surface normals observed from opposite sides of a surface are not two estimates
-    of the same direction, so they are not averaged. The side with more observations
-    is kept, the same way `pose_vector_mean` discards the minority side within a
-    single episode of observations.
-
-    Curvature directions are ambiguous in direction, so the new one is flipped to agree
-    with the stored one before they are averaged.
-
-    Note that the returned pose vectors could be weighted by the number of observations,
-    but this is currently not implemented.
+    """Merge newly observed pose vectors into previous ones using a weighted mean.
 
     Args:
         new_pose_vecs: Flat array of nine elements holding the pose vectors averaged
             over the new observations.
         previous_pose_vecs: Flat array of nine elements holding the averaged previous
             pose vectors.
-        use_cds_to_update: Whether the new curvature directions are meaningful.
         num_new_obs: Number of new observations.
         num_previous_obs: Number of previous observations.
 
     Returns:
         Flat array of nine elements holding the merged pose vectors.
     """
-    new_normal = new_pose_vecs[:3]
-    previous_normal = previous_pose_vecs[:3]
-    if np.dot(new_normal, previous_normal) < 0:
-        majority = (
-            new_pose_vecs if num_new_obs > num_previous_obs else previous_pose_vecs
-        )
-        return orthonormal_pose_vectors(majority[:3], majority[3:6])
-
-    if use_cds_to_update:
-        new_cd1 = new_pose_vecs[3:6]
-        previous_cd1 = previous_pose_vecs[3:6]
-        if np.dot(new_cd1, previous_cd1) < 0:
-            new_cd1 = -new_cd1
-        curvature_direction = new_cd1 + previous_cd1
-    else:
-        curvature_direction = previous_pose_vecs[3:6]
-
-    return orthonormal_pose_vectors(new_normal + previous_normal, curvature_direction)
+    return Rotation.from_matrix(
+        np.stack([new_pose_vecs.reshape(3, 3), previous_pose_vecs.reshape(3, 3)])
+    ).mean(weights=[num_new_obs, num_previous_obs]).as_matrix().flatten()
 
 
 def pose_vector_mean(pose_vecs, pose_fully_defined):

--- a/src/tbp/monty/frameworks/utils/object_model_utils.py
+++ b/src/tbp/monty/frameworks/utils/object_model_utils.py
@@ -366,9 +366,14 @@ def pose_vector_merge(
     Returns:
         Flat array of nine elements holding the merged pose vectors.
     """
-    return Rotation.from_matrix(
-        np.stack([new_pose_vecs.reshape(3, 3), previous_pose_vecs.reshape(3, 3)])
-    ).mean(weights=[num_new_obs, num_previous_obs]).as_matrix().flatten()
+    return (
+        Rotation.from_matrix(
+            np.stack([new_pose_vecs.reshape(3, 3), previous_pose_vecs.reshape(3, 3)])
+        )
+        .mean(weights=[num_new_obs, num_previous_obs])
+        .as_matrix()
+        .flatten()
+    )
 
 
 def pose_vector_mean(pose_vecs, pose_fully_defined):

--- a/tests/unit/frameworks/models/object_model_test.py
+++ b/tests/unit/frameworks/models/object_model_test.py
@@ -12,6 +12,8 @@ import copy
 import unittest
 
 import numpy as np
+from hypothesis import given
+from hypothesis import strategies as st
 
 from tbp.monty.frameworks.models.object_model import (
     GraphObjectModel,
@@ -294,6 +296,43 @@ class ObjectModelTest(unittest.TestCase):
                 np.linalg.norm(pv), 1.0, 3, "Average PVs are not unit vectors anymore"
             )
         self.assertTrue(check_orthonormal(avg_pvs), "Average PVs are not orthonormal")
+
+    @given(pose_fully_defined=st.booleans())
+    def test_update_model_keeps_pose_vectors_as_rotation_matrix(
+        self, pose_fully_defined
+    ):
+        opposite_pv = np.vstack(
+            [-self.dummy_pv[0], self.dummy_pv[1], -self.dummy_pv[2]]
+        )
+        model = GridObjectModel(
+            "test_model", max_nodes=10, max_size=10, num_voxels_per_dim=5
+        )
+        model.build_model(self.dummy_locs, self.dummy_features)
+
+        for _ in range(3):
+            features = copy.deepcopy(self.dummy_features)
+            features["pose_vectors"] = np.vstack([opposite_pv.flatten()] * 4)
+            features["pose_fully_defined"] = np.array([pose_fully_defined] * 4)
+            model.update_model(
+                locations=self.dummy_locs,
+                features=features,
+                location_rel_model=np.zeros(3),
+                object_location_rel_body=np.zeros(3),
+                object_rotation=Rotation.identity(),
+            )
+
+        for pose_vectors in model.get_values_for_feature("pose_vectors"):
+            matrix = np.array(pose_vectors).reshape((3, 3))
+            self.assertAlmostEqual(
+                np.linalg.det(matrix),
+                1.0,
+                3,
+                "Stored pose vectors are no longer a rotation matrix",
+            )
+            self.assertTrue(
+                check_orthonormal(matrix),
+                "Stored pose vectors are not orthonormal",
+            )
 
     def test_max_nodes_applied_correctly(self):
         model = GridObjectModel(

--- a/tests/unit/frameworks/models/object_model_test.py
+++ b/tests/unit/frameworks/models/object_model_test.py
@@ -12,7 +12,7 @@ import copy
 import unittest
 
 import numpy as np
-from hypothesis import given
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from tbp.monty.frameworks.models.object_model import (
@@ -297,6 +297,7 @@ class ObjectModelTest(unittest.TestCase):
             )
         self.assertTrue(check_orthonormal(avg_pvs), "Average PVs are not orthonormal")
 
+    @settings(deadline=1000)
     @given(pose_fully_defined=st.booleans())
     def test_update_model_keeps_pose_vectors_as_rotation_matrix(
         self, pose_fully_defined

--- a/tests/unit/frameworks/utils/object_model_utils_test.py
+++ b/tests/unit/frameworks/utils/object_model_utils_test.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Thousand Brains Project
+#
+# Copyright may exist in Contributors' modifications
+# and/or contributions to the work.
+#
+# Use of this source code is governed by the MIT
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+import numpy.typing as npt
+
+from tbp.monty.frameworks.utils.object_model_utils import (
+    orthonormal_pose_vectors,
+    pose_vector_mean,
+    pose_vector_merge,
+)
+from tbp.monty.frameworks.utils.spatial_arithmetics import (
+    normalize,
+    project_onto_tangent_plane,
+)
+from tbp.monty.geometry import Rotation
+from tbp.monty.math import DEFAULT_TOLERANCE
+
+
+def pose_frame(
+    normal: npt.NDArray[np.float64], tangent_seed: npt.NDArray[np.float64]
+) -> npt.NDArray[np.float64]:
+    """Return flat right-handed orthonormal pose vectors.
+
+    Args:
+        normal: Surface normal direction.
+        tangent_seed: Direction to derive the first curvature direction from.
+
+    Returns:
+        Flat array of nine elements holding the surface normal and the two curvature
+        directions.
+    """
+    normal = normalize(normal)
+    tangent = project_onto_tangent_plane(tangent_seed, normal)
+    cd1 = normalize(tangent)
+    return np.hstack([normal, cd1, np.cross(normal, cd1)])
+
+
+class PoseVectorsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.normal = np.array([0.0, 0.0, 1.0])
+        self.cd1 = np.array([1.0, 0.0, 0.0])
+        self.frame = np.hstack([self.normal, self.cd1, np.cross(self.normal, self.cd1)])
+        self.opposite_frame = np.hstack(
+            [-self.normal, self.cd1, np.cross(-self.normal, self.cd1)]
+        )
+
+    def assert_is_rotation(self, pose_vecs: npt.NDArray[np.float64], msg: str) -> None:
+        """Assert that the pose vectors can be read as a rotation.
+
+        In other words, that the surface normal and the two principal curvatures form an
+        orthonormal, right-handed basis.
+
+        Args:
+            pose_vecs: Flat array of nine elements holding the pose vectors.
+            msg: Assertion message.
+        """
+        matrix = np.array(pose_vecs).reshape((3, 3))
+        self.assertAlmostEqual(np.linalg.det(matrix), 1.0, places=6, msg=msg)
+        np.testing.assert_allclose(matrix @ matrix.T, np.eye(3), atol=1e-6, err_msg=msg)
+        # Raises for non-positive determinant on scipy > 1.14.1
+        Rotation.from_matrix(matrix)
+
+    def test_orthonormal_pose_vectors_orthgonalizes_curvature_direction(self) -> None:
+        pose_vecs = orthonormal_pose_vectors(self.normal, np.array([1.0, 0.0, 0.7]))
+        self.assert_is_rotation(pose_vecs, "Pose vectors are not a rotation")
+        np.testing.assert_allclose(pose_vecs[:3], self.normal, atol=DEFAULT_TOLERANCE)
+
+    def test_orthonormal_pose_vectors_falls_back_to_arbitrary_direction_if_curvature_direction_is_parallel_to_surface_normal(  # noqa: E501
+        self,
+    ) -> None:
+        pose_vecs = orthonormal_pose_vectors(self.normal, self.normal * 2.0)
+        self.assert_is_rotation(
+            pose_vecs, "Degenerate curvature direction did not fall back"
+        )
+
+    def test_pose_vector_mean_of_spread_observations_is_a_rotation(self) -> None:
+        rng = np.random.RandomState(0)
+        for _ in range(50):
+            observations = np.array(
+                [
+                    pose_frame(self.normal + rng.normal(0, 0.3, 3), rng.normal(size=3))
+                    for _ in range(6)
+                ]
+            )
+            pv_mean, _ = pose_vector_mean(observations, np.ones((6, 1)))
+            self.assert_is_rotation(
+                pv_mean, "Mean of spread observations is not a rotation"
+            )
+
+    def test_pose_vector_merge_of_opposite_curvature_directions_is_a_rotation(
+        self,
+    ) -> None:
+        merged = pose_vector_merge(
+            self.opposite_frame,
+            self.frame,
+            use_cds_to_update=True,
+            num_new_obs=4,
+            num_previous_obs=4,
+        )
+        self.assert_is_rotation(merged, "Merged pose vectors are not a rotation")
+
+    def test_pose_vector_merge_keeps_the_surface_side_with_more_observations(
+        self,
+    ) -> None:
+        keeps_new = pose_vector_merge(
+            self.opposite_frame,
+            self.frame,
+            use_cds_to_update=True,
+            num_new_obs=8,
+            num_previous_obs=4,
+        )
+        np.testing.assert_allclose(keeps_new[:3], -self.normal, atol=DEFAULT_TOLERANCE)
+        keeps_previous = pose_vector_merge(
+            self.opposite_frame,
+            self.frame,
+            use_cds_to_update=True,
+            num_new_obs=4,
+            num_previous_obs=8,
+        )
+        np.testing.assert_allclose(
+            keeps_previous[:3], self.normal, atol=DEFAULT_TOLERANCE
+        )
+
+    def test_pose_vector_merge_averages_normals_on_the_same_surface_side(self) -> None:
+        tilted = pose_frame(np.array([0.0, 0.5, 1.0]), self.cd1)
+        merged = pose_vector_merge(
+            tilted,
+            self.frame,
+            use_cds_to_update=True,
+            num_new_obs=4,
+            num_previous_obs=4,
+        )
+        self.assert_is_rotation(merged, "Merged pose vectors are not a rotation")
+        self.assertGreater(np.dot(merged[:3], self.normal), 0.0)
+
+    def test_pose_vector_merge_repeated_merges_from_the_opposite_side_stay_a_rotation(
+        self,
+    ) -> None:
+        stored = self.frame.copy()
+        for update in range(1, 9):
+            stored = pose_vector_merge(
+                self.opposite_frame,
+                stored,
+                use_cds_to_update=True,
+                num_new_obs=4,
+                num_previous_obs=4 * update,
+            )
+            self.assert_is_rotation(
+                stored,
+                "Repeated merge from the opposite side is not a rotation after "
+                f"{update} updates",
+            )
+
+    def test_repeated_merges_of_noisy_observations_stay_a_rotation(self) -> None:
+        rng = np.random.RandomState(0)
+        stored, observation_count = self.frame.copy(), 4
+        for _ in range(50):
+            observations = np.array(
+                [
+                    pose_frame(
+                        self.normal + rng.normal(0, 0.3, 3),
+                        self.cd1 * (1.0 if rng.rand() < 0.5 else -1.0),
+                    )
+                    for _ in range(4)
+                ]
+            )
+            pv_mean, use_cds_to_update = pose_vector_mean(observations, np.ones((4, 1)))
+            stored = pose_vector_merge(
+                pv_mean,
+                stored,
+                use_cds_to_update=use_cds_to_update,
+                num_new_obs=4,
+                num_previous_obs=observation_count,
+            )
+            observation_count += 4
+            self.assert_is_rotation(stored, "Merged frame is not a rotation")

--- a/tests/unit/frameworks/utils/object_model_utils_test.py
+++ b/tests/unit/frameworks/utils/object_model_utils_test.py
@@ -66,7 +66,9 @@ class PoseVectorsTest(unittest.TestCase):
         """
         matrix = np.array(pose_vecs).reshape((3, 3))
         self.assertAlmostEqual(np.linalg.det(matrix), 1.0, places=6, msg=msg)
-        np.testing.assert_allclose(matrix @ matrix.T, np.eye(3), atol=1e-6, err_msg=msg)
+        np.testing.assert_allclose(
+            matrix @ matrix.T, np.identity(3), atol=1e-6, err_msg=msg
+        )
         # Raises for non-positive determinant on scipy > 1.14.1
         Rotation.from_matrix(matrix)
 
@@ -80,7 +82,7 @@ class PoseVectorsTest(unittest.TestCase):
     ) -> None:
         pose_vecs = orthonormal_pose_vectors(self.normal, self.normal * 2.0)
         self.assert_is_rotation(
-            pose_vecs, "Degenerate curvature direction did not fall back"
+            pose_vecs, "Parallel curvature direction did not fall back"
         )
 
     def test_pose_vector_mean_of_spread_observations_is_a_rotation(self) -> None:

--- a/tests/unit/frameworks/utils/object_model_utils_test.py
+++ b/tests/unit/frameworks/utils/object_model_utils_test.py
@@ -65,9 +65,15 @@ class PoseVectorsTest(unittest.TestCase):
             msg: Assertion message.
         """
         matrix = np.array(pose_vecs).reshape((3, 3))
-        self.assertAlmostEqual(np.linalg.det(matrix), 1.0, places=6, msg=msg)
         np.testing.assert_allclose(
-            matrix @ matrix.T, np.identity(3), atol=1e-6, err_msg=msg
+            np.linalg.det(matrix), 1.0, atol=DEFAULT_TOLERANCE, rtol=0.0, err_msg=msg
+        )
+        np.testing.assert_allclose(
+            matrix @ matrix.T,
+            np.identity(3),
+            atol=DEFAULT_TOLERANCE,
+            rtol=0.0,
+            err_msg=msg,
         )
         # Raises for non-positive determinant on scipy > 1.14.1
         Rotation.from_matrix(matrix)

--- a/tests/unit/frameworks/utils/object_model_utils_test.py
+++ b/tests/unit/frameworks/utils/object_model_utils_test.py
@@ -18,31 +18,8 @@ from tbp.monty.frameworks.utils.object_model_utils import (
     pose_vector_mean,
     pose_vector_merge,
 )
-from tbp.monty.frameworks.utils.spatial_arithmetics import (
-    normalize,
-    project_onto_tangent_plane,
-)
 from tbp.monty.geometry import Rotation
 from tbp.monty.math import DEFAULT_TOLERANCE
-
-
-def pose_frame(
-    normal: npt.NDArray[np.float64], tangent_seed: npt.NDArray[np.float64]
-) -> npt.NDArray[np.float64]:
-    """Return flat right-handed orthonormal pose vectors.
-
-    Args:
-        normal: Surface normal direction.
-        tangent_seed: Direction to derive the first curvature direction from.
-
-    Returns:
-        Flat array of nine elements holding the surface normal and the two curvature
-        directions.
-    """
-    normal = normalize(normal)
-    tangent = project_onto_tangent_plane(tangent_seed, normal)
-    cd1 = normalize(tangent)
-    return np.hstack([normal, cd1, np.cross(normal, cd1)])
 
 
 class PoseVectorsTest(unittest.TestCase):
@@ -96,7 +73,9 @@ class PoseVectorsTest(unittest.TestCase):
         for _ in range(50):
             observations = np.array(
                 [
-                    pose_frame(self.normal + rng.normal(0, 0.3, 3), rng.normal(size=3))
+                    orthonormal_pose_vectors(
+                        self.normal + rng.normal(0, 0.3, 3), rng.normal(size=3)
+                    )
                     for _ in range(6)
                 ]
             )
@@ -140,7 +119,7 @@ class PoseVectorsTest(unittest.TestCase):
         )
 
     def test_pose_vector_merge_averages_normals_on_the_same_surface_side(self) -> None:
-        tilted = pose_frame(np.array([0.0, 0.5, 1.0]), self.cd1)
+        tilted = orthonormal_pose_vectors(np.array([0.0, 0.5, 1.0]), self.cd1)
         merged = pose_vector_merge(
             tilted,
             self.frame,
@@ -175,7 +154,7 @@ class PoseVectorsTest(unittest.TestCase):
         for _ in range(50):
             observations = np.array(
                 [
-                    pose_frame(
+                    orthonormal_pose_vectors(
                         self.normal + rng.normal(0, 0.3, 3),
                         self.cd1 * (1.0 if rng.rand() < 0.5 else -1.0),
                     )

--- a/tests/unit/frameworks/utils/object_model_utils_test.py
+++ b/tests/unit/frameworks/utils/object_model_utils_test.py
@@ -90,7 +90,6 @@ class PoseVectorsTest(unittest.TestCase):
         merged = pose_vector_merge(
             self.opposite_frame,
             self.frame,
-            use_cds_to_update=True,
             num_new_obs=4,
             num_previous_obs=4,
         )
@@ -102,7 +101,6 @@ class PoseVectorsTest(unittest.TestCase):
         keeps_new = pose_vector_merge(
             self.opposite_frame,
             self.frame,
-            use_cds_to_update=True,
             num_new_obs=8,
             num_previous_obs=4,
         )
@@ -110,7 +108,6 @@ class PoseVectorsTest(unittest.TestCase):
         keeps_previous = pose_vector_merge(
             self.opposite_frame,
             self.frame,
-            use_cds_to_update=True,
             num_new_obs=4,
             num_previous_obs=8,
         )
@@ -123,7 +120,6 @@ class PoseVectorsTest(unittest.TestCase):
         merged = pose_vector_merge(
             tilted,
             self.frame,
-            use_cds_to_update=True,
             num_new_obs=4,
             num_previous_obs=4,
         )
@@ -138,7 +134,6 @@ class PoseVectorsTest(unittest.TestCase):
             stored = pose_vector_merge(
                 self.opposite_frame,
                 stored,
-                use_cds_to_update=True,
                 num_new_obs=4,
                 num_previous_obs=4 * update,
             )
@@ -161,11 +156,10 @@ class PoseVectorsTest(unittest.TestCase):
                     for _ in range(4)
                 ]
             )
-            pv_mean, use_cds_to_update = pose_vector_mean(observations, np.ones((4, 1)))
+            pv_mean, _ = pose_vector_mean(observations, np.ones((4, 1)))
             stored = pose_vector_merge(
                 pv_mean,
                 stored,
-                use_cds_to_update=use_cds_to_update,
                 num_new_obs=4,
                 num_previous_obs=observation_count,
             )


### PR DESCRIPTION
This pull request aims to fix a bug discovered by @jeremyshoemaker during the SciPy upgrade. SciPy started raising exceptions because it observed rotation matrices with invalid determinants. 

The essence of the problem is this line:
https://github.com/thousandbrainsproject/tbp.monty/blob/25232e7762ab0d083a2d95f15ed566bdbe1214c9/src/tbp/monty/frameworks/models/object_model.py#L855

This is not a valid way of averaging rotation matrices (element-wise), as it does not preserve orthonormality. Take note of the care that `pose_vector_mean(...)` takes to ensure that pose vectors retain desired properties. It throws away up to half of the pose vectors to ensure that averaging makes sense and ensures orthonormality, etc.
https://github.com/thousandbrainsproject/tbp.monty/blob/25232e7762ab0d083a2d95f15ed566bdbe1214c9/src/tbp/monty/frameworks/utils/object_model_utils.py#L315

The fix is to replace the faulty merge of the new and previous pose vectors with one that maintains the result's orthonormality. Hence, the `pose_vector_merge` function that uses `Rotation.mean()`, which, in turn, ensures the result's orthonormality.