### PR TITLE
refactor!: top-test for episode termination

### DIFF
--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -440,12 +440,6 @@ class MontyExperiment:
             self.model.reset()
         self.model.set_experiment_mode(self.experiment_mode)
 
-    def run_episode(self):
-        """Runs an episode with `pre_episode` and `post_episode` hooks."""
-        self.pre_episode()
-        last_step = self.run_episode_steps()
-        self.post_episode(last_step)
-
     def pre_episode(self) -> None:
         """Call pre_episode on elements in experiment and set mode."""
         if self.experiment_mode is ExperimentMode.TRAIN:
@@ -474,6 +468,12 @@ class MontyExperiment:
         if self.show_sensor_output:
             self.live_plotter.initialize_online_plotting()
 
+    def run_episode(self):
+        """Runs an episode with `pre_episode` and `post_episode` hooks."""
+        self.pre_episode()
+        step = self.run_episode_steps()
+        self.post_episode(step)
+
     def run_episode_steps(self) -> int:
         """Runs the steps of an episode.
 
@@ -487,22 +487,9 @@ class MontyExperiment:
         step = 0
         ctx = RuntimeContext(rng=self.rng)
         actions: list[Action] = []
-
         while not self._recognition_complete(step):
-            observations, proprioceptive_state = self.env_interface.step(actions)
-
-            self._fixme_generate_live_plot_frame(observations, step)
-
             try:
-                actions = self.model.step(ctx, observations, proprioceptive_state)
-                actions = self._step_hook(
-                    ctx,
-                    self.model,
-                    self.supervised_lm_ids if self.supervised_lm_ids else [],
-                    step,
-                    observations,
-                    actions,
-                )
+                self.run_step(ctx, step, actions)
             except StopIteration:
                 # TODO: StopIteration is being thrown by NaiveScanPolicy to signal
                 #       episode termination. This is a holdover from when we used
@@ -513,10 +500,30 @@ class MontyExperiment:
                 #       so the experiment can set max steps based on that knowledge
                 #       alone.
                 break
-
             step += 1
-
         return step
+
+    def run_step(self, ctx: RuntimeContext, step: int, actions: list[Action]) -> None:
+        """Runs a single step."""
+        observations, proprioceptive_state = self.env_interface.step(actions)
+
+        self._fixme_generate_live_plot_frame(observations, step)
+
+        if self.model.is_motor_only_step:
+            logger.debug("Performing a motor-only step")
+            actions = self.model.motor_only_step(
+                ctx, observations, proprioceptive_state
+            )
+        else:
+            actions = self.model.step(ctx, observations, proprioceptive_state)
+            actions = self._step_hook(
+                ctx,
+                self.model,
+                self.supervised_lm_ids if self.supervised_lm_ids else [],
+                step,
+                observations,
+                actions,
+            )
 
     def _recognition_complete(self, step: int) -> bool:
         rc = RecognitionCounter(step=step, max_steps=self.max_steps)

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -487,8 +487,8 @@ class MontyExperiment:
         step = 0
         ctx = RuntimeContext(rng=self.rng)
         actions: list[Action] = []
-        stop_requested: bool = False
-        while True:
+
+        while not self._recognition_complete(step):
             observations, proprioceptive_state = self.env_interface.step(actions)
 
             self._fixme_generate_live_plot_frame(observations, step)
@@ -512,13 +512,8 @@ class MontyExperiment:
                 #       fully. For example, we know how many steps the policy will take,
                 #       so the experiment can set max steps based on that knowledge
                 #       alone.
-                stop_requested = True
-
-            stop_requested = stop_requested or self._recognition_complete(step)
-
-            if stop_requested:
-                self.model.set_done()  # TODO: remove `is_done` from Monty
                 break
+
             step += 1
 
         return step

--- a/src/tbp/monty/frameworks/experiments/monty_experiment.py
+++ b/src/tbp/monty/frameworks/experiments/monty_experiment.py
@@ -489,7 +489,7 @@ class MontyExperiment:
         actions: list[Action] = []
         while not self._recognition_complete(step):
             try:
-                self.run_step(ctx, step, actions)
+                actions = self.run_step(ctx, step, actions)
             except StopIteration:
                 # TODO: StopIteration is being thrown by NaiveScanPolicy to signal
                 #       episode termination. This is a holdover from when we used
@@ -503,8 +503,19 @@ class MontyExperiment:
             step += 1
         return step
 
-    def run_step(self, ctx: RuntimeContext, step: int, actions: list[Action]) -> None:
-        """Runs a single step."""
+    def run_step(
+        self, ctx: RuntimeContext, step: int, actions: list[Action]
+    ) -> list[Action]:
+        """Runs a single step.
+
+        Args:
+            ctx: The runtime context.
+            step: The index of the step within the episode.
+            actions: The actions to take in the environment before observing.
+
+        Returns:
+            The actions to take in the environment at the next step.
+        """
         observations, proprioceptive_state = self.env_interface.step(actions)
 
         self._fixme_generate_live_plot_frame(observations, step)
@@ -524,6 +535,7 @@ class MontyExperiment:
                 observations,
                 actions,
             )
+        return actions
 
     def _recognition_complete(self, step: int) -> bool:
         rc = RecognitionCounter(step=step, max_steps=self.max_steps)

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -47,7 +47,9 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
         else:
             self.model.fixme_set_ground_truth(self.env_interface.primary_target)
 
-    def run_step(self, ctx: RuntimeContext, step: int, actions: list[Action]) -> None:
+    def run_step(
+        self, ctx: RuntimeContext, step: int, actions: list[Action]
+    ) -> list[Action]:
         observations, proprioceptive_state = self.env_interface.step(actions)
 
         self._fixme_generate_live_plot_frame(observations, step)
@@ -78,3 +80,4 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
                 observations,
                 actions,
             )
+        return actions

--- a/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
+++ b/src/tbp/monty/frameworks/experiments/object_recognition_experiments.py
@@ -47,61 +47,34 @@ class MontyObjectRecognitionExperiment(MontyExperiment):
         else:
             self.model.fixme_set_ground_truth(self.env_interface.primary_target)
 
-    def run_episode_steps(self) -> int:
-        step = 0
-        ctx = RuntimeContext(rng=self.rng)
-        actions: list[Action] = []
-        stop_requested: bool = False
-        while True:
-            observations, proprioceptive_state = self.env_interface.step(actions)
+    def run_step(self, ctx: RuntimeContext, step: int, actions: list[Action]) -> None:
+        observations, proprioceptive_state = self.env_interface.step(actions)
 
-            self._fixme_generate_live_plot_frame(observations, step)
+        self._fixme_generate_live_plot_frame(observations, step)
 
-            if self.model.check_reached_max_matching_steps(self.max_steps):
-                logger.info(
-                    f"Terminated due to maximum matching steps : {self.max_steps}"
-                )
-                # Need to break here already, otherwise there are problems
-                # when the object is recognized in the last step
-                break
+        if self.model.check_reached_max_matching_steps(self.max_steps):
+            logger.info(f"Terminated due to maximum matching steps : {self.max_steps}")
+            # Need to break here already, otherwise there are problems
+            # when the object is recognized in the last step
+            raise StopIteration
 
-            if step >= (self.max_total_steps):
-                logger.info(f"Terminated due to maximum episode steps : {step}")
-                self.model.deal_with_time_out()
-                break
+        if step >= (self.max_total_steps):
+            logger.info(f"Terminated due to maximum episode steps : {step}")
+            self.model.deal_with_time_out()
+            raise StopIteration
 
-            try:
-                if self.model.is_motor_only_step:
-                    logger.debug("Performing a motor-only step")
-                    actions = self.model.motor_only_step(
-                        ctx, observations, proprioceptive_state
-                    )
-                else:
-                    actions = self.model.step(ctx, observations, proprioceptive_state)
-                    actions = self._step_hook(
-                        ctx,
-                        self.model,
-                        self.supervised_lm_ids if self.supervised_lm_ids else [],
-                        step,
-                        observations,
-                        actions,
-                    )
-            except StopIteration:
-                # TODO: StopIteration is being thrown by NaiveScanPolicy to signal
-                #       episode termination. This is a holdover from when we used
-                #       iterators. However, this also abdicates control of the
-                #       experiment to the policy. We should find a better way to handle
-                #       this, so that the experiment can control the episode termination
-                #       fully. For example, we know how many steps the policy will take,
-                #       so the experiment can set max steps based on that knowledge
-                #       alone.
-                stop_requested = True
-
-            stop_requested = stop_requested or self._recognition_complete(step)
-
-            if stop_requested:
-                self.model.set_done()  # TODO: remove `is_done` from Monty
-                break
-            step += 1
-
-        return step
+        if self.model.is_motor_only_step:
+            logger.debug("Performing a motor-only step")
+            actions = self.model.motor_only_step(
+                ctx, observations, proprioceptive_state
+            )
+        else:
+            actions = self.model.step(ctx, observations, proprioceptive_state)
+            actions = self._step_hook(
+                ctx,
+                self.model,
+                self.supervised_lm_ids if self.supervised_lm_ids else [],
+                step,
+                observations,
+                actions,
+            )


### PR DESCRIPTION
This is part of the IP to move terminal condition checking into a configurable Experiment policy object.

## Breaking Changes
- `MontyExperiment.run_episode_steps` tests for episode termination at the top of the loop, before each step, instead of after the model step.
- `MontyExperiment` now defines `run_step`, called from `run_episode_steps`.
- `MontyObjectRecognitionExperiment` inherits `run_episode_steps` and overrides `run_step`.
- `MontyExperiment.run_step` handles motor-only steps via `model.motor_only_step`, previously only done in `MontyObjectRecognitionExperiment`.
- `MontyExperiment.run_episode_steps` no longer calls `model.set_done()` on episode termination.

## Benchmark results
**All inference benchmarks (WandB tag: `PR#1177`) stayed the same**

<details>
<summary>Results</summary>

### base_config_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 10.29 | 10.29 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 5 | 5 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### base_config_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 3.64 | 3.64 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 12 | 12 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 30 | 30 | 0 | ⬜ |
| rotation_error (deg) | 16.96 | 16.96 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 6 | 6 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_dist_on_distm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 12.7 | 12.7 | 0 | ⬜ |
| runtime (min) | 2 | 2 | 0 | ⬜ |
| episode_runtime (sec) | 7 | 6 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_vocus_on_vocusm

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 31 | 31 | 0 | ⬜ |
| rotation_error (deg) | 16.85 | 16.85 | 0 | ⬜ |
| runtime (min) | 4 | 4 | 0 | ⬜ |
| episode_runtime (sec) | 17 | 17 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 29 | 29 | 0 | ⬜ |
| rotation_error (deg) | 14.43 | 14.43 | 0 | ⬜ |
| runtime (min) | 4 | 5 | 1 | ❌ |
| episode_runtime (sec) | 21 | 24 | 3 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 28 | 28 | 0 | ⬜ |
| rotation_error (deg) | 5.22 | 5.22 | 0 | ⬜ |
| runtime (min) | 3 | 3 | 0 | ⬜ |
| episode_runtime (sec) | 10 | 13 | 3 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10distinctobj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 39 | 39 | 0 | ⬜ |
| rotation_error (deg) | 51.74 | 51.74 | 0 | ⬜ |
| runtime (min) | 5 | 4 | -1 | ✅ |
| episode_runtime (sec) | 21 | 20 | -1 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.57 | 98.57 | 0 | ⬜ |
| used_mlh (%) | 2.14 | 2.14 | 0 | ⬜ |
| match_steps | 49 | 49 | 0 | ⬜ |
| rotation_error (deg) | 2.39 | 2.39 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 18 | 18 | 0 | ⬜ |
| num_episodes | 140 | 140 | 0 | ⬜ |

### randrot_noise_10simobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 95 | 95 | 0 | ⬜ |
| used_mlh (%) | 26 | 26 | 0 | ⬜ |
| match_steps | 172 | 172 | 0 | ⬜ |
| rotation_error (deg) | 25.11 | 25.11 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 27 | 27 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_10simobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 96 | 96 | 0 | ⬜ |
| used_mlh (%) | 22 | 22 | 0 | ⬜ |
| match_steps | 146 | 146 | 0 | ⬜ |
| rotation_error (deg) | 20.5 | 20.5 | 0 | ⬜ |
| runtime (min) | 18 | 16 | -2 | ✅ |
| episode_runtime (sec) | 129 | 111 | -18 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randomrot_rawnoise_10distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 75 | 75 | 0 | ⬜ |
| used_mlh (%) | 60 | 60 | 0 | ⬜ |
| match_steps | 16 | 16 | 0 | ⬜ |
| rotation_error (deg) | 83.93 | 83.93 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 9 | 9 | 0 | ⬜ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### base_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.27 | 98.27 | 0 | ⬜ |
| used_mlh (%) | 8.66 | 8.66 | 0 | ⬜ |
| match_steps | 75 | 75 | 0 | ⬜ |
| rotation_error (deg) | 13.68 | 13.68 | 0 | ⬜ |
| runtime (min) | 13 | 14 | 1 | ❌ |
| episode_runtime (sec) | 24 | 23 | -1 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### base_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| used_mlh (%) | 4.76 | 4.76 | 0 | ⬜ |
| match_steps | 43 | 43 | 0 | ⬜ |
| rotation_error (deg) | 2.27 | 2.27 | 0 | ⬜ |
| runtime (min) | 13 | 16 | 3 | ❌ |
| episode_runtime (sec) | 23 | 28 | 5 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 94.37 | 94.37 | 0 | ⬜ |
| used_mlh (%) | 16.02 | 16.02 | 0 | ⬜ |
| match_steps | 122 | 122 | 0 | ⬜ |
| rotation_error (deg) | 29.87 | 29.87 | 0 | ⬜ |
| runtime (min) | 22 | 25 | 3 | ❌ |
| episode_runtime (sec) | 53 | 59 | 6 | ❌ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98.27 | 98.27 | 0 | ⬜ |
| used_mlh (%) | 15.58 | 15.58 | 0 | ⬜ |
| match_steps | 92 | 92 | 0 | ⬜ |
| rotation_error (deg) | 23.34 | 23.34 | 0 | ⬜ |
| runtime (min) | 37 | 35 | -2 | ✅ |
| episode_runtime (sec) | 94 | 88 | -6 | ✅ |
| num_episodes | 231 | 231 | 0 | ⬜ |

### randrot_noise_77obj_5lms_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 90.91 | 90.91 | 0 | ⬜ |
| used_mlh (%) | 0 | 0 | 0 | ⬜ |
| match_steps | 35 | 35 | 0 | ⬜ |
| rotation_error (deg) | 54.09 | 54.09 | 0 | ⬜ |
| runtime (min) | 12 | 11 | -1 | ✅ |
| episode_runtime (sec) | 89 | 82 | -7 | ✅ |
| num_episodes | 77 | 77 | 0 | ⬜ |

### unsupervised_inference_distinctobj_dist_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 98 | 98 | 0 | ⬜ |
| match_steps | 97 | 97 | 0 | ⬜ |
| runtime (min) | 13 | 14 | 1 | ❌ |
| episode_runtime (sec) | 5 | 6 | 1 | ❌ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### unsupervised_inference_distinctobj_surf_agent

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 100 | 100 | 0 | ⬜ |
| match_steps | 99 | 99 | 0 | ⬜ |
| runtime (min) | 23 | 20 | -3 | ✅ |
| episode_runtime (sec) | 13 | 11 | -2 | ✅ |
| num_episodes | 100 | 100 | 0 | ⬜ |

### randrot_noise_sim_on_scan_monty_world

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 90 | 90 | 0 | ⬜ |
| used_mlh (%) | 87.5 | 87.5 | 0 | ⬜ |
| match_steps | 450 | 450 | 0 | ⬜ |
| runtime (min) | 26 | 27 | 1 | ❌ |
| episode_runtime (sec) | 167 | 171 | 4 | ❌ |
| num_episodes | 120 | 120 | 0 | ⬜ |

### world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 66.67 | 66.67 | 0 | ⬜ |
| used_mlh (%) | 62.5 | 62.5 | 0 | ⬜ |
| match_steps | 374 | 374 | 0 | ⬜ |
| runtime (min) | 9 | 9 | 0 | ⬜ |
| episode_runtime (sec) | 10 | 10 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### dark_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 29.17 | 29.17 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 242 | 242 | 0 | ⬜ |
| runtime (min) | 8 | 8 | 0 | ⬜ |
| episode_runtime (sec) | 9 | 9 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### bright_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 37.5 | 37.5 | 0 | ⬜ |
| used_mlh (%) | 64.58 | 64.58 | 0 | ⬜ |
| match_steps | 413 | 413 | 0 | ⬜ |
| runtime (min) | 10 | 11 | 1 | ❌ |
| episode_runtime (sec) | 11 | 13 | 2 | ❌ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### hand_intrusion_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 43.75 | 43.75 | 0 | ⬜ |
| used_mlh (%) | 18.75 | 18.75 | 0 | ⬜ |
| match_steps | 272 | 272 | 0 | ⬜ |
| runtime (min) | 9 | 9 | 0 | ⬜ |
| episode_runtime (sec) | 10 | 9 | -1 | ✅ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### multi_object_world_image_on_scanned_model

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 25 | 25 | 0 | ⬜ |
| used_mlh (%) | 2.08 | 2.08 | 0 | ⬜ |
| match_steps | 158 | 158 | 0 | ⬜ |
| runtime (min) | 6 | 6 | 0 | ⬜ |
| episode_runtime (sec) | 6 | 6 | 0 | ⬜ |
| num_episodes | 48 | 48 | 0 | ⬜ |

### base_infer_objects_with_stickers_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 36.84 | 36.84 | 0 | ⬜ |
| used_mlh (%) | 82.33 | 82.33 | 0 | ⬜ |
| match_steps | 90 | 90 | 0 | ⬜ |
| rotation_error (deg) | 59.24 | 59.24 | 0 | ⬜ |
| avg_prediction_error | 0.37 | 0.37 | 0 | ⬜ |
| runtime (min) | 41 | 39 | -2 | ✅ |
| num_episodes | 266 | 266 | 0 | ⬜ |

### base_infer_objects_with_stickers_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 34.96 | 34.96 | 0 | ⬜ |
| used_mlh (%) | 78.95 | 78.95 | 0 | ⬜ |
| match_steps | 89 | 89 | 0 | ⬜ |
| rotation_error (deg) | 67.74 | 67.74 | 0 | ⬜ |
| avg_prediction_error | 0.39 | 0.39 | 0 | ⬜ |
| runtime (min) | 38 | 39 | 1 | ❌ |
| num_episodes | 266 | 266 | 0 | ⬜ |

### randrot_noise_infer_objects_with_stickers_monolithic_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 18.95 | 18.95 | 0 | ⬜ |
| used_mlh (%) | 78.95 | 78.95 | 0 | ⬜ |
| match_steps | 85 | 85 | 0 | ⬜ |
| rotation_error (deg) | 112.55 | 112.55 | 0 | ⬜ |
| avg_prediction_error | 0.65 | 0.65 | 0 | ⬜ |
| runtime (min) | 22 | 23 | 1 | ❌ |
| num_episodes | 190 | 190 | 0 | ⬜ |

### randrot_noise_infer_objects_with_stickers_comp_models

| Metric | Baseline | Proposed | Δ | Result |
| --- | --- | --- | --- | --- |
| percent_correct (%) | 21.58 | 21.58 | 0 | ⬜ |
| used_mlh (%) | 76.84 | 76.84 | 0 | ⬜ |
| match_steps | 84 | 84 | 0 | ⬜ |
| rotation_error (deg) | 113.74 | 113.74 | 0 | ⬜ |
| avg_prediction_error | 0.66 | 0.66 | 0 | ⬜ |
| runtime (min) | 21 | 24 | 3 | ❌ |
| num_episodes | 190 | 190 | 0 | ⬜ |


</details>


WIP tracked in [7746](https://app.shortcut.com/thousandbrainsproject/story/7746/align-run-episode-logic-in-all-experiment-implementations)