### PR TITLE
fix: remove max_total_steps in expanded compositional configs

### DIFF
--- a/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_2d_children.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_2d_children.yaml
@@ -19,7 +19,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: 7
     n_eval_epochs: 7
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_3d_children/pretrained/}

--- a/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_2d_children_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_2d_children_mujoco.yaml
@@ -19,7 +19,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: 7
     n_eval_epochs: 7
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_3d_children_mujoco/pretrained/}

--- a/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_3d_children.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_3d_children.yaml
@@ -18,7 +18,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_all_count}
     n_eval_epochs: 3
     model_name_or_path: ''

--- a/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_3d_children_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_3d_children_mujoco.yaml
@@ -18,7 +18,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_all_count}
     n_eval_epochs: 3
     model_name_or_path: ''

--- a/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_comp_models.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_comp_models.yaml
@@ -18,7 +18,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_cube_faces_count}
     n_eval_epochs: 3
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_2d_children/pretrained/}

--- a/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_comp_models_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_comp_models_mujoco.yaml
@@ -18,7 +18,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_cube_faces_count}
     n_eval_epochs: 3
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_2d_children_mujoco/pretrained/}

--- a/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_monolithic_models.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_monolithic_models.yaml
@@ -18,7 +18,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_cube_faces_count}
     n_eval_epochs: 3
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_2d_children/pretrained/}

--- a/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_monolithic_models_mujoco.yaml
+++ b/src/tbp/monty/conf/experiment/supervised_pre_training_expanded_monolithic_models_mujoco.yaml
@@ -18,7 +18,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_cube_faces_count}
     n_eval_epochs: 3
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_2d_children_mujoco/pretrained/}

--- a/tests/conf/snapshots/supervised_pre_training_expanded_2d_children.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_expanded_2d_children.yaml
@@ -374,7 +374,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: 7
     n_eval_epochs: 7
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_3d_children/pretrained/}

--- a/tests/conf/snapshots/supervised_pre_training_expanded_2d_children_mujoco.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_expanded_2d_children_mujoco.yaml
@@ -337,7 +337,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: 7
     n_eval_epochs: 7
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_3d_children_mujoco/pretrained/}

--- a/tests/conf/snapshots/supervised_pre_training_expanded_3d_children.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_expanded_3d_children.yaml
@@ -346,7 +346,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_all_count}
     n_eval_epochs: 3
     model_name_or_path: ''

--- a/tests/conf/snapshots/supervised_pre_training_expanded_3d_children_mujoco.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_expanded_3d_children_mujoco.yaml
@@ -309,7 +309,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_all_count}
     n_eval_epochs: 3
     model_name_or_path: ''

--- a/tests/conf/snapshots/supervised_pre_training_expanded_comp_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_expanded_comp_models.yaml
@@ -460,7 +460,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_cube_faces_count}
     n_eval_epochs: 3
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_2d_children/pretrained/}

--- a/tests/conf/snapshots/supervised_pre_training_expanded_comp_models_mujoco.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_expanded_comp_models_mujoco.yaml
@@ -423,7 +423,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_cube_faces_count}
     n_eval_epochs: 3
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_2d_children_mujoco/pretrained/}

--- a/tests/conf/snapshots/supervised_pre_training_expanded_monolithic_models.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_expanded_monolithic_models.yaml
@@ -456,7 +456,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_cube_faces_count}
     n_eval_epochs: 3
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_2d_children/pretrained/}

--- a/tests/conf/snapshots/supervised_pre_training_expanded_monolithic_models_mujoco.yaml
+++ b/tests/conf/snapshots/supervised_pre_training_expanded_monolithic_models_mujoco.yaml
@@ -419,7 +419,6 @@ experiment:
     show_sensor_output: false
     max_train_steps: 250
     max_eval_steps: 500
-    max_total_steps: 500
     n_train_epochs: ${constants.rotations_cube_faces_count}
     n_eval_epochs: 3
     model_name_or_path: ${path.expanduser:${oc.env:MONTY_MODELS}/my_trained_models/supervised_pre_training_expanded_2d_children_mujoco/pretrained/}


### PR DESCRIPTION
This PR removes obsolete config parameter `max_total_steps`. 